### PR TITLE
fix insertion-only edit_lines rewrite ordering

### DIFF
--- a/__tests__/AI/AIAgent/agentToolApproval.test.ts
+++ b/__tests__/AI/AIAgent/agentToolApproval.test.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import {
+    buildInsertionOnlyEdit,
     extractEditRequest,
     extractWriteRequest,
     getToolArgsRecord,
@@ -59,5 +60,35 @@ describe('agentToolApproval helpers', () => {
         expect(getToolArgsRecord('bash -lc ls')).toBeUndefined();
         expect(extractWriteRequest({ path: 'src/file.ts' }, '/tmp/workspace')).toBeUndefined();
         expect(extractEditRequest({ path: 'src/file.ts' }, '/tmp/workspace')).toBeUndefined();
+    });
+
+    it('keeps inserted lines before a closing brace anchor', () => {
+        const beforeLines = 'if (x) {\n}\n'.split('\n');
+        const afterLines = 'if (x) {\n  work();\n}\n'.split('\n');
+
+        expect(buildInsertionOnlyEdit(beforeLines, afterLines, 1, 1, 2)).toEqual({
+            safeLine: 2,
+            newContent: '  work();\n}',
+        });
+    });
+
+    it('avoids an extra blank line when appending into a trailing newline sentinel', () => {
+        const beforeLines = 'if (x) {\n}\n'.split('\n');
+        const afterLines = 'if (x) {\n}\nnext();\n'.split('\n');
+
+        expect(buildInsertionOnlyEdit(beforeLines, afterLines, 2, 2, 3)).toEqual({
+            safeLine: 3,
+            newContent: 'next();\n',
+        });
+    });
+
+    it('keeps the last real line first when appending without a trailing newline', () => {
+        const beforeLines = 'if (x) {\n}'.split('\n');
+        const afterLines = 'if (x) {\n}\nnext();'.split('\n');
+
+        expect(buildInsertionOnlyEdit(beforeLines, afterLines, 2, 2, 3)).toEqual({
+            safeLine: 2,
+            newContent: '}\nnext();',
+        });
     });
 });

--- a/src/AI/AIAgent/shared/main/agentConversation.ts
+++ b/src/AI/AIAgent/shared/main/agentConversation.ts
@@ -91,7 +91,7 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
         model: options.model,
         workingDirectory: cwd,
         mcpServers: mergedMcpServers,
-        excludedTools: ['str_replace_editor', 'write_file', 'read_file', 'edit', 'view', 'grep', 'glob', 'create'],
+        excludedTools: ['str_replace_editor', 'write_file', 'read_file', 'edit', 'view', 'grep', 'glob', 'create', 'apply_patch'],
         ...(options.contextWindow !== undefined ? { contextWindow: options.contextWindow } : {}),
         onPreToolUse: async (input: AgentPreToolUseHookInput): Promise<AgentPreToolUseHookOutput> => {
             if (!stateRef.current) {

--- a/src/AI/AIAgent/shared/utils/agentToolApproval.ts
+++ b/src/AI/AIAgent/shared/utils/agentToolApproval.ts
@@ -213,3 +213,23 @@ export function extractEditLinesRequest(toolArgs: unknown, workspacePath: string
     return { displayPath: rawPath, endLine, newContent, startLine, targetPath };
 }
 
+export function buildInsertionOnlyEdit(
+    beforeLines: string[],
+    afterLines: string[],
+    commonPrefixLines: number,
+    newSliceStart: number,
+    newSliceEnd: number
+): { safeLine: number, newContent: string } {
+    const safeLine = Math.min(Math.max(commonPrefixLines + 1, 1), Math.max(beforeLines.length, 1));
+    const original = beforeLines[safeLine - 1] ?? '';
+    const insertedLines = afterLines.slice(newSliceStart, newSliceEnd);
+
+    // Insertions inside the BEFORE file belong before the anchor line; true EOF
+    // appends without a trailing newline must keep the last real line first.
+    const insertBeforeAnchor = commonPrefixLines < beforeLines.length;
+    const replacementLines = insertBeforeAnchor
+        ? [...insertedLines, original]
+        : [original, ...insertedLines];
+
+    return { safeLine, newContent: replacementLines.join('\n') };
+}

--- a/src/AI/AIAgent/shared/utils/agentToolHook.ts
+++ b/src/AI/AIAgent/shared/utils/agentToolHook.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import * as neovim from 'neovim';
 import type { VimValue } from 'neovim/lib/types/VimValue';
 import {
+    buildInsertionOnlyEdit,
     coerceNumber,
     coerceNumberArray,
     extractEditLinesRequest,
@@ -919,12 +920,16 @@ export async function handlePreToolUse(
                 const newContents: string[] = [];
 
                 if (editEnd < editStart) {
-                    const safeLine = Math.min(Math.max(editStart, 1), Math.max(beforeLines.length, 1));
-                    const original = beforeLines[safeLine - 1] ?? '';
-                    const inserted = afterLines.slice(newSliceStart, newSliceEnd).join('\n');
+                    const { safeLine, newContent } = buildInsertionOnlyEdit(
+                        beforeLines,
+                        afterLines,
+                        cp,
+                        newSliceStart,
+                        newSliceEnd
+                    );
                     newStarts.push(safeLine);
                     newEnds.push(safeLine);
-                    newContents.push(inserted ? `${original}\n${inserted}` : original);
+                    newContents.push(newContent);
                 } else {
                     const beforeSpan = editEnd - editStart + 1;
                     if (beforeSpan <= EDIT_LINES_HARD_CAP) {


### PR DESCRIPTION
correct the diff-editor rewrite path for insertion-only edit_lines updates so inserted content is placed relative to the right anchor line, this fixes common cases where inserting before a preserved suffix line or appending at EOF could duplicate/misorder lines or introduce an extra blank line

add regression tests for:
inserting before a closing brace
appending at EOF with a trailing newline
appending at EOF without a trailing newline