### PR TITLE
add multi-select support to the @ file picker

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -239,7 +239,7 @@ All key bindings below apply to **both** providers unless noted otherwise.
 |-----|--------|
 | `Enter` | Submit prompt |
 | `Ctrl+C` | Stop current agent turn |
-| `@` | Add file context (Telescope picker) |
+| `@` | Add file context(s) (Telescope picker; `<Tab>` multi-select, `+` marks selections) |
 | `r` | Remove a file from context |
 | `f` | Show active file contexts popup |
 | `Ctrl+X` | Clear all file contexts |

--- a/AI-CHAT-BOT.md
+++ b/AI-CHAT-BOT.md
@@ -83,9 +83,9 @@ graph TB
 | Key | Action | Description |
 |-----|--------|-------------|
 | `⏎ Enter` | 🚀 Submit | Send message to AI (normal mode) |
-| `@ @` | 📎 Add File | Open Telescope file picker for context |
-| `f f` | 📂 Show Contexts | Display popup with active file contexts |
-| `r r` | 🗑️ Remove Context | Select and remove file from context |
+| `@` | 📎 Add File | Open Telescope file picker for context (`<Tab>` multi-select, `+` marks selections) |
+| `f` | 📂 Show Contexts | Display popup with active file contexts |
+| `r` | 🗑️ Remove Context | Select and remove file from context |
 | `Ctrl+X` | 🧹 Clear All | Remove all file contexts |
 | `Ctrl+C` | ⏹️ Stop Stream | Abort AI response generation |
 | `Space` | ✂️ Add Selection | Add visual selection to context (visual mode) |

--- a/__tests__/AI/shared/handleAddFileContext.test.ts
+++ b/__tests__/AI/shared/handleAddFileContext.test.ts
@@ -1,0 +1,71 @@
+import type { NeovimClient } from 'neovim';
+import { handleAddFileContext } from '@/AI/shared/utils/conversationUtils/fileContexts';
+import * as fileContextPickers from '@/AI/shared/utils/conversationUtils/fileContextPickers';
+import * as fileContextOps from '@/AI/shared/utils/conversationUtils/fileContextOps';
+
+jest.mock('@/AI/shared/utils/conversationUtils/fileContextPickers', () => ({
+    selectContextToRemove: jest.fn(),
+    selectFileOrFolder: jest.fn(),
+    promptShareMode: jest.fn(),
+    selectFileFromFolder: jest.fn(),
+}));
+
+jest.mock('@/AI/shared/utils/conversationUtils/fileContextOps', () => ({
+    addFolderContext: jest.fn(),
+    addEntireFileContext: jest.fn(),
+    addPartialFileContext: jest.fn(),
+}));
+
+describe('handleAddFileContext', () => {
+    const mockCommand = jest.fn().mockResolvedValue(undefined);
+    const mockNvimClient = {
+        command: mockCommand,
+    } as unknown as NeovimClient;
+
+    const mockSelectFileOrFolder = jest.mocked(fileContextPickers.selectFileOrFolder);
+    const mockPromptShareMode = jest.mocked(fileContextPickers.promptShareMode);
+    const mockSelectFileFromFolder = jest.mocked(fileContextPickers.selectFileFromFolder);
+    const mockAddFolderContext = jest.mocked(fileContextOps.addFolderContext);
+    const mockAddEntireFileContext = jest.mocked(fileContextOps.addEntireFileContext);
+    const mockAddPartialFileContext = jest.mocked(fileContextOps.addPartialFileContext);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCommand.mockResolvedValue(undefined);
+    });
+
+    it('adds every selected file when entire mode is chosen', async () => {
+        mockSelectFileOrFolder.mockResolvedValue([
+            { path: '/repo/src/one.ts', isDir: false },
+            { path: '/repo/src/two.ts', isDir: false },
+        ]);
+        mockPromptShareMode.mockResolvedValue('entire');
+
+        await handleAddFileContext(mockNvimClient, '/tmp/chat.md');
+
+        expect(mockAddEntireFileContext).toHaveBeenNthCalledWith(1, mockNvimClient, '/tmp/chat.md', '/repo/src/one.ts', undefined);
+        expect(mockAddEntireFileContext).toHaveBeenNthCalledWith(2, mockNvimClient, '/tmp/chat.md', '/repo/src/two.ts', undefined);
+        expect(mockAddPartialFileContext).not.toHaveBeenCalled();
+        expect(mockAddFolderContext).not.toHaveBeenCalled();
+    });
+
+    it('adds every selected folder file and standalone file in snippet mode', async () => {
+        mockSelectFileOrFolder.mockResolvedValue([
+            { path: '/repo/src/components', isDir: true },
+            { path: '/repo/src/app.ts', isDir: false },
+        ]);
+        mockPromptShareMode.mockResolvedValue('snippet');
+        mockSelectFileFromFolder.mockResolvedValue([
+            '/repo/src/components/Button.tsx',
+            '/repo/src/components/Card.tsx',
+        ]);
+
+        await handleAddFileContext(mockNvimClient, '/tmp/chat.md', { agentMode: true });
+
+        expect(mockSelectFileFromFolder).toHaveBeenCalledWith(mockNvimClient, '/repo/src/components');
+        expect(mockAddPartialFileContext).toHaveBeenNthCalledWith(1, mockNvimClient, '/tmp/chat.md', '/repo/src/components/Button.tsx', true);
+        expect(mockAddPartialFileContext).toHaveBeenNthCalledWith(2, mockNvimClient, '/tmp/chat.md', '/repo/src/components/Card.tsx', true);
+        expect(mockAddPartialFileContext).toHaveBeenNthCalledWith(3, mockNvimClient, '/tmp/chat.md', '/repo/src/app.ts', true);
+        expect(mockAddEntireFileContext).not.toHaveBeenCalled();
+    });
+});

--- a/src/AI/AIAgent/shared/main/agentNeovimSetup.ts
+++ b/src/AI/AIAgent/shared/main/agentNeovimSetup.ts
@@ -15,7 +15,7 @@ export async function createAgentChatFile(chatFile: string): Promise<void> {
             # Controls / Shortcuts:
             #   Enter        -> Submit prompt
             #   Ctrl+c       -> Stop current agent turn
-            #   @            -> Add file context
+            #   @            -> Add file context(s) (<Tab> multi-select, + marks selections, <CR> confirm, <Esc> cancel)
             #   r            -> Remove file from context
             #   f            -> Show active file contexts
             #   Ctrl+x       -> Clear all contexts

--- a/src/AI/AIChat/main/conversation.ts
+++ b/src/AI/AIChat/main/conversation.ts
@@ -229,7 +229,7 @@ export async function initializeChatFile(filePath: string, userPrompt = false): 
 # AI Chat History\n\nThis file contains the conversation history between the user and AI.\n
         # ✨ Controls / Shortcuts:
         #   ⏎  Enter     → Save & Submit
-        #   📎  @        → Add File Context
+        #   📎  @        → Add File Context(s) (<Tab> multi-select, + marks selections, <CR> confirm, <Esc> cancel)
         #   ❌  r        → Remove File From Context
         #   📂  f        → Show Files Currently Context
         #   🗑️  <C-x>    → Clear Contexts

--- a/src/AI/shared/utils/conversationUtils/fileContextPickers.ts
+++ b/src/AI/shared/utils/conversationUtils/fileContextPickers.ts
@@ -3,6 +3,44 @@ import { FileContext } from "@/AI/shared/types/aiTypes";
 import fs from 'fs/promises';
 import { fileContexts } from './fileContexts';
 
+export interface FilePickerSelection {
+    path: string;
+    isDir: boolean;
+}
+
+function parsePickerItems<T>(raw: unknown, isItem: (value: unknown) => value is T): T[] | null {
+    if (typeof raw !== 'string') {
+        return null;
+    }
+
+    try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (!Array.isArray(parsed)) {
+            return null;
+        }
+
+        const items = parsed.filter(isItem);
+
+        return items.length > 0 ? items : null;
+    } catch {
+        return null;
+    }
+}
+
+function isFilePickerSelection(value: unknown): value is FilePickerSelection {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    const candidate = value as Record<string, unknown>;
+
+    return typeof candidate['path'] === 'string' && typeof candidate['isDir'] === 'boolean';
+}
+
+function isString(value: unknown): value is string {
+    return typeof value === 'string';
+}
+
 /**
  * Telescope picker: choose a file context to remove. Resolves to the index in
  * `fileContexts` (or null if the user cancelled).
@@ -24,17 +62,19 @@ export async function selectContextToRemove(nvim: NeovimClient): Promise<number 
             const sizeKB = Math.round(content.length / 1024);
 
             return `${index + 1}. 📁 ${fileName} (${lineCount} lines, ${sizeKB}KB)`;
-        } catch (error) {
+        } catch (_error) {
             return `${index + 1}. ❌ ${fileName} (error reading file)`;
         }
     }));
 
     return new Promise((resolve) => {
-        const handler = (method: string, args: any[]) => {
-            if (method === 'fzf_selected_index') {
-                nvim.removeListener('notification', handler);
-                resolve(args[0] !== undefined ? args[0] : null);
+        const handler = (method: string, args: unknown[]): void => {
+            if (method !== 'fzf_selected_index') {
+                return;
             }
+
+            nvim.removeListener('notification', handler);
+            resolve(typeof args[0] === 'number' ? args[0] : null);
         };
 
         nvim.on('notification', handler);
@@ -75,17 +115,17 @@ export async function selectContextToRemove(nvim: NeovimClient): Promise<number 
 /**
  * Telescope picker: choose any file or folder under the cwd.
  */
-export async function selectFileOrFolder(nvim: NeovimClient): Promise<{ path: string; isDir: boolean } | null> {
+export async function selectFileOrFolder(nvim: NeovimClient): Promise<FilePickerSelection[] | null> {
     const channelId = await nvim.channelId;
 
     return new Promise((resolve) => {
-        const handler = (method: string, args: any[]) => {
-            if (method === 'unified_selection') {
-                nvim.removeListener('notification', handler);
-                const path: string = args[0];
-                const isDir: boolean = args[1] === true;
-                resolve(path ? { path, isDir } : null);
+        const handler = (method: string, args: unknown[]): void => {
+            if (method !== 'unified_selection') {
+                return;
             }
+
+            nvim.removeListener('notification', handler);
+            resolve(parsePickerItems(args[0], isFilePickerSelection));
         };
         nvim.on('notification', handler);
 
@@ -109,31 +149,67 @@ export async function selectFileOrFolder(nvim: NeovimClient): Promise<{ path: st
                 end
 
                 pickers.new({}, {
-                    prompt_title = 'Select File or Folder',
+                    prompt_title = 'Select File or Folder  [↑↓:move  <Tab>:toggle multi  <CR>:confirm  <Esc>:cancel]',
                     finder = finders.new_oneshot_job(find_cmd, {
                         entry_maker = make_entry.gen_from_file({}),
                     }),
                     sorter = conf.file_sorter({}),
                     previewer = conf.file_previewer({}),
-                    attach_mappings = function(prompt_bufnr, _)
-                        actions.select_default:replace(function()
-                            local selection = action_state.get_selected_entry()
-                            actions.close(prompt_bufnr)
-                            if not selection then
-                                vim.fn.rpcnotify(${channelId}, 'unified_selection', nil, false)
-                                return
+                    attach_mappings = function(prompt_bufnr, map)
+                        local function finish_selection()
+                            local picker = action_state.get_current_picker(prompt_bufnr)
+                            local multi = picker:get_multi_selection()
+                            local selected = {}
+                            local seen = {}
+
+                            local function add_item(item)
+                                if not item then
+                                    return
+                                end
+
+                                local path = vim.fn.fnamemodify(item.value or '', ':p')
+                                if path == '' or seen[path] then
+                                    return
+                                end
+
+                                table.insert(selected, {
+                                    path = path,
+                                    isDir = vim.fn.isdirectory(path) == 1,
+                                })
+                                seen[path] = true
                             end
-                            local path = vim.fn.fnamemodify(selection.value or '', ':p')
-                            local is_dir = vim.fn.isdirectory(path) == 1
-                            vim.fn.rpcnotify(${channelId}, 'unified_selection', path, is_dir)
-                        end)
+
+                            if multi and #multi > 0 then
+                                for _, item in ipairs(multi) do
+                                    add_item(item)
+                                end
+                            else
+                                add_item(action_state.get_selected_entry())
+                            end
+
+                            actions.close(prompt_bufnr)
+                            vim.fn.rpcnotify(${channelId}, 'unified_selection', #selected > 0 and vim.fn.json_encode(selected) or nil)
+                        end
+
+                        local function cancel_selection()
+                            actions.close(prompt_bufnr)
+                            vim.fn.rpcnotify(${channelId}, 'unified_selection', nil)
+                        end
+
+                        actions.select_default:replace(finish_selection)
+                        map('i', '<Tab>', function() actions.toggle_selection(prompt_bufnr) end)
+                        map('n', '<Tab>', function() actions.toggle_selection(prompt_bufnr) end)
+                        map('i', '<Esc>', cancel_selection)
+                        map('n', 'q', cancel_selection)
+                        map('i', '<C-c>', cancel_selection)
+                        map('n', '<C-c>', cancel_selection)
                         return true
                     end,
                 }):find()
             end)
             if not ok then
                 vim.notify('File/folder picker error: ' .. tostring(err), vim.log.levels.ERROR)
-                vim.fn.rpcnotify(${channelId}, 'unified_selection', nil, false)
+                vim.fn.rpcnotify(${channelId}, 'unified_selection', nil)
             end
         `;
 
@@ -144,6 +220,7 @@ export async function selectFileOrFolder(nvim: NeovimClient): Promise<{ path: st
     });
 }
 
+
 /**
  * Telescope prompt: ask whether to share the entire file/folder or a snippet.
  */
@@ -151,11 +228,14 @@ export async function promptShareMode(nvim: NeovimClient): Promise<'entire' | 's
     const channelId = await nvim.channelId;
 
     return new Promise((resolve) => {
-        const handler = (method: string, args: any[]) => {
-            if (method === 'share_mode_selected') {
-                nvim.removeListener('notification', handler);
-                resolve((args[0] as 'entire' | 'snippet') || null);
+        const handler = (method: string, args: unknown[]): void => {
+            if (method !== 'share_mode_selected') {
+                return;
             }
+
+            nvim.removeListener('notification', handler);
+            const shareMode = args[0];
+            resolve(shareMode === 'entire' || shareMode === 'snippet' ? shareMode : null);
         };
         nvim.on('notification', handler);
 
@@ -203,15 +283,17 @@ export async function promptShareMode(nvim: NeovimClient): Promise<'entire' | 's
 /**
  * Telescope picker: choose one file from inside a previously-selected folder.
  */
-export async function selectFileFromFolder(nvim: NeovimClient, folderPath: string): Promise<string | null> {
+export async function selectFileFromFolder(nvim: NeovimClient, folderPath: string): Promise<string[] | null> {
     const channelId = await nvim.channelId;
 
     return new Promise((resolve) => {
-        const handler = (method: string, args: any[]) => {
-            if (method === 'folder_file_selected') {
-                nvim.removeListener('notification', handler);
-                resolve(args[0] || null);
+        const handler = (method: string, args: unknown[]): void => {
+            if (method !== 'folder_file_selected') {
+                return;
             }
+
+            nvim.removeListener('notification', handler);
+            resolve(parsePickerItems(args[0], isString));
         };
         nvim.on('notification', handler);
 
@@ -233,24 +315,58 @@ export async function selectFileFromFolder(nvim: NeovimClient, folderPath: strin
                 end
 
                 pickers.new({}, {
-                    prompt_title = 'Select File from Folder',
+                    prompt_title = 'Select File from Folder  [↑↓:move  <Tab>:toggle multi  <CR>:confirm  <Esc>:cancel]',
                     cwd = folder,
                     finder = finders.new_oneshot_job(find_cmd, {
                         entry_maker = make_entry.gen_from_file({}),
                     }),
                     sorter = conf.file_sorter({}),
                     previewer = conf.file_previewer({}),
-                    attach_mappings = function(prompt_bufnr, _)
-                        actions.select_default:replace(function()
-                            local selection = action_state.get_selected_entry()
-                            actions.close(prompt_bufnr)
-                            if not selection then
-                                vim.fn.rpcnotify(${channelId}, 'folder_file_selected', nil)
-                                return
+                    attach_mappings = function(prompt_bufnr, map)
+                        local function finish_selection()
+                            local picker = action_state.get_current_picker(prompt_bufnr)
+                            local multi = picker:get_multi_selection()
+                            local selected = {}
+                            local seen = {}
+
+                            local function add_item(item)
+                                if not item then
+                                    return
+                                end
+
+                                local path = vim.fn.fnamemodify(item.value or '', ':p')
+                                if path == '' or seen[path] then
+                                    return
+                                end
+
+                                table.insert(selected, path)
+                                seen[path] = true
                             end
-                            local path = vim.fn.fnamemodify(selection.value or '', ':p')
-                            vim.fn.rpcnotify(${channelId}, 'folder_file_selected', path)
-                        end)
+
+                            if multi and #multi > 0 then
+                                for _, item in ipairs(multi) do
+                                    add_item(item)
+                                end
+                            else
+                                add_item(action_state.get_selected_entry())
+                            end
+
+                            actions.close(prompt_bufnr)
+                            vim.fn.rpcnotify(${channelId}, 'folder_file_selected', #selected > 0 and vim.fn.json_encode(selected) or nil)
+                        end
+
+                        local function cancel_selection()
+                            actions.close(prompt_bufnr)
+                            vim.fn.rpcnotify(${channelId}, 'folder_file_selected', nil)
+                        end
+
+                        actions.select_default:replace(finish_selection)
+                        map('i', '<Tab>', function() actions.toggle_selection(prompt_bufnr) end)
+                        map('n', '<Tab>', function() actions.toggle_selection(prompt_bufnr) end)
+                        map('i', '<Esc>', cancel_selection)
+                        map('n', 'q', cancel_selection)
+                        map('i', '<C-c>', cancel_selection)
+                        map('n', '<C-c>', cancel_selection)
                         return true
                     end,
                 }):find()

--- a/src/AI/shared/utils/conversationUtils/fileContexts.ts
+++ b/src/AI/shared/utils/conversationUtils/fileContexts.ts
@@ -11,8 +11,8 @@ export async function handleAddFileContext(nvim: NeovimClient, chatFile: string,
     try {
         await nvim.command('echohl MoreMsg | echo "Opening context selector..." | echohl None');
 
-        const selection = await selectFileOrFolder(nvim);
-        if (!selection) {
+        const selections = await selectFileOrFolder(nvim);
+        if (!selections || selections.length === 0) {
             await nvim.command('echohl WarningMsg | echo "Cancelled" | echohl None');
 
             return;
@@ -25,22 +25,34 @@ export async function handleAddFileContext(nvim: NeovimClient, chatFile: string,
             return;
         }
 
-        const { path, isDir } = selection;
         const agentMode = options?.agentMode;
 
-        if (isDir && shareMode === 'entire') {
-            await addFolderContext(nvim, chatFile, path.replace(/\/$/, ''), agentMode);
-        } else if (isDir && shareMode === 'snippet') {
-            const fileInFolder = await selectFileFromFolder(nvim, path);
-            if (!fileInFolder) {
-                await nvim.command('echohl WarningMsg | echo "No file selected" | echohl None');
+        for (const selection of selections) {
+            const { path, isDir } = selection;
 
-                return;
+            if (isDir && shareMode === 'entire') {
+                await addFolderContext(nvim, chatFile, path.replace(/\/$/, ''), agentMode);
+                continue;
             }
-            await addPartialFileContext(nvim, chatFile, fileInFolder, agentMode);
-        } else if (!isDir && shareMode === 'entire') {
-            await addEntireFileContext(nvim, chatFile, path, agentMode);
-        } else {
+
+            if (isDir && shareMode === 'snippet') {
+                const filesInFolder = await selectFileFromFolder(nvim, path);
+                if (!filesInFolder || filesInFolder.length === 0) {
+                    await nvim.command('echohl WarningMsg | echo "No file selected" | echohl None');
+                    continue;
+                }
+
+                for (const fileInFolder of filesInFolder) {
+                    await addPartialFileContext(nvim, chatFile, fileInFolder, agentMode);
+                }
+                continue;
+            }
+
+            if (shareMode === 'entire') {
+                await addEntireFileContext(nvim, chatFile, path, agentMode);
+                continue;
+            }
+
             await addPartialFileContext(nvim, chatFile, path, agentMode);
         }
     } catch (error: unknown) {
@@ -218,7 +230,7 @@ export async function showFileContextsPopup(nvim: NeovimClient): Promise<void> {
                 const lineCount = content.split('\n').length;
                 const sizeKB = Math.round(content.length / 1024);
                 popupLines.push(`${index + 1}. 📁 ${fileName} (${lineCount} lines, ${sizeKB}KB)`, `   ${context.filePath}`, '');
-            } catch (error) {
+            } catch (_error) {
                 popupLines.push(`${index + 1}. ❌ ${fileName} (error reading file)`, `   ${context.filePath}`, '');
             }
         }


### PR DESCRIPTION
make the @ file-context picker behave like the kra-memory picker by supporting Telescope multi-select with <Tab> and the + selection marker process every selected file or folder when adding context extend the folder file picker with the same behavior update the on-screen/docs instructions and cover the batch-add flow with tests