### PR TITLE
refactor - unify MCP server plumbing and split agent docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -16,19 +16,7 @@ When you run `kra ai agent`, the first picker is **provider selection** (`copilo
 - [Quick Start](#-quick-start)
 - [How It Works](#-how-it-works)
 - [Architecture](#-architecture)
-- [Provider: Copilot](#-provider-copilot)
-- [Provider: BYOK](#-provider-byok)
-- [Model Catalog](#-model-catalog)
-- [Key Bindings](#️-key-bindings)
-- [Tool Approval](#-tool-approval)
-- [Diff Editor & User Edits](#-diff-editor--user-edits)
-- [File Editing Tools (kra-file-context MCP)](#-file-editing-tools-kra-file-context-mcp)
-- [Bash & Web Tools (BYOK)](#-bash--web-tools-byok)
-- [Persistent Memory (kra-memory MCP)](#-persistent-memory-kra-memory-mcp)
-- [Session Diff History & Per-File Revert](#-session-diff-history--per-file-revert)
-- [Skills (Copilot only)](#-skills-copilot-only)
-- [MCP Server Configuration](#-mcp-server-configuration)
-- [Quota Monitoring (Copilot only)](#-quota-monitoring-copilot-only)
+- [Detailed Documentation](#-detailed-documentation)
 
 ---
 
@@ -89,538 +77,77 @@ Every file mutation the agent performs — through `edit_lines`, `create_file`, 
 
 ## 🗺 Architecture
 
-The diagram below shows the full turn lifecycle for both providers — the only branching is at session start.
+The diagram below is the simplified runtime flow (accurate to the current approval and review behavior).
 
 ```mermaid
-flowchart TD
-    START["kra ai agent"] --> PROVIDER{Pick provider}
+graph TB
+    subgraph "Startup"
+        START[kra ai agent]
+        PICK[Pick provider and model]
+        ADAPTER[Provider adapter: copilot or byok]
+        SESSION[Create AgentSession]
+        NVIM[Open Neovim chat buffer]
+        START --> PICK --> ADAPTER --> SESSION --> NVIM
+    end
 
-    PROVIDER -- copilot --> COPILOT_AUTH[Authenticate CopilotClient]
-    COPILOT_AUTH --> COPILOT_MODEL[Pick Copilot model + reasoning effort]
-    COPILOT_MODEL --> SHARED
+    subgraph "Turn Loop"
+        PROMPT[Submit prompt]
+        STREAM[Stream text and reasoning]
+        TOOLQ{Tool requested?}
+        APPROVAL[Tool approval popup]
+        ARGS[Edit tool args JSON]
+        WRITE{Write tool?}
+        DIFF[Diff review editor]
+        EXEC[Execute tool]
+        RESULT[Return tool result]
+        DONE[Turn output complete]
 
-    PROVIDER -- byok --> BYOK_PROV[Pick BYOK sub-provider]
-    BYOK_PROV --> BYOK_MODEL[Pick model from live catalog]
-    BYOK_MODEL --> SHARED
+        PROMPT --> STREAM --> TOOLQ
+        TOOLQ -- No --> DONE
+        TOOLQ -- Yes --> APPROVAL
 
-    SHARED[Load MCP servers from settings.toml<br/>+ kra-file-context + session-complete + kra-memory<br/>+ kra-bash + kra-web for BYOK]
-    SHARED --> SESSION[Start AgentSession]
-    SESSION --> NVIM[Open Neovim chat buffer]
+        APPROVAL -- Edit args --> ARGS
+        ARGS --> APPROVAL
+        APPROVAL -- Deny --> RESULT
+        APPROVAL -- Approve --> WRITE
+        WRITE -- No --> EXEC
+        WRITE -- Yes --> DIFF
+        DIFF -- Approve --> EXEC
+        DIFF -- Deny --> RESULT
 
-    NVIM --> PROMPT[User types prompt / Enter to submit]
-    PROMPT --> SDK[Agent reasons & streams text]
-    SDK --> TOOLS{Tool calls?}
-    TOOLS -- No --> TURN_END[Turn ends]
-    TOOLS -- Yes --> PRETOOL[onPreToolUse hook]
+        EXEC --> RESULT --> STREAM
+    end
 
-    PRETOOL --> IS_CONFIRM{confirm_task_complete?}
-    IS_CONFIRM -- Yes --> CONFIRM_POPUP[Confirm popup<br/>summary + 2-4 choices]
-    CONFIRM_POPUP -- End session --> DONE([Session ends])
-    CONFIRM_POPUP -- Any other choice --> FREE[Reply sent back<br/>AI continues in same turn]
-    FREE --> SDK
+    subgraph "Session Control"
+        CONTINUE[Continue session]
+        SDIFF[Optional session diff browser]
+        CONFIRM{confirm_task_complete}
+        END[End session]
 
-    IS_CONFIRM -- No --> AUTO{Auto-approve?}
-    AUTO -- report_intent / YOLO / allowed family --> ALLOW[Allow tool]
+        DONE --> CONTINUE --> PROMPT
+        DONE -- Optional review --> SDIFF
+        SDIFF --> CONTINUE
+        DONE --> CONFIRM
+        CONFIRM -- Continue --> CONTINUE
+        CONFIRM -- End session --> END
+    end
 
-    AUTO -- Strict mode --> APPROVE_POPUP[Tool approval popup<br/>tool name · args · diff preview]
-    APPROVE_POPUP -- a: approve once --> ALLOW
-    APPROVE_POPUP -- s: allow family --> ALLOW
-    APPROVE_POPUP -- y: YOLO --> ALLOW
-    APPROVE_POPUP -- e: diff editor --> DIFF_EDITOR[3-pane diff editor<br/>current / proposed / reference]
-    DIFF_EDITOR -- leader+a: approve --> USER_EDITED{User edited the<br/>proposed buffer?}
-    USER_EDITED -- Yes --> NOTIFY{Notify AI of<br/>post-edit lines?}
-    NOTIFY --> ALLOW
-    USER_EDITED -- No --> ALLOW
-    DIFF_EDITOR -- leader+d or q: deny --> DENY[Deny tool]
-    APPROVE_POPUP -- d/q: deny --> DENY
-
-    ALLOW --> EXEC[Tool executes against repo]
-    EXEC --> HISTORY[Record mutation in AgentHistory<br/>finalize pending diff entry]
-    HISTORY --> SDK
-    DENY --> SDK
-
-    TURN_END --> PROMPT
-    TURN_END --> CHANGED{Check changes manually?}
-    CHANGED -- leader+d --> DIFF_TAB[Proposal diff tab]
-    DIFF_TAB --> REVIEW[Inspect and edit files]
-    REVIEW -- a: apply --> PROMPT
-    REVIEW -- r: reject / git restore + clean -fd --> PROMPT
+    NVIM --> PROMPT
 ```
 
 ---
 
-## 🟦 Provider: Copilot
-
-Wraps `@github/copilot-sdk` behind the provider-neutral `AgentClient` interface.
-
-- **Auth:** uses your logged-in GitHub Copilot session (via the SDK's device flow), or honours `GITHUB_TOKEN` / `getGithubToken()` from `settings.toml` if set.
-- **Models:** fetched live from the Copilot SDK at session start. Each entry is annotated with:
-  - `[DISABLED]` — the model is currently unavailable for your account
-  - `[xN]` — the billing multiplier (premium-interaction cost) when greater than 1
-- **Reasoning effort:** if the chosen model advertises multiple efforts (`low`, `medium`, `high`, `xhigh`), a second picker appears. The model's recommended effort is marked `(default)`.
-- **Default model:** set in `settings.toml` to skip the picker:
-  ```toml
-  [ai.agent]
-  defaultModel = "gpt-5-mini"
-  ```
-- **Built-in tools:** the SDK ships its own bash/web/MCP tooling. Kra **excludes** the SDK's stock file editors (`str_replace_editor`, `write_file`, `read_file`, `edit`, `view`, `grep`, `glob`) so the agent is forced through the precise `kra-file-context` line-range tools described below.
-- **Skills:** loaded from `<repo>/skills/` via the SDK's `skillDirectories` option (Copilot only — BYOK has no skill concept).
-- **Quota monitoring:** see [Quota Monitoring](#-quota-monitoring-copilot-only).
-
----
-
-## 🟨 Provider: BYOK
-
-A "Bring Your Own Key" provider that talks to **any OpenAI Chat Completions–compatible API**. Supported sub-providers ship out of the box:
-
-| Sub-provider | Base URL | API key source |
-|--------------|----------|----------------|
-| `open-ai` | `https://api.openai.com/v1` | `OPENAI_API_KEY` env var |
-| `deep-seek` | `https://api.deepseek.com/v1` | `keys.getDeepSeekKey()` |
-| `deep-infra` | `https://api.deepinfra.com/v1/openai` | `keys.getDeepInfraKey()` |
-| `open-router` | `https://openrouter.ai/api/v1` | `keys.getOpenRouterKey()` |
-| `gemini` | `https://generativelanguage.googleapis.com/v1beta/openai/` | `keys.getGeminiKey()` |
-| `mistral` | `https://api.mistral.ai/v1` | `keys.getMistralKey()` |
-
-
-Adding a new BYOK provider is a 3-step change in `src/AI/shared/data/`:
-
-1. Append it to `SUPPORTED_PROVIDERS` in `providers.ts`
-2. Add a `baseURL` + key-getter case in `providers.ts`
-3. Add a live-fetcher branch in `modelCatalog.ts` (used to populate the model picker)
-
-### How a BYOK turn works
-
-- One session = one OpenAI client + one MCP client pool.
-- The session drives a streaming tool-call loop: the model produces text + tool calls, Kra dispatches each tool call through the same `onPreToolUse` / `onPostToolUse` hooks the Copilot path uses, and feeds tool results back as `tool` messages until the model returns a turn with no tool calls.
-- Reasoning deltas (`deepseek-reasoner` et al.) are detected via `delta.reasoning_content` / `delta.reasoning` and streamed to the same Neovim reasoning panel the Copilot provider uses.
-- Tool denials are surfaced to the model as the tool result so it can react.
-- A synthetic **turn reminder** (`onUserPromptSubmitted`) is injected into the system prompt so the model gets the same housekeeping context the Copilot SDK supplies natively.
-
-### Context-window compaction
-
-BYOK ships a **summarization-based compactor** (`byokCompactor.ts`) that triggers when:
-
-- the provider returns a context-length error (matched against common phrasings: `context length`, `maximum context`, `too many tokens`, `reduce the length`, …), **or**
-- the estimated token count (chars / 4 heuristic) exceeds the model's advertised context window by the % we set.
-
-When triggered, the compactor:
-
-1. Keeps all `system` messages and the **last 10** non-system messages verbatim
-2. Asks the same model to summarize the older transcript into a dense bullet recap (user goals, key decisions, files touched, errors hit, outstanding TODOs)
-3. Replaces the older messages with `<compacted_history>…</compacted_history>` and retries the failed request
-
-### MCP client pool
-
-Because BYOK has no SDK-level tools, Kra spins up the configured MCP servers itself via `@modelcontextprotocol/sdk`. Each tool is exposed to the model with a namespaced name (`<server>__<tool>`) to avoid collisions. The pool honours per-server `tools = [...]` allow-lists and the session-level `excludedTools` filter; remote (`http`/`sse`) MCP servers are ignored — BYOK only deals with local stdio servers.
-
----
-
-## 📚 Model Catalog
-
-Both the BYOK agent picker **and** the regular `kra ai chat` provider picker are now driven by a shared **live model catalog** (`src/AI/shared/data/modelCatalog.ts`).
-
-- Models are fetched directly from each provider's `/models` endpoint at session start
-- For providers whose endpoint omits metadata, a small static fallback table fills in well-known context windows + pricing
-- Results are cached on disk under `~/.config/kra-tmux/model-catalog/<provider>.json` with a **24-hour TTL**
-- On network failure, the **most recent cached snapshot is returned** (even if expired); only if no cache exists does the catalog fall through to the built-in static lists
-- The picker formats each entry as `<model id padded>  <Nk ctx>  $<in>/$<out> in/out  cached $<cached>` so you can compare cost and context at a glance
-- The catalog's `contextWindow` is the same value that drives BYOK's proactive compaction
-
----
-
-## ⌨️ Key Bindings
-
-All key bindings below apply to **both** providers unless noted otherwise.
-
-### Chat Buffer
-
-| Key | Action |
-|-----|--------|
-| `Enter` | Submit prompt |
-| `Ctrl+C` | Stop current agent turn |
-| `@` | Add file context(s) (Telescope picker; `<Tab>` multi-select, `+` marks selections) |
-| `r` | Remove a file from context |
-| `f` | Show active file contexts popup |
-| `Ctrl+X` | Clear all file contexts |
-| `<leader>o` | Open a changed proposal file |
-| `<leader>a` | Apply proposal to the repository |
-| `<leader>r` | Reject / discard proposal changes |
-| `<leader>y` | Toggle YOLO mode (auto-approve all tools) |
-| `<leader>P` | Reset remembered per-family tool approvals |
-| `<leader>h` | Browse tool call history for this session |
-| `<leader>s` | Browse session diff history (all AI write diffs + per-file `ORIG`) |
-| `<leader>m` | Browse `kra-memory`. Picker keys: `<Tab>` cycles all/findings/revisits, `a` adds, `dd`/`D` deletes, `<CR>` opens entry in a scratch buffer. In the buffer: `<leader>w` (or `:w`) saves edits, `<leader>d` deletes, `<leader>r` resolves a revisit, `<leader>x` dismisses a revisit, `q` closes |
-| `<Space>t` | Toggle tool/intent popups on or off (global keymap) |
-| `<leader>?` | Show all keymaps (which-key) |
-
-> **Note:** `<leader>d` opens the proposal diff tab on demand. `<leader>o/a/r` let you open a file, apply, or reject from anywhere.
-
-#### Tool Call History (`<leader>h`)
-
-Opens a searchable Telescope picker listing every tool invoked during the session — name, started/updated time, and success/failure status. The preview pane shows the tool's **result** (output) for the highlighted entry. Press `<CR>` to open a read-only side-by-side view in a new tab: the **arguments JSON** (as the agent sent them) on the left, and the **tool result** on the right. Inside the view, `q` closes the tab and `<Tab>` / `<S-Tab>` switch focus between the two panes. The history is view-only — tools cannot be re-run from here.
-
-### Proposal Review Tab
-
-The diff tab has its own local keymaps:
-
-| Key | Action |
-|-----|--------|
-| `a` | Apply proposal to repository |
-| `r` | Reject proposal |
-| `o` | Open a changed file (Telescope picker) |
-| `R` | Refresh the diff |
-| `q` | Close the tab |
-
-
-### Tool Approval Popup
-
-When the agent requests permission to run a tool (strict mode):
-
-| Key | Action |
-|-----|--------|
-| `<CR>` | Run the currently highlighted action (same as pressing its letter) |
-| `<Up>` / `<Down>` | Move the highlight between actions |
-| `a` | Approve this tool call once |
-| `s` | Allow this **tool family** for the rest of the session |
-| `y` | Enable **YOLO mode** — approve everything automatically |
-| `e` | Open the **diff editor** to review/edit the proposed change (file writes only — falls back to JSON editor for other tools) |
-| `J` / `<leader>j` | Open the raw tool JSON args in an editor (only when a write preview is shown) |
-| `d` / `q` | Deny this tool call |
-
----
-
-## 🔐 Tool Approval
-
-### Auto-Approved Tools
-
-Some tools are always allowed silently, without showing a popup:
-
-| Tool | Reason |
-|------|--------|
-| `report_intent` | Status-reporting only — no side effects |
-| `confirm_task_complete` | Handled by the confirm-before-done popup, not the approval flow |
-
-### Strict Mode (default)
-
-Every other tool call shows a popup. You see the tool name, arguments, and — for file writes — a diff preview. Choose to:
-
-- **Approve once** (`a`) — allow just this call
-- **Allow family** (`s`) — remember approval for all tools of the same type (e.g., all shell commands) for this session
-- **YOLO mode** (`y`) — disable approval prompts entirely until you reset (`<leader>P`)
-
-### YOLO Mode
-
-All tool calls are approved automatically. File writes still go directly to the repository. Toggle with `<leader>y`; reset with `<leader>P`.
-
----
-
-## ✏️ Diff Editor & User Edits
-
-From the tool-approval popup, press `e` on a file write (`edit_lines`, `create_file`, …) to open a three-pane diff view: **current** ← **proposed** → **reference** (the original pre-mutation buffer).
-
-| Key | Action |
-|-----|--------|
-| `<leader>a` | Approve the (possibly edited) proposed content |
-| `<leader>d` | Deny |
-| `<leader>j` | Edit the raw tool JSON arguments |
-| `q` | Close and deny |
-
-### What happens when you edit the proposed buffer
-
-If you change the **proposed** pane before approving, Kra:
-
-1. Computes a prefix/suffix-stripped hunk diff between the original file and your edited proposal
-2. Splits the diff into ≤100-line chunks if needed
-3. **Replaces the agent's `modifiedArgs`** with a real `edit_lines` call that applies your edit — so the tool runs for real instead of being silently swallowed
-4. Asks (`vim.ui.select`) whether the AI should be **notified** of the post-edit lines
-   - **Yes, send numbered post-edit lines** — the model sees exactly what landed
-   - **No, send a short "trust LSP" notice** — the model is told the user edited it and should re-read if needed
-   - The choice is forwarded through `__userEditNotify` and surfaces as `additionalContext` in the next tool result
-
-Denied or intercepted edits are dropped from the session diff history queue; only successful tool executions get committed.
-
----
-
-## 🛠 File Editing Tools (kra-file-context MCP)
-
-The agent has a built-in MCP server (`kra-file-context`) that exposes precise, line-range based file editing tools. To force the agent to use these — instead of fuzzy string-replacement tools — the SDK's stock editing tools are **excluded** (Copilot provider):
-
-```
-excludedTools: ['str_replace_editor', 'write_file', 'read_file', 'edit', 'view', 'grep', 'glob']
-```
-
-The built-in `grep` and `glob` tools are also replaced by the unified `search` tool below.
-
-The agent must use the following tools instead:
-
-| Tool | Purpose |
-|------|---------|
-| `search(name_pattern?, content_pattern?)` | **Unified file finder + content grep.** Provide a glob (`name_pattern`), a regex (`content_pattern`), or both to intersect. Every result is annotated with the file's line count. Powered by ripgrep; respects `.gitignore`. Replaces the built-in `grep`/`glob` tools. |
-| `get_outline(file_path)` | Returns a structured outline (functions, classes, methods + line numbers). Cheap way to understand a large file before reading it. |
-| `read_lines(file_path, start_line, end_line)` | Read a specific line range (1-indexed, inclusive). |
-| `read_lines(file_path, startLines[], endLines[])` | **Array form** — read multiple ranges in one call (parallel arrays). |
-| `read_function(file_path, function_name)` | Look up a symbol by name and return its full body. |
-| `edit_lines(file_path, start_line, end_line, new_content)` | Replace a line range with new content. Empty `new_content` deletes the lines. Returns the old content for verification. |
-| `edit_lines(file_path, startLines[], endLines[], newContents[])` | **Array form** — apply multiple edits in one call. Line numbers refer to the original file; the tool sorts ranges bottom-to-top internally and rejects overlapping ranges. |
-| `create_file(file_path, content)` | Create a new file (or overwrite an existing one). Parent directories are created automatically. |
-| `lsp_query` | Hover / definition / references / implementations / type-definition / document-symbols against a configured language server (see `[lsp.*]` blocks in `settings.toml`). |
-
-### `search` options
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `name_pattern` | string | Glob to filter by file name/path (e.g. `**/*.ts`, `src/AI/**/auth*`). |
-| `content_pattern` | string | Ripgrep regex to search file contents. |
-| `path` | string | Root directory to search from. Defaults to cwd. |
-| `type` | string | Ripgrep `--type` alias (e.g. `ts`, `py`, `go`). |
-| `case_insensitive` | boolean | Case-insensitive content match. Default `false`. |
-| `context` | number | Lines of context around each match (`-C N`). Default `0`. |
-| `multiline` | boolean | Allow pattern to match across line boundaries. Default `false`. |
-| `max_results` | number | Cap on results (file count or match-line count). Default `50`, hard cap `200`. |
-
-At least one of `name_pattern` or `content_pattern` is required.
-
-### `read_lines` gating
-
-- `read_lines` accepts up to **500 lines per call** (hard cap).
-- A **soft gate** bounces a single call back to `get_outline` when the total requested range exceeds **200 lines** — but **only** for files that have a meaningful outline (LSP entries, regex fallback, or import lines). Plain text / CSV / log / markdown-without-headings files are exempt and can be read in any range up to the 500-line cap.
-
-### Recommended workflow
-
-1. `search` → locate the file(s) and note the reported line count
-2. `get_outline` → understand the file structure; especially valuable for files over ~150 lines where guessing read ranges wastes tokens
-3. `read_lines` → reads only the exact range(s) needed
-4. `edit_lines` → replaces them — makes one targeted call per changed section, not a wholesale file rewrite
-
-For multi-section reads/edits, **always prefer the array form** over multiple sequential calls.
-
----
-
-## 🐚 Bash & Web Tools (BYOK)
-
-Because BYOK has no SDK-level tools, Kra ships two extra MCP servers that are auto-injected only on the BYOK code path:
-
-### `kra-bash` — `bash` tool
-
-- Runs the given shell command via `/bin/sh -c` in `process.env.WORKING_DIR` (set to the agent's CWD)
-- Default 120 s timeout, 10 MB combined stdout/stderr cap
-- **Output truncation:** anything longer than ~8000 chars is collapsed to **first 2000 + last 6000 chars** with the middle elided — bounds context-window growth without losing tail/head signal
-- Emits before/after `git status` snapshots so any files the bash command touches get recorded in `AgentHistory`
-
-### `kra-web` — `web_fetch` + `web_search` tools
-
-| Tool | Purpose | Limits |
-|------|---------|--------|
-| `web_fetch(url, max_length?)` | Fetches a URL over HTTPS/HTTP, strips HTML to plain text via `cheerio` + `html-to-text` | default 8 000 chars, hard cap 50 000, 20 s timeout |
-| `web_search(query, max_results?)` | Scrapes DuckDuckGo's HTML endpoint and returns a markdown list of hits | default 5 results, hard cap 15 |
-
-A realistic browser User-Agent is sent on every request to reduce DuckDuckGo rate-limiting.
-
-> The Copilot provider does **not** load `kra-bash` / `kra-web` — the SDK already provides equivalents.
-
----
-
-## 🧠 Persistent Memory (kra-memory MCP)
-
-The agent loses context every time a session ends, and even within a session BYOK's compactor and Copilot's SDK compaction smooth specifics away. `kra-memory` gives the agent a **local, persistent vector store** so design decisions, bug fixes, gotchas, and follow-ups survive across sessions, branches, and compaction events.
-
-It's auto-loaded for **both** providers (alongside `kra-file-context` and `kra-session-complete`) so you don't have to touch `settings.toml` to get it.
-
-### Storage
-
-- `<repo>/.kra-memory/lance/memory_findings.lance/` — LanceDB table for findings (note / bug-fix / gotcha / decision / investigation), 384-dim vectors
-- `<repo>/.kra-memory/lance/memory_revisits.lance/` — LanceDB table for revisits (parked discussions, with status), 384-dim vectors
-- The legacy single `memory.lance/` table is dropped on first connect after upgrade
-- ~2 KB per entry; thousands of entries fit in a few MB
-- Add `.kra-memory/` to your `.gitignore` if you prefer local-only memory (the directory contains raw debugging context that may be noisy in git history)
-
-### Embedder
-
-- **`fastembed`** with **BGE-small int8** (~30 MB, bundled inside the npm package)
-- Lazy-loaded on first use (~200 ms cold start); fully offline; no API keys, no Python, no Ollama
-
-### Manual browsing & editing (`<leader>m`)
-
-The agent isn't the only one allowed to write to the memory store. Inside the agent chat buffer, press `<leader>m` to open a Telescope picker over every entry, with a preview pane showing the body, tags, paths, status and creation time. From the picker:
-
-- `a` (or `<C-a>` in insert mode) — prompts for kind / title / body / tags via `vim.ui.select` + `vim.ui.input` and inserts a new memory (`source = 'user'`)
-- `dd` — confirms then deletes the highlighted entry
-- `D` — deletes without confirmation (use sparingly)
-- `<Tab>` — cycles the view: all → findings → revisits → all (the title shows the current view + counts)
-- `<CR>` — opens the selected entry in a markdown scratch buffer with a YAML-style header (`id` / `kind` / `status` / `created` / `paths` / `title` / `tags`) above the body. From that buffer:
-  - `<leader>w` (or `:w`) — saves edits via `edit_memory` (title, tags, and body are parsed from the buffer; id/kind/status/created/paths are read-only)
-  - `<leader>d` — deletes the entry (with confirm)
-  - `<leader>r` — resolves the entry as a revisit (prompts for an optional resolution note); no-op on findings
-  - `<leader>x` — dismisses the entry as a revisit (prompts for an optional reason); no-op on findings
-  - `q` — closes the buffer without saving
-
-Each action re-opens the picker on the same view so you can chain operations. The same `notes.ts` helpers back both the picker and the MCP tools, so user-edited and agent-edited memories are indistinguishable to `recall` / `semantic_search`.
-
-When the **agent** tries to read memory via `recall` or memory-scoped `semantic_search`, that read is intercepted before the model sees it: a Telescope picker opens, `<Tab>` toggles multi-select, arrow keys move the cursor, `<CR>` confirms, and only the selected memory ids are passed back to the tool call.
-
-For a CLI-side equivalent (no agent session needed), run `kra ai memory`. It's a blessed wizard that operates over the **central registry at `~/.kra-memory/registry.json`**, so it manages **every repo you've ever indexed** — not just the cwd. Two branches: **Indexed codebases** (list every registered repo with alias, path, last-indexed commit and chunk count; pick any one to view details, drop its `code_chunks` table, reset its indexing baseline so the next agent launch in that repo does a fresh full index, or rename its alias) and **Long-term memories** (scope to All / Findings / Revisits, view body in a scrollable blessed modal, edit body in Neovim — round-trips through a temp file and re-embeds the vector — change status, delete, or add a brand-new entry). Useful when you want to clean house across multiple projects without launching the agent in each one.
-
-### Tools exposed (5, intentionally minimal)
-
-The surface is intentionally compact so the model doesn't have to choose between near-duplicate tools. Two writes (`remember` + `edit_memory`), one read (`recall`), one mutation (`update_memory`), and one cross-table search (`semantic_search`).
-
-| Tool | Signature | Purpose |
-|------|-----------|---------|
-| `remember` | `({ kind, title, body, tags?, paths? })` | Store a long-term entry. `kind` is `note \| bug-fix \| gotcha \| decision \| investigation` (written to `memory_findings`) **or** `revisit` (written to `memory_revisits`). `revisit` is for ideas you discussed but deferred — they default to `status: open` so they show up in `recall({ kind: 'revisit', status: 'open' })`. |
-| `recall` | `({ kind, query?, k?, selectedIds?, tagsAny?, status? })` | Vector search across stored entries. **`kind` is required** — use `findings` to search all long-term memories, `revisit` for parked discussions, or a specific finding kind to narrow the findings table. Omit `query` to list everything matching the filters. `selectedIds` is an internal approval-hook filter used after the Telescope picker. |
-| `update_memory` | `({ id, status, resolution? })` | Mutate a **revisit's** `status` (`resolved` or `dismissed`) and optionally attach a resolution note. The original `body` is preserved. Findings have no status concept; use `edit_memory` to amend them. |
-| `semantic_search` | `({ query, k?, scope?, memoryKind?, selectedIds?, pathGlob? })` | Conceptual vector search across code and/or memory. `scope` is `code` (default), `memory`, or `both`. For memory scope, use `memoryKind: 'findings'` to search all long-term memories, `memoryKind: 'revisit'` for parked discussions, or a specific finding kind to narrow the findings table. The tool is **always exposed** so memory-only semantic search still works even if the repo is not indexed for code search; when code indexing is absent, the code side simply returns no hits. `selectedIds` is an internal approval-hook filter used after the Telescope picker. |
-| `edit_memory` | `({ id, title?, body?, tags?, paths? })` | Edit an existing entry's user-visible fields. Re-embeds the vector when `title` or `body` changes. Works on entries in either table. |
-### Agent prompt (built-in)
-
-The agent is told to:
-- Call `remember` after fixing a non-obvious bug, hitting a gotcha, or making a design decision the next session would want to know.
-- Use `kind: 'revisit'` when you discuss an idea worth pursuing but choose not to do it now — with a clear title, what you considered, and why you deferred. Use one of the **finding** kinds (`note` / `bug-fix` / `gotcha` / `decision` / `investigation`) for things discovered while working that the next session will want to know.
-- Call `recall` at the start of work in a familiar area, or whenever it suspects past context exists.
-- Call `update_memory` when a revisit is resolved or dismissed, instead of creating a duplicate entry.
-
-### `settings.toml` knobs
-
-```toml
-[ai.agent.memory]
-enabled = true                    # master switch for the whole memory layer
-indexCodeOnSave = false           # background watcher reindexes files on save (opted-in repos only)
-autoSurfaceOnStart = false        # quietly seed recall() / open-revisit list into the session preamble
-gitignoreMemory = true            # whether .kra-memory/ should be added to gitignore by default
-# Tuning knobs (defaults are good for most repos):
-# chunkLines = 80
-# chunkOverlap = 5
-# includeExtensions = [".ts", ".js", ".py", ".go", ".rs", ".md"]
-# excludeGlobs = ["node_modules/**", "dest/**", "coverage/**", ".kra-memory/**"]
-```
-
-### Codebase indexing (Phase 2)
-
-Code search is **multi-codebase and opt-in per launch**. A central registry at `~/.kra-memory/registry.json` keyed by `git remote get-url origin` (with a top-level path fallback for non-git repos) tracks every workspace you've indexed: alias, root path, last-indexed commit, last-index timestamp, chunk count. Identity is the origin URL, not the directory, so reindex status survives renames and re-clones.
-
-**On every `kra ai agent` launch:** a Yes/No modal appears in Neovim. Pick **No** and the session starts immediately **without refreshing the code index**. `semantic_search` still stays available for memory scope, but code hits will be empty until the repo is indexed. Pick **Yes** and the agent brings the index up to date before the prompt:
-
-- First time on this repo → full `reindexAll`.
-- Already indexed → catch-up only. The change set is the union of `git diff --name-only $lastIndexedCommit HEAD` (committed since last index, including pulls and branch switches) and `git status --porcelain` (uncommitted edits, *including* edits made outside the agent between sessions). Deletions are removed from the index; everything else is reindexed. Above 500 changed files a secondary prompt offers a full reindex instead.
-- Non-git workspaces → mtime > `lastIndexedAt` fallback.
-
-Progress streams live to a Neovim floating tab — one line per file as it's indexed. The modal stays open until you dismiss it (`q` / `<Esc>`). After indexing finishes, the registry is updated with the new `lastIndexedCommit` / `lastIndexedAt` / `chunksCount`.
-
-Other ways to keep the index fresh once a repo is opted in:
-
-1. **One-off / on demand:** `kra ai index` runs a full reindex of the cwd from the terminal. Safe to re-run — chunks whose content hasn't changed are skipped (~30–150 ms per file, content-hashed). Updates the registry baseline so the next agent launch can do a tight catch-up.
-2. **On save (background):** flip `indexCodeOnSave = true` and a `chokidar` watcher reindexes files in the background as you edit (debounced 500 ms per path; deletes remove the file's chunks). The watcher only fires for repos that are already in the registry — it will not silently recreate `code_chunks` in opted-out repos.
-
-To manage indexes across all your repos from one place — view details, drop a repo's `code_chunks` table, reset its baseline, or rename its alias — use `kra ai memory` → *Indexed codebases*.
-
-Under the hood:
-- File enumeration uses `git ls-files -co --exclude-standard` so your `.gitignore` is honoured for free.
-- Files are split into fixed-line windows of `chunkLines` (default 80) with `chunkOverlap` (default 5) lines of overlap; chunk IDs encode `path:startLine-endLine:hash(content)` so unchanged windows survive reindex passes.
-- Embeddings are batched 32 chunks at a time (~60 ms/batch on M-series) and stored in `<repo>/.kra-memory/lance/code_chunks.lance/`.
-
-### Implementation notes
-
-- LanceDB's `createTable` seeds the table with the first row; `getOrCreateMemoryTable` (used by both `getFindingsTable` and `getRevisitsTable`) returns a `{ table, justCreated }` tuple so callers don't accidentally insert the seed twice. The legacy single `memory` table is dropped once per process on first connect after upgrade.
-- `update_memory` passes raw values (not SQL strings) via LanceDB's `values` parameter — `valuesSql` is the SQL-expression sibling and easy to confuse.
-- `<repo>/.kra-memory/meta.sqlite` is reserved for housekeeping (settings, last-used) but currently unused.
-
-> `kra-memory` is auto-loaded for **both** providers — it lives alongside `kra-file-context` and `kra-session-complete` in the always-on MCP block in `agentConversation.ts`, so neither BYOK nor Copilot needs anything in `settings.toml` to enable it. The same code path serves both providers; nothing in `shared/memory/` knows or cares which backend is talking to it.
-
----
-
-
-## 📜 Session Diff History & Per-File Revert
-
-Every write the agent performs (`edit_lines`, `create_file`, plus any path mutated as a side-effect of `bash`) is recorded in a session-scoped diff history backed by the unified `agentHistory` module. Press `<leader>s` in the chat buffer to open a Telescope picker showing:
-
-- **One entry per write** — the diff that was actually applied at that point in the session
-- **One `ORIG` entry per unique file** — the diff between the file's pre-session baseline and its current state
-
-Select any entry to open the diff in a new tab. The `ORIG` entries make it easy to **revert a single file** to how it was before the session started, even after many edits.
-
-History is committed only after a tool actually succeeds — the diff editor queues the entry on approve and the tool-hook plumbing finalizes (or drops) it via `tool.execution_complete`. Denied or failed edits never show up.
-
----
-
-## 🎓 Skills (Copilot only)
-
-The Copilot provider loads skills from `<repo>/skills/` via the SDK's `skillDirectories` option. Skills are reusable instruction sets / prompt fragments that the agent can pull in on demand (file format and discovery follow the Copilot SDK skill convention).
-
-Drop a skill folder into `skills/` and it becomes available the next time you start `kra ai agent` and pick the Copilot provider. The directory does not exist by default — create it when you have skills to register.
-
-> BYOK has no skill abstraction; embed any persistent instructions directly into your role prompt or a per-project `system` message.
-
----
-
-## 🔌 MCP Server Configuration
-
-MCP servers extend the agent with custom tools. Configure them in `settings.toml` — both providers read from the same block:
-
-```toml
-[ai.agent.mcpServers.filesystem]
-active = true
-type = "local"
-command = "npx"
-args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
-tools = ["*"]
-
-[ai.agent.mcpServers.github]
-active = true
-type = "http"
-url = "https://api.githubcopilot.com/mcp/"
-tools = ["*"]
-
-[ai.agent.mcpServers.github.headers]
-Authorization = "Bearer YOUR_GITHUB_TOKEN"
-```
-
-See `settings.toml.example` for a full reference (including the `[lsp.*]` blocks that drive `lsp_query`). Only servers with `active = true` are injected into the session.
-
-> ⚠ Remote (`http`/`sse`) MCP servers are honoured by the Copilot provider but **ignored** by BYOK — BYOK's MCP client pool only spawns local stdio servers.
-
----
-
-## 📊 Quota Monitoring (Copilot only)
-
-### Check Quota On Demand
-
-```bash
-kra ai quota
-```
-
-Shows two sections:
-
-**Monthly (live from GitHub API)**
-```
-Copilot Quota — Monthly
-  Resets on: June 1, 2026
-
-  Premium interactions:
-    ████████████░░░░░░░░░░░░░░░░░░ 42.3% remaining
-    173 / 300 used  (127 left)
-```
-
-**Weekly/Session (cached from last session)**
-```
-Copilot Quota — Usage Limits (last session)
-
-  Weekly:
-    ██████████████████████░░░░░░░░ 73.5% remaining
-    Resets: Jun 7, 2025  (12m ago)
-```
-
-> Weekly and session limits come from API response headers — they're only observable during active sessions. The cache is updated automatically after each agent turn.
-
-### In-Session Warnings
-
-The agent warns in the terminal (not Neovim) when weekly or session quota drops to **50%**, **25%**, and **10%**:
-
-```
-⚠ You've used over 75% of your weekly usage limit. Resets: Sat, Jun 7, 2026, 12:00 AM
-```
-
-Yellow at 50%/25%, red at 10%.
-
-> BYOK does not surface quota — bring your own provider's billing dashboard.
-
+## 📚 Detailed Documentation
+
+`AGENT.md` is now the high-level overview. The implementation-heavy sections were split into focused docs so each topic stays easier to navigate and maintain.
+
+| Topic | Doc |
+|---|---|
+| Documentation index | [`docs/agent/README.md`](docs/agent/README.md) |
+| Providers, model catalog, backend add/remove lifecycle | [`docs/agent/providers.md`](docs/agent/providers.md) |
+| Turn workflow, keymaps, tool-approval UX, diff review | [`docs/agent/workflow-and-keymaps.md`](docs/agent/workflow-and-keymaps.md) |
+| File-context tools, BYOK bash/web tools, MCP config | [`docs/agent/tools-and-mcp.md`](docs/agent/tools-and-mcp.md) |
+| Persistent memory, memory tools, indexing behavior | [`docs/agent/memory-and-indexing.md`](docs/agent/memory-and-indexing.md) |
+| Copilot-only skills and quota operations | [`docs/agent/copilot-operations.md`](docs/agent/copilot-operations.md) |
+
+If you want to start coding quickly, open `docs/agent/README.md` first, then jump to the topical doc for the subsystem you are touching.

--- a/__tests__/AI/AIAgent/agentPromptActionDispatch.test.ts
+++ b/__tests__/AI/AIAgent/agentPromptActionDispatch.test.ts
@@ -1,0 +1,135 @@
+import { dispatchPromptAction } from '@/AI/AIAgent/shared/main/agentPromptActionDispatch';
+import type { AgentConversationState } from '@/AI/AIAgent/shared/types/agentTypes';
+import * as conversation from '@/AI/shared/conversation';
+import * as sessionEvents from '@/AI/AIAgent/shared/utils/agentSessionEvents';
+import * as memoryActions from '@/AI/AIAgent/shared/main/agentMemoryActions';
+
+jest.mock('@/AI/shared/conversation', () => ({
+    handleAddFileContext: jest.fn(),
+    showFileContextsPopup: jest.fn(),
+    handleRemoveFileContext: jest.fn(),
+    clearAllFileContexts: jest.fn(),
+}));
+
+jest.mock('@/AI/AIAgent/shared/utils/agentSessionEvents', () => ({
+    applyProposal: jest.fn(),
+    openChangedProposalFile: jest.fn(),
+    rejectCurrentProposal: jest.fn(),
+    showProposalReview: jest.fn(),
+    updateAgentUi: jest.fn(),
+}));
+
+jest.mock('@/AI/AIAgent/shared/main/agentMemoryActions', () => ({
+    handleAddMemory: jest.fn(),
+    handleDeleteMemory: jest.fn(),
+    handleEditMemory: jest.fn(),
+    handleSetMemoryStatus: jest.fn(),
+    openMemoryBrowser: jest.fn(),
+}));
+
+function typed<T>(value: unknown): T {
+    return value as T;
+}
+
+function makeState(): AgentConversationState {
+    const nvimClient = typed<AgentConversationState['nvim']>({});
+    const session = typed<AgentConversationState['session']>({
+        abort: jest.fn(async () => undefined),
+        executeTool: jest.fn(async () => 'tool ok'),
+    });
+
+    const state: AgentConversationState = {
+        nvim: nvimClient,
+        chatFile: '/tmp/chat.md',
+        model: 'test-model',
+        client: typed<AgentConversationState['client']>({}),
+        session,
+        cwd: '/tmp',
+        history: typed<AgentConversationState['history']>({}),
+        isStreaming: true,
+        approvalMode: 'strict',
+        allowedToolFamilies: new Set<string>(['bash']),
+    };
+
+    return state;
+}
+
+describe('dispatchPromptAction', () => {
+    const mockedUpdateUi = jest.mocked(sessionEvents.updateAgentUi);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('stops active streaming turns and notifies the UI', async () => {
+        const state = makeState();
+
+        await dispatchPromptAction(state, 'stop_stream', []);
+
+        expect(state.session.abort).toHaveBeenCalledTimes(1);
+        expect(state.isStreaming).toBe(false);
+        expect(mockedUpdateUi).toHaveBeenCalledWith(state.nvim, 'stop_turn', ['Stopped current agent turn']);
+    });
+
+    it('toggles approval mode and clears remembered tool approvals', async () => {
+        const state = makeState();
+
+        await dispatchPromptAction(state, 'toggle_yolo_mode', []);
+
+        expect(state.approvalMode).toBe('yolo');
+        expect(state.allowedToolFamilies.size).toBe(0);
+        expect(mockedUpdateUi).toHaveBeenCalledWith(
+            state.nvim,
+            'show_error',
+            ['Approval mode', 'YOLO mode enabled.']
+        );
+    });
+
+    it('normalizes unsupported memory browser view values to all', async () => {
+        const state = makeState();
+
+        await dispatchPromptAction(state, 'browse_memory', [undefined, { view: 'unsupported-view' }]);
+
+        expect(memoryActions.openMemoryBrowser).toHaveBeenCalledWith(state.nvim, 'all');
+    });
+
+    it('reports invalid execute_tool JSON payloads to the UI', async () => {
+        const state = makeState();
+
+        await dispatchPromptAction(state, 'execute_tool', [undefined, { title: 'kra:bash', args_json: '{bad json' }]);
+
+        expect(mockedUpdateUi).toHaveBeenCalledWith(
+            state.nvim,
+            'show_tool_execution_result',
+            ['', expect.stringContaining('Invalid JSON'), 'kra:bash']
+        );
+        expect(state.session.executeTool).not.toHaveBeenCalled();
+    });
+
+    it('runs execute_tool and returns result text when tool execution succeeds', async () => {
+        const state = makeState();
+
+        await dispatchPromptAction(state, 'execute_tool', [undefined, { title: 'kra:bash', args_json: '{"cmd":"pwd"}' }]);
+
+        expect(state.session.executeTool).toHaveBeenCalledWith('kra:bash', { cmd: 'pwd' });
+        expect(mockedUpdateUi).toHaveBeenCalledWith(
+            state.nvim,
+            'show_tool_execution_result',
+            ['tool ok', '', 'kra:bash']
+        );
+    });
+
+    it('routes file context actions through shared conversation handlers', async () => {
+        const state = makeState();
+
+        await dispatchPromptAction(state, 'add_file_context', []);
+        await dispatchPromptAction(state, 'show_contexts_popup', []);
+        await dispatchPromptAction(state, 'remove_file_context', []);
+        await dispatchPromptAction(state, 'clear_contexts', []);
+
+        expect(conversation.handleAddFileContext).toHaveBeenCalledWith(state.nvim, state.chatFile, { agentMode: true });
+        expect(conversation.showFileContextsPopup).toHaveBeenCalledWith(state.nvim);
+        expect(conversation.handleRemoveFileContext).toHaveBeenCalledWith(state.nvim);
+        expect(conversation.clearAllFileContexts).toHaveBeenCalledWith(state.nvim);
+    });
+});

--- a/__tests__/AI/AIAgent/executableToolBridge.test.ts
+++ b/__tests__/AI/AIAgent/executableToolBridge.test.ts
@@ -1,0 +1,86 @@
+import {
+    createExecutableToolBridge,
+    disconnectPool,
+    executeToolFromPool,
+    listExecutableToolsFromPool,
+} from '@/AI/AIAgent/mcp/executableToolBridge';
+import type { McpClientPool, RegisteredTool } from '@/AI/AIAgent/providers/byok/mcpClientPool';
+
+
+function makeRegisteredTool(
+    server: string,
+    originalName: string,
+    callTool?: unknown
+): RegisteredTool {
+    return {
+        server,
+        originalName,
+        namespacedName: `${server}__${originalName}`,
+        description: `${server}:${originalName}`,
+        inputSchema: {},
+        client: {
+            callTool: (callTool ?? jest.fn(async () => ({ content: [] }))) as RegisteredTool['client']['callTool'],
+        } as unknown as RegisteredTool['client'],
+    };
+}
+
+function makePool(tools: RegisteredTool[]): McpClientPool {
+    return {
+        tools: new Map(tools.map((tool) => [`${tool.server}:${tool.originalName}`, tool])),
+        openaiTools: [],
+        disconnect: jest.fn(async () => undefined),
+    };
+}
+
+describe('executableToolBridge', () => {
+    it('lists tools in executable UI format', () => {
+        const pool = makePool([makeRegisteredTool('kra-bash', 'bash')]);
+
+        expect(listExecutableToolsFromPool(pool)).toEqual([
+            { title: 'kra-bash:bash', server: 'kra-bash', name: 'bash' },
+        ]);
+    });
+
+    it('executes the selected tool and joins text parts only', async () => {
+        const callTool = jest.fn(async () => ({
+            content: [
+                { type: 'text', text: 'first line' },
+                { type: 'image', data: 'ignored' },
+                { type: 'text', text: 'second line' },
+            ],
+        }));
+        const pool = makePool([makeRegisteredTool('kra-file', 'search', callTool)]);
+
+        await expect(executeToolFromPool(pool, 'kra-file:search', { query: 'abc' })).resolves.toBe('first line\nsecond line');
+        expect(callTool).toHaveBeenCalledWith({ name: 'search', arguments: { query: 'abc' } });
+    });
+
+    it('returns clear errors for unknown or unavailable tools', async () => {
+        await expect(executeToolFromPool(undefined, 'kra-x:y', {}, { uninitializedError: 'Not ready' }))
+            .rejects.toThrow('Not ready');
+
+        const pool = makePool([]);
+
+        await expect(executeToolFromPool(pool, 'kra-x:y', {})).rejects.toThrow('Unknown tool: kra-x:y');
+    });
+
+    it('bridge delegates listing/execution and disconnect helper supports swallow mode', async () => {
+        const callTool = jest.fn(async () => ({ content: [{ type: 'text', text: 'ok' }] }));
+        const pool = makePool([makeRegisteredTool('kra-memory', 'recall', callTool)]);
+
+        const bridge = createExecutableToolBridge(() => pool);
+        expect(bridge.listExecutableTools()).toEqual([
+            { title: 'kra-memory:recall', server: 'kra-memory', name: 'recall' },
+        ]);
+        await expect(bridge.executeTool('kra-memory:recall', {})).resolves.toBe('ok');
+
+        const throwingPool = {
+            tools: new Map(),
+            openaiTools: [],
+            disconnect: jest.fn(async () => { throw new Error('disconnect failed'); }),
+        } as unknown as McpClientPool;
+
+        await expect(disconnectPool(throwingPool, true)).resolves.toBeUndefined();
+        await expect(disconnectPool(throwingPool, false)).rejects.toThrow('disconnect failed');
+    });
+});

--- a/__tests__/AI/AIAgent/providerToolBridgeIntegration.test.ts
+++ b/__tests__/AI/AIAgent/providerToolBridgeIntegration.test.ts
@@ -1,0 +1,125 @@
+import type { AgentSessionOptions } from '@/AI/AIAgent/shared/types/agentTypes';
+import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
+import type { McpClientPool, RegisteredTool } from '@/AI/AIAgent/providers/byok/mcpClientPool';
+
+let originalSdkDisconnect = jest.fn(async () => undefined);
+let currentSdkSession = {
+    disconnect: originalSdkDisconnect,
+};
+const mockCopilotCreateSession = jest.fn(async () => currentSdkSession);
+
+jest.mock('@github/copilot-sdk', () => ({
+    CopilotClient: class {
+        public createSession = mockCopilotCreateSession;
+        public start = jest.fn(async () => undefined);
+        public stop = jest.fn(async () => undefined);
+        public forceStop = jest.fn(async () => undefined);
+        public getAuthStatus = jest.fn(async () => ({}));
+        public listModels = jest.fn(async () => []);
+    },
+}));
+
+const mockBuildMcpClientPool = jest.fn();
+
+jest.mock('@/AI/AIAgent/providers/byok/mcpClientPool', () => ({
+    buildMcpClientPool: (...args: unknown[]) => mockBuildMcpClientPool(...args),
+}));
+
+import { OpenAICompatibleSession } from '@/AI/AIAgent/providers/byok/byokSession';
+import { CopilotClientWrapper } from '@/AI/AIAgent/providers/copilot/copilotClient';
+
+function typed<T>(value: unknown): T {
+    return value as T;
+}
+
+function makeSessionOptions(): AgentSessionOptions {
+    return {
+        model: 'test-model',
+        workingDirectory: '/tmp/workspace',
+        mcpServers: {},
+        onPreToolUse: async () => ({}),
+        onPostToolUse: async () => undefined,
+    };
+}
+
+function makePoolWithSingleTool(server: string, name: string, textResult: string): McpClientPool {
+    const callTool = jest.fn(async () => ({ content: [{ type: 'text', text: textResult }] }));
+    const tool: RegisteredTool = {
+        server,
+        originalName: name,
+        namespacedName: `${server}__${name}`,
+        description: `${server}:${name}`,
+        inputSchema: {},
+        client: typed<RegisteredTool['client']>({ callTool }),
+    };
+
+    return {
+        tools: new Map([[`${server}:${name}`, tool]]),
+        openaiTools: [],
+        disconnect: jest.fn(async () => undefined),
+    };
+}
+
+describe('provider executable tool bridge integration', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        originalSdkDisconnect = jest.fn(async () => undefined);
+        currentSdkSession = {
+            disconnect: originalSdkDisconnect,
+        };
+    });
+
+    it('BYOK session exposes executable tools from MCP pool and executes by title', async () => {
+        const session = new OpenAICompatibleSession({
+            sessionOptions: makeSessionOptions(),
+            apiKey: 'test-key',
+            baseURL: 'https://example.test',
+        });
+        const pool = makePoolWithSingleTool('kra-bash', 'bash', 'pwd output');
+
+        typed<{ mcp: McpClientPool | undefined }>(session).mcp = pool;
+
+        expect(session.listExecutableTools()).toEqual([
+            { title: 'kra-bash:bash', server: 'kra-bash', name: 'bash' },
+        ]);
+        await expect(session.executeTool('kra-bash:bash', { command: 'pwd' })).resolves.toBe('pwd output');
+
+        await session.disconnect();
+        expect(pool.disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('Copilot wrapper wires kra-* side-pool tools for re-execution', async () => {
+        const sidePool = makePoolWithSingleTool('kra-memory', 'recall', 'memory result');
+        mockBuildMcpClientPool.mockResolvedValue(sidePool);
+
+        const wrapper = new CopilotClientWrapper({ useLoggedInUser: true });
+        const options: AgentSessionOptions = {
+            ...makeSessionOptions(),
+            mcpServers: {
+                'kra-memory': typed<MCPServerConfig>({ type: 'stdio', command: 'node', args: ['memory.js'] }),
+                'external-tool': typed<MCPServerConfig>({ type: 'stdio', command: 'node', args: ['ext.js'] }),
+            },
+        };
+
+        const session = await wrapper.createSession(options);
+
+        expect(mockBuildMcpClientPool).toHaveBeenCalledWith({
+            servers: {
+                'kra-memory': options.mcpServers['kra-memory'],
+            },
+            workingDirectory: '/tmp/workspace',
+        });
+        if (!session.listExecutableTools || !session.executeTool) {
+            throw new Error('Copilot session should expose executable tool bridge methods');
+        }
+
+        expect(session.listExecutableTools()).toEqual([
+            { title: 'kra-memory:recall', server: 'kra-memory', name: 'recall' },
+        ]);
+        await expect(session.executeTool('kra-memory:recall', { query: 'recent' })).resolves.toBe('memory result');
+
+        await session.disconnect();
+        expect(sidePool.disconnect).toHaveBeenCalledTimes(1);
+        expect(originalSdkDisconnect).toHaveBeenCalledTimes(1);
+    });
+});

--- a/__tests__/AI/AIAgent/stdioServer.test.ts
+++ b/__tests__/AI/AIAgent/stdioServer.test.ts
@@ -1,0 +1,145 @@
+import { EventEmitter } from 'events';
+import readline from 'readline';
+import { JsonRpcToolError, runStdioMcpServer } from '@/AI/AIAgent/mcp/stdioServer';
+
+jest.mock('readline', () => ({
+    __esModule: true,
+    default: {
+        createInterface: jest.fn(),
+    },
+}));
+
+type FakeReadline = EventEmitter & {
+    close: () => void;
+};
+
+function makeReadline(): FakeReadline {
+    const rl = new EventEmitter() as FakeReadline;
+    rl.close = (): void => {
+        rl.emit('close');
+    };
+
+    return rl;
+}
+
+function parseResponses(writeSpy: jest.SpyInstance): Array<Record<string, unknown>> {
+    return writeSpy.mock.calls
+        .map((call) => String((call as unknown[])[0] ?? ''))
+        .flatMap((chunk) => chunk.split('\n'))
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function flushAsyncWork(): Promise<void> {
+    await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('runStdioMcpServer', () => {
+    let writeSpy: jest.SpyInstance;
+    let exitSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        exitSpy = jest.spyOn(process, 'exit').mockImplementation(((() => undefined) as unknown) as never);
+    });
+
+    afterEach(() => {
+        writeSpy.mockRestore();
+        exitSpy.mockRestore();
+    });
+
+    it('responds to initialize and tools/list with advertised server capabilities', async () => {
+        const rl = makeReadline();
+        jest.mocked(readline.createInterface).mockReturnValue(rl as unknown as readline.Interface);
+
+        runStdioMcpServer({
+            serverName: 'test-server',
+            tools: [{ name: 'echo' }],
+            handleToolCall: async () => ({ ok: true }),
+        });
+
+        rl.emit('line', JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }));
+        rl.emit('line', JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
+        await flushAsyncWork();
+
+        const responses = parseResponses(writeSpy);
+        const init = responses.find((response) => response['id'] === 1);
+        const list = responses.find((response) => response['id'] === 2);
+
+        expect(init?.['result']).toMatchObject({
+            protocolVersion: '2024-11-05',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'test-server' },
+        });
+        expect((list?.['result'] as { tools: Array<{ name: string }> }).tools).toEqual([{ name: 'echo' }]);
+    });
+
+    it('maps unknown tools and JsonRpcToolError to expected JSON-RPC errors', async () => {
+        const rl = makeReadline();
+        jest.mocked(readline.createInterface).mockReturnValue(rl as unknown as readline.Interface);
+
+        runStdioMcpServer({
+            serverName: 'test-server',
+            tools: [{ name: 'echo' }],
+            handleToolCall: async () => {
+                throw new JsonRpcToolError(-32602, 'Invalid parameters');
+            },
+        });
+
+        rl.emit('line', JSON.stringify({ jsonrpc: '2.0', id: 10, method: 'tools/call', params: { name: 'missing' } }));
+        rl.emit('line', JSON.stringify({ jsonrpc: '2.0', id: 11, method: 'tools/call', params: { name: 'echo' } }));
+        await flushAsyncWork();
+
+        const responses = parseResponses(writeSpy);
+        const unknownTool = responses.find((response) => response['id'] === 10);
+        const invalidParams = responses.find((response) => response['id'] === 11);
+
+        expect((unknownTool?.['error'] as { code: number }).code).toBe(-32601);
+        expect((invalidParams?.['error'] as { code: number; message: string })).toEqual({
+            code: -32602,
+            message: 'Invalid parameters',
+        });
+    });
+
+    it('honors parse-error mode and internal error result mapping', async () => {
+        const rl = makeReadline();
+        jest.mocked(readline.createInterface).mockReturnValue(rl as unknown as readline.Interface);
+
+        runStdioMcpServer({
+            serverName: 'test-server',
+            tools: [{ name: 'echo' }],
+            respondParseError: false,
+            handleToolCall: async () => {
+                throw new Error('handler boom');
+            },
+            onInternalError: () => ({ kind: 'result', result: { recovered: true } }),
+        });
+
+        rl.emit('line', '{not-json');
+        rl.emit('line', JSON.stringify({ jsonrpc: '2.0', id: 20, method: 'tools/call', params: { name: 'echo' } }));
+        await flushAsyncWork();
+
+        const responses = parseResponses(writeSpy);
+
+        expect(responses.some((response) => (response['error'] as { code?: number } | undefined)?.code === -32700)).toBe(false);
+        expect(responses.find((response) => response['id'] === 20)?.['result']).toEqual({ recovered: true });
+    });
+
+    it('exits when stdin closes after pending work is drained', async () => {
+        const rl = makeReadline();
+        jest.mocked(readline.createInterface).mockReturnValue(rl as unknown as readline.Interface);
+
+        runStdioMcpServer({
+            serverName: 'test-server',
+            tools: [{ name: 'echo' }],
+            handleToolCall: async () => ({ ok: true }),
+        });
+
+        rl.close();
+        await flushAsyncWork();
+
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+});

--- a/__tests__/AI/shared/conversationBoundaryContract.test.ts
+++ b/__tests__/AI/shared/conversationBoundaryContract.test.ts
@@ -1,0 +1,31 @@
+import * as conversation from '@/AI/shared/conversation';
+
+describe('shared conversation boundary contract', () => {
+    it('exposes AI Neovim helper capabilities used by chat and agent flows', () => {
+        expect(typeof conversation.generateSocketPath).toBe('function');
+        expect(typeof conversation.waitForSocket).toBe('function');
+        expect(typeof conversation.addNeovimFunctions).toBe('function');
+        expect(typeof conversation.addCommands).toBe('function');
+        expect(typeof conversation.setupKeyBindings).toBe('function');
+        expect(typeof conversation.updateNvimAndGoToLastLine).toBe('function');
+    });
+
+    it('exposes file-context lifecycle APIs through one stable import path', () => {
+        expect(Array.isArray(conversation.fileContexts)).toBe(true);
+        expect(typeof conversation.handleAddFileContext).toBe('function');
+        expect(typeof conversation.showFileContextsPopup).toBe('function');
+        expect(typeof conversation.handleRemoveFileContext).toBe('function');
+        expect(typeof conversation.clearAllFileContexts).toBe('function');
+        expect(typeof conversation.clearFileContexts).toBe('function');
+        expect(typeof conversation.getFileContextsForPrompt).toBe('function');
+        expect(typeof conversation.getFileExtension).toBe('function');
+    });
+
+    it('keeps shared file-context state accessible and resettable via boundary', () => {
+        conversation.fileContexts.push({ filePath: '/tmp/a.ts', isPartial: false, summary: 'Full file: a.ts' });
+        expect(conversation.fileContexts).toHaveLength(1);
+
+        conversation.clearFileContexts();
+        expect(conversation.fileContexts).toHaveLength(0);
+    });
+});

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -1,0 +1,32 @@
+# Agent Mode Docs
+
+This folder contains the technical docs for `kra ai agent`. `AGENT.md` at the repo root is now the quick overview; use these sub-docs for implementation-level detail.
+
+## Start here
+
+```bash
+kra ai agent
+```
+
+1. Pick provider (`copilot` or `byok`)
+2. Pick model (and reasoning effort for supported Copilot models)
+3. Work in Neovim chat buffer, review diffs, approve/reject tool calls
+
+## Doc map
+
+| Doc | What it covers |
+|---|---|
+| [`providers.md`](./providers.md) | Provider architecture, Copilot/BYOK behavior, backend add/remove lifecycle, model catalog |
+| [`workflow-and-keymaps.md`](./workflow-and-keymaps.md) | Turn lifecycle, keymaps, tool approval UX, diff editor behavior, session diff history |
+| [`tools-and-mcp.md`](./tools-and-mcp.md) | File-context tools, bash/web tools, MCP configuration and provider differences |
+| [`memory-and-indexing.md`](./memory-and-indexing.md) | `kra-memory` store, tools, picker UX, indexing behavior and settings |
+| [`copilot-operations.md`](./copilot-operations.md) | Copilot-only skills and quota monitoring |
+
+## Contributor orientation
+
+If you are modifying the agent stack, these are the highest-signal implementation areas:
+
+- Provider adapters: `src/AI/AIAgent/providers/*`
+- Shared provider abstractions: `src/AI/AIAgent/mcp/executableToolBridge.ts`, `src/AI/AIAgent/mcp/stdioServer.ts`
+- Shared conversation boundary: `src/AI/shared/conversation/index.ts`
+- Prompt/action orchestration: `src/AI/AIAgent/shared/main/*`

--- a/docs/agent/copilot-operations.md
+++ b/docs/agent/copilot-operations.md
@@ -1,0 +1,34 @@
+# Copilot-Only Operations
+
+## Skills
+
+Copilot provider loads skills from `<repo>/skills/` via SDK `skillDirectories`.
+
+- Add a folder under `skills/` to register a skill
+- Skills are available on next `kra ai agent` Copilot session
+- BYOK has no equivalent skill abstraction
+
+## Quota monitoring
+
+### On-demand
+
+```bash
+kra ai quota
+```
+
+Shows:
+
+- Monthly usage (live via GitHub API)
+- Weekly/session usage (cached from last session headers)
+
+### In-session warnings
+
+Terminal warnings are emitted when remaining weekly/session quota crosses thresholds:
+
+- 50%
+- 25%
+- 10%
+
+Weekly/session limits come from Copilot response headers and are only refreshed during active sessions.
+
+BYOK does not expose quota telemetry through this flow.

--- a/docs/agent/memory-and-indexing.md
+++ b/docs/agent/memory-and-indexing.md
@@ -1,0 +1,81 @@
+# Persistent Memory and Indexing (`kra-memory`)
+
+`kra-memory` is a local vector memory layer used by the agent to persist findings and revisits across sessions.
+
+It is auto-loaded for both providers together with `kra-file-context` and `kra-session-complete`.
+
+## Storage layout
+
+- `<repo>/.kra-memory/lance/memory_findings.lance/`
+- `<repo>/.kra-memory/lance/memory_revisits.lance/`
+
+Findings store: `note | bug-fix | gotcha | decision | investigation`
+
+Revisits store: deferred items with status (`open | resolved | dismissed`)
+
+## Embeddings
+
+- `fastembed` + BGE-small int8
+- Offline, no external model/API required
+
+## Memory picker/editor (`<leader>m`)
+
+Within agent chat buffer:
+
+- Browse all/findings/revisits
+- Add/edit/delete entries
+- Resolve/dismiss revisits
+- Open and edit entries in markdown scratch buffer
+
+Agent memory reads (`recall` / memory-scoped `semantic_search`) are approval-intercepted, and only selected IDs are returned.
+
+CLI alternative for cross-repo memory management: `kra ai memory`.
+
+## Exposed MCP tools
+
+| Tool | Purpose |
+|---|---|
+| `remember` | Create findings/revisit entries |
+| `recall` | Query/list memories (kind required) |
+| `update_memory` | Resolve/dismiss revisits |
+| `semantic_search` | Conceptual search across code and/or memory |
+| `edit_memory` | Update title/body/tags/paths |
+
+## Agent memory conventions
+
+- Write `bug-fix`/`gotcha`/`decision` when learnings are reusable
+- Use `revisit` for deferred ideas
+- Close revisits via `update_memory` instead of duplicating entries
+
+## Settings
+
+```toml
+[ai.agent.memory]
+enabled = true
+indexCodeOnSave = false
+autoSurfaceOnStart = false
+gitignoreMemory = true
+# chunkLines = 80
+# chunkOverlap = 5
+```
+
+## Code indexing model
+
+Code semantic search is opt-in per launch and tracked in a central registry:
+
+- Registry: `~/.kra-memory/registry.json`
+- Identity: repo remote URL (path fallback for non-git)
+- First index: full reindex
+- Subsequent index: catch-up (committed + uncommitted changes)
+
+Additional indexing flows:
+
+1. `kra ai index` (manual full reindex)
+2. `indexCodeOnSave = true` (background watcher)
+
+Index implementation highlights:
+
+- File discovery via `git ls-files -co --exclude-standard`
+- Chunking by fixed line windows + overlap
+- Content-hash chunk IDs to avoid re-embedding unchanged chunks
+- Stored in `<repo>/.kra-memory/lance/code_chunks.lance/`

--- a/docs/agent/providers.md
+++ b/docs/agent/providers.md
@@ -1,0 +1,93 @@
+# Providers
+
+`kra ai agent` supports two top-level provider backends behind one UX:
+
+| Provider | Backend | Auth | Built-in tools | Extra MCP servers added by Kra |
+|---|---|---|---|---|
+| `copilot` | `@github/copilot-sdk` | Logged-in Copilot user or `GITHUB_TOKEN` | Yes (SDK tools) | `kra-file-context`, `session-complete`, `kra-memory` |
+| `byok` | OpenAI-compatible Chat Completions (`openai`) | Provider API key | No | `kra-file-context`, `session-complete`, `kra-memory`, `kra-bash`, `kra-web` |
+
+## Copilot provider
+
+Wraps `@github/copilot-sdk` behind the provider-neutral session/client path.
+
+- Auth: SDK/device-flow, or token from settings/env
+- Models: fetched live at session start; entries can include disabled/billing metadata
+- Reasoning effort: optional second picker when model supports it (`low`, `medium`, `high`, `xhigh`)
+- Tools: SDK editor tools are excluded so edits route through line-precise file-context tools
+- Skills and quota: see [`copilot-operations.md`](./copilot-operations.md)
+
+## BYOK provider
+
+BYOK speaks OpenAI Chat Completions-compatible APIs.
+
+### Supported BYOK sub-providers
+
+| Sub-provider | Base URL | API key source |
+|---|---|---|
+| `open-ai` | `https://api.openai.com/v1` | `OPENAI_API_KEY` |
+| `deep-seek` | `https://api.deepseek.com/v1` | `keys.getDeepSeekKey()` |
+| `deep-infra` | `https://api.deepinfra.com/v1/openai` | `keys.getDeepInfraKey()` |
+| `open-router` | `https://openrouter.ai/api/v1` | `keys.getOpenRouterKey()` |
+| `gemini` | `https://generativelanguage.googleapis.com/v1beta/openai/` | `keys.getGeminiKey()` |
+| `mistral` | `https://api.mistral.ai/v1` | `keys.getMistralKey()` |
+
+### BYOK turn mechanics
+
+- One session = one OpenAI client + one MCP client pool
+- Streaming loop: model emits text/tool-calls, tool results are fed back as `tool` messages until no more tool calls
+- Reasoning deltas are surfaced to the same reasoning panel used by Copilot
+- Tool denials are returned as tool results so model can react
+- A synthetic turn reminder is injected so housekeeping behavior matches Copilot expectations
+
+### BYOK context-window compaction
+
+BYOK uses summarization compaction when:
+
+1. Provider returns context-length style errors, or
+2. Estimated tokens exceed the model context window threshold
+
+Compaction keeps system + recent messages verbatim, summarizes older history, then retries.
+
+### BYOK MCP pool constraints
+
+- BYOK spawns local stdio MCP servers
+- Tools are namespaced as `<server>__<tool>`
+- Honors per-server allow-lists and excluded tools
+- Remote (`http`/`sse`) MCP servers are ignored by BYOK
+
+## Provider backend lifecycle (remove/add)
+
+This is for top-level backends (`copilot`, `byok`, or a future adapter like Claude SDK), not only BYOK sub-provider data.
+
+Shared layers that normally remain unchanged:
+
+- `src/AI/AIAgent/mcp/executableToolBridge.ts`
+- `src/AI/AIAgent/mcp/stdioServer.ts`
+- `src/AI/shared/conversation/index.ts`
+
+### Remove a provider backend
+
+1. Remove provider selection and startup/session wiring branches
+2. Delete adapter implementation under `src/AI/AIAgent/providers/<provider>/`
+3. Remove provider-specific auth/model flow
+4. Remove provider-specific tests and docs
+
+### Add a provider backend (example: Claude SDK)
+
+1. Add adapter in `src/AI/AIAgent/providers/<new-provider>/`
+2. Implement the same session/tool contract used by existing providers
+3. Wire provider selection + session bootstrap branches
+4. Reuse shared executable-tool bridge + stdio transport
+5. Add integration tests for create-session/list-tools/execute-tool/disconnect
+
+If changing only a BYOK sub-provider (`open-ai`, `deep-seek`, etc.), most work stays in `src/AI/shared/data/providers.ts` and `src/AI/shared/data/modelCatalog.ts`.
+
+## Model catalog
+
+Shared live model catalog drives both agent provider/model pickers and chat provider pickers.
+
+- Fetches `/models` from providers at startup
+- Uses fallback metadata where providers omit context/pricing
+- Caches under `~/.config/kra-tmux/model-catalog/<provider>.json` (24h TTL)
+- Falls back to last cache snapshot on network failure

--- a/docs/agent/tools-and-mcp.md
+++ b/docs/agent/tools-and-mcp.md
@@ -1,0 +1,87 @@
+# Tools and MCP
+
+## File editing tools (`kra-file-context`)
+
+`kra-file-context` is the line-precise editing surface. Copilot stock editor tools are excluded so edits go through deterministic range operations.
+
+```txt
+excludedTools: ['str_replace_editor', 'write_file', 'read_file', 'edit', 'view', 'grep', 'glob']
+```
+
+### Core file-context tools
+
+| Tool | Purpose |
+|---|---|
+| `search(name_pattern?, content_pattern?)` | Unified file finder + grep (glob/regex or both) |
+| `get_outline(file_path)` | Structural outline (symbols + line numbers) |
+| `read_lines(...)` | Read exact line ranges (single or array form) |
+| `read_function(file_path, function_name)` | Return full function/class body by name |
+| `edit_lines(...)` | Replace exact ranges (single or array form) |
+| `create_file(file_path, content)` | Create new file |
+| `lsp_query(...)` | Hover/definition/references/etc via language server |
+
+### `search` options
+
+- `name_pattern` (glob)
+- `content_pattern` (ripgrep regex)
+- `path`, `type`, `case_insensitive`, `context`, `multiline`, `max_results`
+
+At least one of `name_pattern` or `content_pattern` is required.
+
+### `read_lines` gating
+
+- Hard cap: 500 lines/call
+- Soft gate: requests over 200 lines on structured files are bounced to `get_outline` first
+
+### Recommended workflow
+
+1. `search`
+2. `get_outline`
+3. `read_lines`
+4. `edit_lines`
+
+Prefer array-form reads/edits for multiple disjoint ranges.
+
+## BYOK-only extra tools
+
+Because BYOK has no SDK tools, Kra injects these MCP servers for BYOK sessions:
+
+### `kra-bash` (`bash`)
+
+- Executes command in session working dir
+- 120s timeout, 10MB stdout/stderr cap
+- Long output is head/tail truncated
+- Emits git status before/after for history tracking
+
+### `kra-web` (`web_fetch`, `web_search`)
+
+| Tool | Purpose | Limits |
+|---|---|---|
+| `web_fetch(url, max_length?)` | Fetch + text extraction | default 8k chars, cap 50k, 20s timeout |
+| `web_search(query, max_results?)` | DuckDuckGo HTML search summary | default 5 results, cap 15 |
+
+Copilot does not load `kra-bash`/`kra-web` (SDK already has equivalents).
+
+## MCP server configuration (`settings.toml`)
+
+```toml
+[ai.agent.mcpServers.filesystem]
+active = true
+type = "local"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
+tools = ["*"]
+
+[ai.agent.mcpServers.github]
+active = true
+type = "http"
+url = "https://api.githubcopilot.com/mcp/"
+tools = ["*"]
+```
+
+Only servers with `active = true` are injected.
+
+Provider behavior differences:
+
+- Copilot: supports local + remote MCP servers
+- BYOK: local stdio servers only (`http`/`sse` ignored)

--- a/docs/agent/workflow-and-keymaps.md
+++ b/docs/agent/workflow-and-keymaps.md
@@ -1,0 +1,88 @@
+# Workflow and Keymaps
+
+## Turn lifecycle (high-level)
+
+1. Start with `kra ai agent`
+2. Pick provider/model
+3. Submit prompt from Neovim chat buffer
+4. Agent streams text/reasoning, requests tools when needed
+5. Tool approval UI mediates tool calls (unless YOLO)
+6. Successful writes become session diffs for review/apply/reject
+
+## Chat buffer keymaps
+
+| Key | Action |
+|---|---|
+| `Enter` | Submit prompt |
+| `Ctrl+C` | Stop current turn |
+| `@` | Add file contexts |
+| `r` / `f` / `Ctrl+X` | Remove/show/clear file contexts |
+| `<leader>o` / `<leader>a` / `<leader>r` | Open/apply/reject proposal |
+| `<leader>y` / `<leader>P` | Toggle YOLO / reset remembered approvals |
+| `<leader>h` | Tool call history |
+| `<leader>s` | Session diff history |
+| `<leader>m` | Memory browser/editor |
+| `<Space>t` | Toggle tool/intent popups |
+| `<leader>?` | Show all keymaps (which-key) |
+
+## Tool call history (`<leader>h`)
+
+Opens searchable history of all tool calls in this session.
+
+- Preview shows tool result for selected call
+- `<CR>` opens side-by-side view: args JSON vs result
+- Read-only inspection surface (not a rerun UI)
+
+## Proposal review tab keymaps
+
+| Key | Action |
+|---|---|
+| `a` | Apply proposal |
+| `r` | Reject proposal |
+| `o` | Open changed file |
+| `R` | Refresh diff |
+| `q` | Close tab |
+
+## Tool approval behavior
+
+Auto-approved tools:
+
+- `report_intent`
+- `confirm_task_complete`
+
+All other tools require approval in strict mode.
+
+### Approval popup keys
+
+| Key | Action |
+|---|---|
+| `<CR>` | Run highlighted action |
+| `<Up>` / `<Down>` | Move highlight |
+| `a` | Approve once |
+| `s` | Allow tool family for session |
+| `y` | Enable YOLO mode |
+| `e` | Open diff editor (writes) |
+| `J` / `<leader>j` | Open raw tool args JSON |
+| `d` / `q` | Deny call |
+
+## Diff editor and user edits
+
+From approval popup on write tools, `e` opens a three-pane diff view: current / proposed / reference. For non-write tools, args inspection/editing stays in the JSON args editor path.
+
+| Key | Action |
+|---|---|
+| `<leader>a` | Approve (including user-edited proposal) |
+| `<leader>d` | Deny |
+| `<leader>j` | Edit tool args JSON |
+| `q` | Close and deny |
+
+When user edits proposed content before approval, Kra rebuilds the tool mutation as concrete `edit_lines` arguments and optionally notifies the model with post-edit context.
+
+## Session diff history (`<leader>s`)
+
+Tracks successful write effects for the current session.
+
+- One entry per successful write
+- One `ORIG` entry per file (pre-session baseline vs current)
+- Supports per-file revert to pre-session state
+- Denied/failed/intercepted writes are not committed to history

--- a/src/AI/AIAgent/mcp/executableToolBridge.ts
+++ b/src/AI/AIAgent/mcp/executableToolBridge.ts
@@ -1,0 +1,79 @@
+import type { AgentSession } from '@/AI/AIAgent/shared/types/agentTypes';
+import type { McpClientPool, RegisteredTool } from '@/AI/AIAgent/providers/byok/mcpClientPool';
+
+export interface ExecutableToolBridgeOptions {
+    uninitializedError?: string;
+}
+
+function listTools(pool: McpClientPool | undefined): RegisteredTool[] {
+    return pool ? Array.from(pool.tools.values()) : [];
+}
+
+function findToolByTitle(pool: McpClientPool, title: string): RegisteredTool | undefined {
+    return listTools(pool).find((tool) => `${tool.server}:${tool.originalName}` === title);
+}
+
+export function listExecutableToolsFromPool(
+    pool: McpClientPool | undefined
+): ReturnType<NonNullable<AgentSession['listExecutableTools']>> {
+    return listTools(pool).map((tool) => ({
+        title: `${tool.server}:${tool.originalName}`,
+        server: tool.server,
+        name: tool.originalName,
+    }));
+}
+
+export async function executeToolFromPool(
+    pool: McpClientPool | undefined,
+    title: string,
+    args: Record<string, unknown>,
+    options: ExecutableToolBridgeOptions = {}
+): Promise<string> {
+    if (!pool) {
+        throw new Error(options.uninitializedError ?? 'MCP pool not initialized');
+    }
+
+    const tool = findToolByTitle(pool, title);
+    if (!tool) {
+        throw new Error(`Unknown tool: ${title}`);
+    }
+
+    const result = await tool.client.callTool({ name: tool.originalName, arguments: args });
+    const contentArray = (result.content ?? []) as Array<{ type: string; text?: string }>;
+
+    return contentArray
+        .filter((part) => part.type === 'text' && typeof part.text === 'string')
+        .map((part) => part.text)
+        .join('\n');
+}
+
+export function createExecutableToolBridge(
+    getPool: () => McpClientPool | undefined,
+    options: ExecutableToolBridgeOptions = {}
+): {
+    listExecutableTools: NonNullable<AgentSession['listExecutableTools']>;
+    executeTool: NonNullable<AgentSession['executeTool']>;
+} {
+    return {
+        listExecutableTools: () => listExecutableToolsFromPool(getPool()),
+        executeTool: async (title, args) => executeToolFromPool(getPool(), title, args, options),
+    };
+}
+
+export async function disconnectPool(pool: McpClientPool | undefined, swallowErrors = false): Promise<void> {
+    if (!pool) {
+        return;
+    }
+
+    if (swallowErrors) {
+        try {
+            await pool.disconnect();
+        } catch {
+            return;
+        }
+
+        return;
+    }
+
+    await pool.disconnect();
+}

--- a/src/AI/AIAgent/mcp/index.ts
+++ b/src/AI/AIAgent/mcp/index.ts
@@ -1,0 +1,8 @@
+export {
+    createExecutableToolBridge,
+    disconnectPool,
+    executeToolFromPool,
+    listExecutableToolsFromPool,
+} from './executableToolBridge';
+export { buildByokExtraMcpServers, buildCoreMcpServers } from './serverConfig';
+export { JsonRpcToolError, runStdioMcpServer } from './stdioServer';

--- a/src/AI/AIAgent/mcp/serverConfig.ts
+++ b/src/AI/AIAgent/mcp/serverConfig.ts
@@ -1,0 +1,48 @@
+import path from 'path';
+import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
+import { getConfiguredMcpServers } from '@/AI/AIAgent/shared/utils/agentSettings';
+
+function bundledServerScript(scriptName: string): string {
+    return path.join(__dirname, '..', 'shared', 'utils', scriptName);
+}
+
+function stdioServer(scriptName: string, tools: string[]): MCPServerConfig {
+    return {
+        type: 'stdio',
+        command: process.execPath,
+        args: [bundledServerScript(scriptName)],
+        tools,
+    };
+}
+
+export async function buildCoreMcpServers(): Promise<Record<string, MCPServerConfig>> {
+    const configuredServers = await getConfiguredMcpServers();
+
+    return {
+        ...configuredServers,
+        'kra-session-complete': stdioServer('sessionCompleteMcpServer.js', ['confirm_task_complete']),
+        'kra-file-context': stdioServer('fileContextMcpServer.js', [
+            'get_outline',
+            'read_lines',
+            'read_function',
+            'edit_lines',
+            'create_file',
+            'search',
+            'lsp_query',
+        ]),
+        'kra-memory': stdioServer('memoryMcpServer.js', [
+            'remember',
+            'recall',
+            'update_memory',
+            'edit_memory',
+            'semantic_search',
+        ]),
+    };
+}
+
+export function buildByokExtraMcpServers(): Record<string, MCPServerConfig> {
+    return {
+        'kra-bash': stdioServer('bashMcpServer.js', ['bash']),
+        'kra-web': stdioServer('webMcpServer.js', ['web_fetch', 'web_search']),
+    };
+}

--- a/src/AI/AIAgent/mcp/stdioServer.ts
+++ b/src/AI/AIAgent/mcp/stdioServer.ts
@@ -1,0 +1,170 @@
+import readline from 'readline';
+
+export type JsonRpcId = number | string | null;
+
+interface JsonRpcRequest {
+    jsonrpc: '2.0';
+    id?: JsonRpcId;
+    method: string;
+    params?: unknown;
+}
+
+interface JsonRpcResponse {
+    jsonrpc: '2.0';
+    id: JsonRpcId;
+    result?: unknown;
+    error?: { code: number; message: string };
+}
+
+export interface StdioMcpTool {
+    name: string;
+}
+
+export interface RunStdioMcpServerOptions<TTool extends StdioMcpTool> {
+    serverName: string;
+    tools: readonly TTool[];
+    handleToolCall: (input: { toolName: string; params: unknown; id: JsonRpcId }) => Promise<unknown>;
+    allowPing?: boolean;
+    respondParseError?: boolean;
+    serverVersion?: string;
+    onInternalError?: (error: unknown) => { kind: 'error'; code: number; message: string } | { kind: 'result'; result: unknown };
+}
+
+export class JsonRpcToolError extends Error {
+    public readonly code: number;
+
+    public constructor(code: number, message: string) {
+        super(message);
+        this.code = code;
+    }
+}
+
+function send(response: JsonRpcResponse): void {
+    process.stdout.write(JSON.stringify(response) + '\n');
+}
+
+function sendResult(id: JsonRpcId, result: unknown): void {
+    send({ jsonrpc: '2.0', id, result });
+}
+
+function sendError(id: JsonRpcId, code: number, message: string): void {
+    send({ jsonrpc: '2.0', id, error: { code, message } });
+}
+
+export function runStdioMcpServer<TTool extends StdioMcpTool>(
+    options: RunStdioMcpServerOptions<TTool>
+): void {
+    const rl = readline.createInterface({ input: process.stdin, terminal: false });
+    const serverVersion = options.serverVersion ?? '1.0.0';
+    const respondParseError = options.respondParseError ?? true;
+
+    let pending = 0;
+    let inputClosed = false;
+
+    const hasTool = (toolName: string): boolean => options.tools.some((t) => t.name === toolName);
+
+    function maybeExit(): void {
+        if (inputClosed && pending === 0) {
+            process.exit(0);
+        }
+    }
+
+    rl.on('line', (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+
+        let request: JsonRpcRequest;
+        try {
+            request = JSON.parse(trimmed) as JsonRpcRequest;
+        } catch {
+            if (respondParseError) sendError(null, -32700, 'Parse error');
+
+            return;
+        }
+
+        const id = request.id ?? null;
+        pending++;
+
+        void (async (): Promise<void> => {
+            try {
+                switch (request.method) {
+                    case 'initialize':
+                        sendResult(id, {
+                            protocolVersion: '2024-11-05',
+                            capabilities: { tools: {} },
+                            serverInfo: { name: options.serverName, version: serverVersion },
+                        });
+
+                        return;
+
+                    case 'notifications/initialized':
+                        return;
+
+                    case 'tools/list':
+                        sendResult(id, { tools: options.tools });
+
+                        return;
+
+                    case 'tools/call': {
+                        const params = (request.params ?? {}) as { name?: unknown };
+                        const toolName = typeof params.name === 'string' ? params.name : '';
+
+                        if (!hasTool(toolName)) {
+                            sendError(id, -32601, `Unknown tool: ${toolName || '(none)'}`);
+
+                            return;
+                        }
+
+                        const result = await options.handleToolCall({ toolName, params: request.params ?? {}, id });
+                        sendResult(id, result);
+
+                        return;
+                    }
+
+                    case 'ping':
+                        if (options.allowPing) {
+                            sendResult(id, {});
+
+                            return;
+                        }
+                        sendError(id, -32601, `Method not found: ${request.method}`);
+
+                        return;
+
+                    default:
+                        sendError(id, -32601, `Method not found: ${request.method}`);
+
+                        return;
+                }
+            } catch (error) {
+                if (options.onInternalError) {
+                    const mapped = options.onInternalError(error);
+                    if (mapped.kind === 'error') {
+                        sendError(id, mapped.code, mapped.message);
+                    } else {
+                        sendResult(id, mapped.result);
+                    }
+
+                    return;
+                }
+
+                if (error instanceof JsonRpcToolError) {
+                    sendError(id, error.code, error.message);
+
+                    return;
+                }
+
+                const message = error instanceof Error ? error.message : String(error);
+                sendError(id, -32603, `Internal error: ${message}`);
+            } finally {
+                pending--;
+                maybeExit();
+            }
+        })();
+    });
+
+    rl.on('close', () => {
+        inputClosed = true;
+        maybeExit();
+    });
+}

--- a/src/AI/AIAgent/providers/byok/byokSession.ts
+++ b/src/AI/AIAgent/providers/byok/byokSession.ts
@@ -35,6 +35,7 @@ import {
 } from '@/AI/AIAgent/shared/types/agentTypes';
 import { TURN_REMINDER } from '@/AI/AIAgent/shared/main/turnReminder';
 import { buildMcpClientPool, type McpClientPool } from '@/AI/AIAgent/providers/byok/mcpClientPool';
+import { createExecutableToolBridge, disconnectPool } from '@/AI/AIAgent/mcp/executableToolBridge';
 import { compactMessages, estimateTokens, isContextLengthError } from '@/AI/AIAgent/providers/byok/byokCompactor';
 
 const DEFAULT_SYSTEM_PROMPT = [
@@ -69,6 +70,7 @@ export class OpenAICompatibleSession implements AgentSession {
     private listeners: { [K in keyof AgentSessionEventMap]?: EventListener<K>[] } = {};
     private abortController: AbortController | undefined;
     private compactedThisTurn = false;
+    private readonly executableToolBridge = createExecutableToolBridge(() => this.mcp);
 
     public constructor(opts: OpenAICompatibleSessionOptions) {
         this.opts = opts.sessionOptions;
@@ -236,16 +238,12 @@ export class OpenAICompatibleSession implements AgentSession {
 
         for await (const chunk of stream) {
             chunkCount += 1;
-            const delta = chunk.choices[0]?.delta;
+            const delta = chunk.choices[0].delta;
 
             if (debug) {
                 process.stderr.write(
-                    `[byok] chunk #${chunkCount} content=${JSON.stringify(delta.content ?? null)} tool_calls=${delta.tool_calls?.length ?? 0} finish=${chunk.choices[0]?.finish_reason ?? ''}\n`
+                    `[byok] chunk #${chunkCount} content=${JSON.stringify(delta.content ?? null)} tool_calls=${delta.tool_calls?.length ?? 0} finish=${chunk.choices[0].finish_reason ?? ''}\n`
                 );
-            }
-
-            if (!delta) {
-                continue;
             }
 
             const reasoning =
@@ -443,29 +441,14 @@ export class OpenAICompatibleSession implements AgentSession {
 
     public disconnect: AgentSession['disconnect'] = async () => {
         this.abortController?.abort();
-        await this.mcp?.disconnect();
+        await disconnectPool(this.mcp);
     };
 
     public listExecutableTools: NonNullable<AgentSession['listExecutableTools']> = () => {
-        if (!this.mcp) return [];
-        return Array.from(this.mcp.tools.values()).map((t) => ({
-            title: `${t.server}:${t.originalName}`,
-            server: t.server,
-            name: t.originalName,
-        }));
+        return this.executableToolBridge.listExecutableTools();
     };
 
     public executeTool: NonNullable<AgentSession['executeTool']> = async (title, args) => {
-        if (!this.mcp) throw new Error('MCP pool not initialized');
-        const tool = Array.from(this.mcp.tools.values()).find(
-            (t) => `${t.server}:${t.originalName}` === title
-        );
-        if (!tool) throw new Error(`Unknown tool: ${title}`);
-        const result = await tool.client.callTool({ name: tool.originalName, arguments: args });
-        const contentArray = (result.content ?? []) as Array<{ type: string; text?: string }>;
-        return contentArray
-            .filter((p) => p.type === 'text' && typeof p.text === 'string')
-            .map((p) => p.text)
-            .join('\n');
+        return this.executableToolBridge.executeTool(title, args);
     };
 }

--- a/src/AI/AIAgent/providers/byok/byokStartFlow.ts
+++ b/src/AI/AIAgent/providers/byok/byokStartFlow.ts
@@ -14,10 +14,9 @@
  * add a live fetcher branch in `src/AI/shared/data/modelCatalog.ts`.
  */
 
-import path from 'path';
 import * as conversation from '@/AI/AIAgent/shared/main/agentConversation';
 import * as ui from '@/UI/generalUI';
-import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
+import { buildByokExtraMcpServers } from '@/AI/AIAgent/mcp/serverConfig';
 import {
     SUPPORTED_PROVIDERS,
     type SupportedProvider,
@@ -68,25 +67,6 @@ async function pickModel(provider: SupportedProvider): Promise<ModelInfo> {
     return picked;
 }
 
-function buildAdditionalMcpServers(): Record<string, MCPServerConfig> {
-    const bashServerJs = path.join(__dirname, '..', '..', 'shared', 'utils', 'bashMcpServer.js');
-    const webServerJs = path.join(__dirname, '..', '..', 'shared', 'utils', 'webMcpServer.js');
-
-    return {
-        'kra-bash': {
-            type: 'stdio',
-            command: process.execPath,
-            args: [bashServerJs],
-            tools: ['bash'],
-        },
-        'kra-web': {
-            type: 'stdio',
-            command: process.execPath,
-            args: [webServerJs],
-            tools: ['web_fetch', 'web_search'],
-        },
-    };
-}
 
 export async function startByokFlow(): Promise<void> {
     const provider = await pickProvider();
@@ -100,7 +80,7 @@ export async function startByokFlow(): Promise<void> {
         await conversation.converseAgent({
             client,
             model: model.id,
-            additionalMcpServers: buildAdditionalMcpServers(),
+            additionalMcpServers: buildByokExtraMcpServers(),
             ...(model.contextWindow > 0 ? { contextWindow: model.contextWindow } : {}),
         });
     } catch (error) {

--- a/src/AI/AIAgent/providers/copilot/copilotClient.ts
+++ b/src/AI/AIAgent/providers/copilot/copilotClient.ts
@@ -8,6 +8,7 @@ import type {
 } from '@/AI/AIAgent/shared/types/agentTypes';
 import { TURN_REMINDER } from '@/AI/AIAgent/shared/main/turnReminder';
 import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
+import { createExecutableToolBridge, disconnectPool } from '@/AI/AIAgent/mcp/executableToolBridge';
 import { buildMcpClientPool, type McpClientPool } from '@/AI/AIAgent/providers/byok/mcpClientPool';
 
 export interface CopilotClientWrapperOptions {
@@ -85,9 +86,9 @@ export class CopilotClientWrapper implements AgentClient {
         // provider is Copilot (whose SDK does not expose its internal MCP
         // clients).
         const kraServers: Record<string, MCPServerConfig> = {};
-        for (const [name, cfg] of Object.entries(options.mcpServers ?? {})) {
+        for (const [name, cfg] of Object.entries(options.mcpServers)) {
             if (name.startsWith('kra-')) {
-                kraServers[name] = cfg as MCPServerConfig;
+                kraServers[name] = cfg;
             }
         }
 
@@ -106,26 +107,12 @@ export class CopilotClientWrapper implements AgentClient {
 
         const session = sdkSession as unknown as AgentSession;
         if (sidePool) {
-            session.listExecutableTools = () => Array.from(sidePool!.tools.values()).map((t) => ({
-                title: `${t.server}:${t.originalName}`,
-                server: t.server,
-                name: t.originalName,
-            }));
-            session.executeTool = async (title, args) => {
-                const tool = Array.from(sidePool!.tools.values()).find(
-                    (t) => `${t.server}:${t.originalName}` === title
-                );
-                if (!tool) throw new Error(`Unknown tool: ${title}`);
-                const result = await tool.client.callTool({ name: tool.originalName, arguments: args });
-                const contentArray = (result.content ?? []) as Array<{ type: string; text?: string }>;
-                return contentArray
-                    .filter((p) => p.type === 'text' && typeof p.text === 'string')
-                    .map((p) => p.text)
-                    .join('\n');
-            };
+            const bridge = createExecutableToolBridge(() => sidePool);
+            session.listExecutableTools = bridge.listExecutableTools;
+            session.executeTool = bridge.executeTool;
             const originalDisconnect = session.disconnect.bind(session);
             session.disconnect = async () => {
-                try { await sidePool!.disconnect(); } catch { /* swallow */ }
+                await disconnectPool(sidePool, true);
                 await originalDisconnect();
             };
         }

--- a/src/AI/AIAgent/shared/main/agentConversation.ts
+++ b/src/AI/AIAgent/shared/main/agentConversation.ts
@@ -1,10 +1,8 @@
 import * as fs from 'fs/promises';
-import path from 'path';
-import { getConfiguredMcpServers } from '@/AI/AIAgent/shared/utils/agentSettings';
 import { execCommand } from '@/utils/bashHelper';
 import { createAgentHistory } from '@/AI/AIAgent/shared/utils/agentHistory';
-import * as aiNeovimHelper from '@/AI/shared/utils/conversationUtils/aiNeovimHelper';
-import * as fileContext from '@/AI/shared/utils/conversationUtils/fileContexts';
+import { buildCoreMcpServers } from '@/AI/AIAgent/mcp/serverConfig';
+import * as conversation from '@/AI/shared/conversation';
 import type {
     AgentConversationOptions,
     AgentConversationState,
@@ -26,7 +24,8 @@ import {
 } from '@/AI/AIAgent/shared/main/agentNeovimSetup';
 import { getErrorMessage, setupEventHandlers } from '@/AI/AIAgent/shared/main/agentPromptActions';
 
-
+const aiNeovimHelper = conversation;
+const fileContext = conversation;
 
 async function cleanup(state: AgentConversationState): Promise<void> {
     fileContext.clearFileContexts();
@@ -54,34 +53,7 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
     const nvimClient = await openAgentNeovim(chatFile);
     await runStartupIndexingFlow(nvimClient, cwd);
 
-    const userMcpServers = await getConfiguredMcpServers();
-    const mcpServers = {
-        ...userMcpServers,
-        'kra-session-complete': {
-            type: 'stdio' as const,
-            command: process.execPath,
-            args: [path.join(__dirname, '..', 'utils', 'sessionCompleteMcpServer.js')],
-            tools: ['confirm_task_complete'],
-        },
-        'kra-file-context': {
-            type: 'stdio' as const,
-            command: process.execPath,
-            args: [path.join(__dirname, '..', 'utils', 'fileContextMcpServer.js')],
-            tools: ['get_outline', 'read_lines', 'read_function', 'edit_lines', 'create_file', 'search', 'lsp_query'],
-        },
-        'kra-memory': {
-            type: 'stdio' as const,
-            command: process.execPath,
-            args: [path.join(__dirname, '..', 'utils', 'memoryMcpServer.js')],
-            tools: [
-                'remember',
-                'recall',
-                'update_memory',
-                'edit_memory',
-                'semantic_search',
-            ],
-        },
-    };
+    const mcpServers = await buildCoreMcpServers();
     const stateRef: { current?: AgentConversationState } = {};
     const mergedMcpServers = {
         ...mcpServers,

--- a/src/AI/AIAgent/shared/main/agentNeovimSetup.ts
+++ b/src/AI/AIAgent/shared/main/agentNeovimSetup.ts
@@ -5,7 +5,7 @@ import { buildAgentTmuxCommand } from '@/AI/AIAgent/shared/utils/agentTmux';
 import * as bash from '@/utils/bashHelper';
 import { openVim } from '@/utils/neovimHelper';
 import { neovimConfig } from '@/filePaths';
-import * as aiNeovimHelper from '@/AI/shared/utils/conversationUtils/aiNeovimHelper';
+import * as aiNeovimHelper from '@/AI/shared/conversation';
 
 export async function createAgentChatFile(chatFile: string): Promise<void> {
     const initialContent = `# Copilot Agent Chat

--- a/src/AI/AIAgent/shared/main/agentPromptActionDispatch.ts
+++ b/src/AI/AIAgent/shared/main/agentPromptActionDispatch.ts
@@ -1,0 +1,128 @@
+import type { AgentConversationState } from '@/AI/AIAgent/shared/types/agentTypes';
+import * as fileContext from '@/AI/shared/conversation';
+import {
+    applyProposal,
+    openChangedProposalFile,
+    rejectCurrentProposal,
+    showProposalReview,
+    updateAgentUi,
+} from '@/AI/AIAgent/shared/utils/agentSessionEvents';
+import {
+    handleAddMemory,
+    handleDeleteMemory,
+    handleEditMemory,
+    handleSetMemoryStatus,
+    openMemoryBrowser,
+} from '@/AI/AIAgent/shared/main/agentMemoryActions';
+
+function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message;
+    }
+
+    if (typeof error === 'string') {
+        return error;
+    }
+
+    return 'Unknown error';
+}
+
+export async function dispatchPromptAction(
+    state: AgentConversationState,
+    action: string,
+    args: unknown[]
+): Promise<void> {
+    switch (action) {
+        case 'add_file_context':
+            await fileContext.handleAddFileContext(state.nvim, state.chatFile, { agentMode: true });
+            break;
+        case 'stop_stream':
+            await state.session.abort();
+            state.isStreaming = false;
+            await updateAgentUi(state.nvim, 'stop_turn', ['Stopped current agent turn']);
+            break;
+        case 'show_contexts_popup':
+            await fileContext.showFileContextsPopup(state.nvim);
+            break;
+        case 'remove_file_context':
+            await fileContext.handleRemoveFileContext(state.nvim);
+            break;
+        case 'clear_contexts':
+            await fileContext.clearAllFileContexts(state.nvim);
+            break;
+        case 'review_proposal':
+            await showProposalReview(state.nvim, state);
+            break;
+        case 'open_proposal_file':
+            await openChangedProposalFile(state);
+            break;
+        case 'apply_proposal':
+            await applyProposal(state);
+            break;
+        case 'reject_proposal':
+            await rejectCurrentProposal(state);
+            break;
+        case 'toggle_yolo_mode':
+            state.approvalMode = state.approvalMode === 'yolo' ? 'strict' : 'yolo';
+            state.allowedToolFamilies.clear();
+            await updateAgentUi(
+                state.nvim,
+                'show_error',
+                ['Approval mode', state.approvalMode === 'yolo' ? 'YOLO mode enabled.' : 'Strict approval mode enabled.']
+            );
+            break;
+        case 'reset_tool_approvals':
+            state.approvalMode = 'strict';
+            state.allowedToolFamilies.clear();
+            await updateAgentUi(state.nvim, 'show_error', ['Approval mode', 'Reset remembered approvals.']);
+            break;
+        case 'browse_memory': {
+            const params = (args[1] ?? {}) as { view?: unknown };
+            const v = String(params.view ?? 'all');
+            const view = v === 'findings' || v === 'revisits' ? v : 'all';
+            await openMemoryBrowser(state.nvim, view);
+            break;
+        }
+        case 'add_memory':
+            await handleAddMemory(state.nvim, (args[1] ?? {}) as Record<string, unknown>);
+            break;
+        case 'delete_memory':
+            await handleDeleteMemory(state.nvim, (args[1] ?? {}) as Record<string, unknown>);
+            break;
+        case 'edit_memory':
+            await handleEditMemory(state.nvim, (args[1] ?? {}) as Record<string, unknown>);
+            break;
+        case 'set_memory_status':
+            await handleSetMemoryStatus(state.nvim, (args[1] ?? {}) as Record<string, unknown>);
+            break;
+        case 'execute_tool': {
+            const payload = (args[1] ?? {}) as { title?: unknown; args_json?: unknown };
+            const title = String(payload.title ?? '');
+            const argsJson = String(payload.args_json ?? '{}');
+            if (!title) {
+                await updateAgentUi(state.nvim, 'show_tool_execution_result', ['', 'Missing tool title', '']);
+                break;
+            }
+            if (!state.session.executeTool) {
+                await updateAgentUi(state.nvim, 'show_tool_execution_result', ['', 'Tool re-execution not supported by current provider', title]);
+                break;
+            }
+            let parsedArgs: Record<string, unknown>;
+            try {
+                parsedArgs = JSON.parse(argsJson) as Record<string, unknown>;
+            } catch (err) {
+                await updateAgentUi(state.nvim, 'show_tool_execution_result', ['', `Invalid JSON: ${getErrorMessage(err)}`, title]);
+                break;
+            }
+            try {
+                const result = await state.session.executeTool(title, parsedArgs);
+                await updateAgentUi(state.nvim, 'show_tool_execution_result', [result, '', title]);
+            } catch (err) {
+                await updateAgentUi(state.nvim, 'show_tool_execution_result', ['', getErrorMessage(err), title]);
+            }
+            break;
+        }
+        default:
+            console.log('Unknown action:', action);
+    }
+}

--- a/src/AI/AIAgent/shared/main/agentPromptActions.ts
+++ b/src/AI/AIAgent/shared/main/agentPromptActions.ts
@@ -8,23 +8,12 @@ import {
     materializeAgentDraft,
 } from '@/AI/AIAgent/shared/utils/agentUi';
 import type { FileContext } from '@/AI/shared/types/aiTypes';
-import * as aiNeovimHelper from '@/AI/shared/utils/conversationUtils/aiNeovimHelper';
-import * as fileContext from '@/AI/shared/utils/conversationUtils/fileContexts';
+import * as conversation from '@/AI/shared/conversation';
 import { appendToChat } from '@/AI/AIAgent/shared/utils/agentToolHook';
-import {
-    applyProposal,
-    openChangedProposalFile,
-    rejectCurrentProposal,
-    showProposalReview,
-    updateAgentUi,
-} from '@/AI/AIAgent/shared/utils/agentSessionEvents';
-import {
-    handleAddMemory,
-    handleDeleteMemory,
-    handleEditMemory,
-    handleSetMemoryStatus,
-    openMemoryBrowser,
-} from '@/AI/AIAgent/shared/main/agentMemoryActions';
+import { updateAgentUi } from '@/AI/AIAgent/shared/utils/agentSessionEvents';
+import { dispatchPromptAction } from './agentPromptActionDispatch';
+const aiNeovimHelper = conversation;
+const fileContext = conversation;
 
 export function getErrorMessage(error: unknown): string {
     if (error instanceof Error) {
@@ -150,110 +139,19 @@ async function handleSubmit(state: AgentConversationState): Promise<void> {
 }
 
 export async function setupEventHandlers(state: AgentConversationState): Promise<void> {
-    state.nvim.on('notification', (method, args) => {
+    state.nvim.on('notification', (method: string, args: unknown[]) => {
         void (async (): Promise<void> => {
         if (method !== 'prompt_action') {
             return;
         }
 
-        const action = args[0] as string;
+        const action = typeof args[0] === 'string' ? args[0] : '';
 
         try {
-            switch (action) {
-                case 'submit_pressed':
-                    await handleSubmit(state);
-                    break;
-                case 'add_file_context':
-                    await fileContext.handleAddFileContext(state.nvim, state.chatFile, { agentMode: true });
-                    break;
-                case 'stop_stream':
-                    await state.session.abort();
-                    state.isStreaming = false;
-                    await updateAgentUi(state.nvim, 'stop_turn', ['Stopped current agent turn']);
-                    break;
-                case 'show_contexts_popup':
-                    await fileContext.showFileContextsPopup(state.nvim);
-                    break;
-                case 'remove_file_context':
-                    await fileContext.handleRemoveFileContext(state.nvim);
-                    break;
-                case 'clear_contexts':
-                    await fileContext.clearAllFileContexts(state.nvim);
-                    break;
-                case 'review_proposal':
-                    await showProposalReview(state.nvim, state);
-                    break;
-                case 'open_proposal_file':
-                    await openChangedProposalFile(state);
-                    break;
-                case 'apply_proposal':
-                    await applyProposal(state);
-                    break;
-                case 'reject_proposal':
-                    await rejectCurrentProposal(state);
-                    break;
-                case 'toggle_yolo_mode':
-                    state.approvalMode = state.approvalMode === 'yolo' ? 'strict' : 'yolo';
-                    state.allowedToolFamilies.clear();
-                    await updateAgentUi(
-                        state.nvim,
-                        'show_error',
-                        ['Approval mode', state.approvalMode === 'yolo' ? 'YOLO mode enabled.' : 'Strict approval mode enabled.']
-                    );
-                    break;
-                case 'reset_tool_approvals':
-                    state.approvalMode = 'strict';
-                    state.allowedToolFamilies.clear();
-                    await updateAgentUi(state.nvim, 'show_error', ['Approval mode', 'Reset remembered approvals.']);
-                    break;
-                case 'browse_memory': {
-                    const params = (args[1] ?? {}) as { view?: unknown };
-                    const v = String(params.view ?? 'all');
-                    const view = v === 'findings' || v === 'revisits' ? v : 'all';
-                    await openMemoryBrowser(state.nvim, view);
-                    break;
-                }
-                case 'add_memory':
-                    await handleAddMemory(state.nvim, (args[1] ?? {}) as Record<string, unknown>);
-                    break;
-                case 'delete_memory':
-                    await handleDeleteMemory(state.nvim, (args[1] ?? {}) as Record<string, unknown>);
-                    break;
-                case 'edit_memory':
-                    await handleEditMemory(state.nvim, (args[1] ?? {}) as Record<string, unknown>);
-                    break;
-                case 'set_memory_status':
-                    await handleSetMemoryStatus(state.nvim, (args[1] ?? {}) as Record<string, unknown>);
-                    break;
-                case 'execute_tool': {
-                    const payload = (args[1] ?? {}) as { title?: unknown; args_json?: unknown };
-                    const title = String(payload.title ?? '');
-                    const argsJson = String(payload.args_json ?? '{}');
-                    if (!title) {
-                        await updateAgentUi(state.nvim, 'show_tool_execution_result', ['', 'Missing tool title', '']);
-                        break;
-                    }
-                    if (!state.session.executeTool) {
-                        await updateAgentUi(state.nvim, 'show_tool_execution_result', ['', 'Tool re-execution not supported by current provider', title]);
-                        break;
-                    }
-                    let parsedArgs: Record<string, unknown>;
-                    try {
-                        parsedArgs = JSON.parse(argsJson) as Record<string, unknown>;
-                    } catch (err) {
-                        await updateAgentUi(state.nvim, 'show_tool_execution_result', ['', `Invalid JSON: ${getErrorMessage(err)}`, title]);
-                        break;
-                    }
-                    try {
-                        const result = await state.session.executeTool(title, parsedArgs);
-                        await updateAgentUi(state.nvim, 'show_tool_execution_result', [result, '', title]);
-                    } catch (err) {
-                        await updateAgentUi(state.nvim, 'show_tool_execution_result', ['', getErrorMessage(err), title]);
-                    }
-                    break;
-                }
-                default:
-                    console.log('Unknown action:', action);
+            if (action === 'submit_pressed') {
+                await handleSubmit(state);
+            } else {
+                await dispatchPromptAction(state, action, args);
             }
         } catch (error) {
             await updateAgentUi(state.nvim, 'show_error', [

--- a/src/AI/AIAgent/shared/utils/agentSessionEvents.ts
+++ b/src/AI/AIAgent/shared/utils/agentSessionEvents.ts
@@ -10,7 +10,7 @@ import {
     summarizeToolCall,
 } from '@/AI/AIAgent/shared/utils/agentUi';
 import * as bash from '@/utils/bashHelper';
-import * as aiNeovimHelper from '@/AI/shared/utils/conversationUtils/aiNeovimHelper';
+import * as aiNeovimHelper from '@/AI/shared/conversation';
 import { appendToChat } from '@/AI/AIAgent/shared/utils/agentToolHook';
 import type { AgentConversationState } from '@/AI/AIAgent/shared/types/agentTypes';
 import { setupQuotaTracking } from '@/AI/AIAgent/shared/utils/agentQuotaTracker';

--- a/src/AI/AIAgent/shared/utils/bashMcpServer.ts
+++ b/src/AI/AIAgent/shared/utils/bashMcpServer.ts
@@ -9,33 +9,7 @@
  */
 
 import { exec } from 'child_process';
-import readline from 'readline';
-
-interface JsonRpcRequest {
-    jsonrpc: '2.0';
-    id?: number | string | null;
-    method: string;
-    params?: unknown;
-}
-
-interface JsonRpcResponse {
-    jsonrpc: '2.0';
-    id: number | string | null;
-    result?: unknown;
-    error?: { code: number; message: string };
-}
-
-function send(response: JsonRpcResponse): void {
-    process.stdout.write(JSON.stringify(response) + '\n');
-}
-
-function sendResult(id: number | string | null, result: unknown): void {
-    send({ jsonrpc: '2.0', id: id ?? null, result });
-}
-
-function sendError(id: number | string | null, code: number, message: string): void {
-    send({ jsonrpc: '2.0', id: id ?? null, error: { code, message } });
-}
+import { JsonRpcToolError, runStdioMcpServer } from '../../mcp/stdioServer';
 
 const TOOL_DEFINITION = {
     name: 'bash',
@@ -106,84 +80,25 @@ async function runBash(args: BashArgs): Promise<{ output: string; isError: boole
     });
 }
 
-const rl = readline.createInterface({ input: process.stdin, terminal: false });
+runStdioMcpServer({
+    serverName: 'kra-bash',
+    tools: [TOOL_DEFINITION],
+    handleToolCall: async ({ params }) => {
+        const rawArgs = (params as { arguments?: unknown }).arguments;
+        const args = (rawArgs ?? {}) as Partial<BashArgs>;
 
-rl.on('line', (line: string) => {
-    const trimmed = line.trim();
-
-    if (!trimmed) {
-        return;
-    }
-
-    let request: JsonRpcRequest;
-
-    try {
-        request = JSON.parse(trimmed) as JsonRpcRequest;
-    } catch {
-        sendError(null, -32700, 'Parse error');
-
-        return;
-    }
-
-    const id = request.id ?? null;
-
-    void (async (): Promise<void> => {
-        try {
-            switch (request.method) {
-                case 'initialize':
-                    sendResult(id, {
-                        protocolVersion: '2024-11-05',
-                        capabilities: { tools: {} },
-                        serverInfo: { name: 'kra-bash', version: '1.0.0' },
-                    });
-
-                    return;
-
-                case 'notifications/initialized':
-                    return;
-
-                case 'tools/list':
-                    sendResult(id, { tools: [TOOL_DEFINITION] });
-
-                    return;
-
-                case 'tools/call': {
-                    const params = (request.params ?? {}) as { name?: string; arguments?: BashArgs };
-
-                    if (params.name !== 'bash') {
-                        sendError(id, -32601, `Unknown tool: ${params.name ?? '(none)'}`);
-
-                        return;
-                    }
-
-                    const args = params.arguments;
-
-                    if (!args || typeof args.command !== 'string') {
-                        sendError(id, -32602, 'Missing required argument: command');
-
-                        return;
-                    }
-
-                    const { output, isError } = await runBash(args);
-
-                    sendResult(id, {
-                        content: [{ type: 'text', text: output }],
-                        isError,
-                    });
-
-                    return;
-                }
-
-                default:
-                    sendError(id, -32601, `Method not found: ${request.method}`);
-            }
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            sendError(id, -32603, `Internal error: ${message}`);
+        if (typeof args.command !== 'string') {
+            throw new JsonRpcToolError(-32602, 'Missing required argument: command');
         }
-    })();
-});
 
-rl.on('close', () => {
-    process.exit(0);
+        const { output, isError } = await runBash({
+            command: args.command,
+            ...(typeof args.timeoutMs === 'number' ? { timeoutMs: args.timeoutMs } : {}),
+        });
+
+        return {
+            content: [{ type: 'text', text: output }],
+            isError,
+        };
+    },
 });

--- a/src/AI/AIAgent/shared/utils/fileContextMcpServer.ts
+++ b/src/AI/AIAgent/shared/utils/fileContextMcpServer.ts
@@ -2,13 +2,13 @@
 /**
  * Stdio MCP server exposing file-context tools for the agent:
  *
- *   lsp_query(file_path, op, ...)        \u2014 LSP-backed hover / definition / etc.
- *   search(name_pattern?, content_pattern?, ...) \u2014 ripgrep wrapper
- *   get_outline(file_path)               \u2014 list functions/classes + line numbers
- *   read_lines(file_path, start, end)    \u2014 return a specific line range (1-indexed)
- *   read_function(file_path, name)       \u2014 return the body of a named symbol
- *   edit_lines(file_path, ...)           \u2014 replace one or more line ranges
- *   create_file(file_path, content)      \u2014 create a NEW file (refuses if exists)
+ *   lsp_query(file_path, op, ...)        — LSP-backed hover / definition / etc.
+ *   search(name_pattern?, content_pattern?, ...) — ripgrep wrapper
+ *   get_outline(file_path)               — list functions/classes + line numbers
+ *   read_lines(file_path, start, end)    — return a specific line range (1-indexed)
+ *   read_function(file_path, name)       — return the body of a named symbol
+ *   edit_lines(file_path, ...)           — replace one or more line ranges
+ *   create_file(file_path, content)      — create a NEW file (refuses if exists)
  *
  * The agent is directed to use these tools instead of the built-in
  * str_replace_editor, write_file, and read_file tools (which are excluded
@@ -24,7 +24,7 @@
  */
 import 'module-alias/register';
 
-import * as readline from 'readline';
+import { runStdioMcpServer } from '../../mcp/stdioServer';
 import { dispatchFileContextTool } from '../fileContext/dispatch';
 import { TOOLS } from '../fileContext/tools';
 import { errorContent, getArgs } from '../fileContext';
@@ -40,99 +40,22 @@ process.on('unhandledRejection', (reason) => {
     process.stderr.write(`[mcp] unhandledRejection: ${reason instanceof Error ? reason.stack ?? reason.message : String(reason)}\n`);
 });
 
-interface JsonRpcRequest {
-    jsonrpc: '2.0';
-    id?: number | string | null;
-    method: string;
-    params?: unknown;
-}
+runStdioMcpServer({
+    serverName: 'kra-file-context',
+    tools: TOOLS,
+    allowPing: true,
+    respondParseError: false,
+    handleToolCall: async ({ toolName, params }) => {
+        const toolArgs = getArgs(params);
 
-interface JsonRpcResponse {
-    jsonrpc: '2.0';
-    id: number | string | null;
-    result?: unknown;
-    error?: { code: number; message: string };
-}
-
-function send(response: JsonRpcResponse): void {
-    process.stdout.write(JSON.stringify(response) + '\n');
-}
-
-function sendResult(id: number | string | null, result: unknown): void {
-    send({ jsonrpc: '2.0', id: id ?? null, result });
-}
-
-function sendError(id: number | string | null, code: number, message: string): void {
-    send({ jsonrpc: '2.0', id: id ?? null, error: { code, message } });
-}
-
-const rl = readline.createInterface({ input: process.stdin, terminal: false });
-
-let pending = 0;
-let inputClosed = false;
-
-function maybeExit(): void {
-    if (inputClosed && pending === 0) process.exit(0);
-}
-
-rl.on('line', (line: string) => {
-    const trimmed = line.trim();
-
-    if (!trimmed) return;
-
-    let request: JsonRpcRequest;
-
-    try {
-        request = JSON.parse(trimmed) as JsonRpcRequest;
-    } catch {
-        return;
-    }
-
-    const id = request.id ?? null;
-
-    switch (request.method) {
-        case 'initialize':
-            sendResult(id, {
-                protocolVersion: '2024-11-05',
-                capabilities: { tools: {} },
-                serverInfo: { name: 'kra-file-context', version: '1.0.0' },
-            });
-            break;
-
-        case 'notifications/initialized':
-            break;
-
-        case 'tools/list':
-            sendResult(id, { tools: TOOLS });
-            break;
-
-        case 'tools/call': {
-            const params = request.params as Record<string, unknown> | undefined;
-            const toolName = typeof params?.name === 'string' ? params.name : '';
-            const toolArgs = getArgs(params);
-
-            pending++;
-            dispatchFileContextTool(toolName, toolArgs)
-                .then((result) => sendResult(id, result))
-                .catch((err) => sendResult(id, errorContent(String(err))))
-                .finally(() => {
-                    pending--;
-                    maybeExit();
-                });
-            break;
+        try {
+            return await dispatchFileContextTool(toolName, toolArgs);
+        } catch (err) {
+            return errorContent(String(err));
         }
-
-        case 'ping':
-            sendResult(id, {});
-            break;
-
-        default:
-            sendError(id, -32601, `Method not found: ${request.method}`);
-            break;
-    }
-});
-
-rl.on('close', () => {
-    inputClosed = true;
-    maybeExit();
+    },
+    onInternalError: (error) => ({
+        kind: 'result',
+        result: errorContent(String(error)),
+    }),
 });

--- a/src/AI/AIAgent/shared/utils/memoryMcpServer.ts
+++ b/src/AI/AIAgent/shared/utils/memoryMcpServer.ts
@@ -8,37 +8,12 @@
  * scoped per agent workspace.
  */
 
-import readline from 'readline';
+import { runStdioMcpServer } from '../../mcp/stdioServer';
 import 'module-alias/register';
 import { editMemory, recall, remember, updateMemory } from '../memory/notes';
 import { semanticSearch } from '../memory/search';
 import { MEMORY_KINDS, MEMORY_LOOKUP_KINDS, MEMORY_STATUSES } from '../memory/types';
 
-interface JsonRpcRequest {
-    jsonrpc: '2.0';
-    id?: number | string | null;
-    method: string;
-    params?: unknown;
-}
-
-interface JsonRpcResponse {
-    jsonrpc: '2.0';
-    id: number | string | null;
-    result?: unknown;
-    error?: { code: number; message: string };
-}
-
-function send(response: JsonRpcResponse): void {
-    process.stdout.write(JSON.stringify(response) + '\n');
-}
-
-function sendResult(id: number | string | null, result: unknown): void {
-    send({ jsonrpc: '2.0', id: id ?? null, result });
-}
-
-function sendError(id: number | string | null, code: number, message: string): void {
-    send({ jsonrpc: '2.0', id: id ?? null, error: { code, message } });
-}
 
 const REMEMBER_TOOL = {
     name: 'remember',
@@ -179,94 +154,29 @@ async function dispatchTool(name: ToolName, args: Record<string, unknown>): Prom
     }
 }
 
-const rl = readline.createInterface({ input: process.stdin, terminal: false });
+runStdioMcpServer({
+    serverName: 'kra-memory',
+    tools: TOOLS,
+    handleToolCall: async ({ toolName, params }) => {
+        const callParams = (params ?? {}) as { arguments?: unknown };
+        const rawArgs = callParams.arguments;
+        const args = (typeof rawArgs === 'object' && rawArgs !== null ? rawArgs : {}) as Record<string, unknown>;
+        const result = await dispatchTool(toolName, args);
 
-let pending = 0;
-let inputClosed = false;
+        return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+            isError: false,
+        };
+    },
+    onInternalError: (error) => {
+        const message = error instanceof Error ? error.message : String(error);
 
-function maybeExit(): void {
-    if (inputClosed && pending === 0) {
-        process.exit(0);
-    }
-}
-
-rl.on('line', (line: string) => {
-    const trimmed = line.trim();
-
-    if (!trimmed) {
-        return;
-    }
-
-    let request: JsonRpcRequest;
-
-    try {
-        request = JSON.parse(trimmed) as JsonRpcRequest;
-    } catch {
-        sendError(null, -32700, 'Parse error');
-
-        return;
-    }
-
-    const id = request.id ?? null;
-
-    pending++;
-    void (async (): Promise<void> => {
-        try {
-            switch (request.method) {
-                case 'initialize':
-                    sendResult(id, {
-                        protocolVersion: '2024-11-05',
-                        capabilities: { tools: {} },
-                        serverInfo: { name: 'kra-memory', version: '1.0.0' },
-                    });
-
-                    return;
-
-                case 'notifications/initialized':
-                    return;
-
-                case 'tools/list':
-                    sendResult(id, { tools: TOOLS });
-
-                    return;
-
-                case 'tools/call': {
-                    const params = (request.params ?? {}) as { name?: string; arguments?: Record<string, unknown> };
-                    const toolName = params.name;
-
-                    if (!toolName || !TOOLS.some((t) => t.name === toolName)) {
-                        sendError(id, -32601, `Unknown tool: ${toolName ?? '(none)'}`);
-
-                        return;
-                    }
-
-                    const result = await dispatchTool(toolName, params.arguments ?? {});
-
-                    sendResult(id, {
-                        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-                        isError: false,
-                    });
-
-                    return;
-                }
-
-                default:
-                    sendError(id, -32601, `Method not found: ${request.method}`);
-            }
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            sendResult(id, {
+        return {
+            kind: 'result',
+            result: {
                 content: [{ type: 'text', text: `Error: ${message}` }],
                 isError: true,
-            });
-        } finally {
-            pending--;
-            maybeExit();
-        }
-    })();
-});
-
-rl.on('close', () => {
-    inputClosed = true;
-    maybeExit();
+            },
+        };
+    },
 });

--- a/src/AI/AIAgent/shared/utils/sessionCompleteMcpServer.ts
+++ b/src/AI/AIAgent/shared/utils/sessionCompleteMcpServer.ts
@@ -10,33 +10,7 @@
  * Run directly: node dest/AI/AIAgent/utils/sessionCompleteMcpServer.js
  */
 
-import * as readline from 'readline';
-
-interface JsonRpcRequest {
-    jsonrpc: '2.0';
-    id?: number | string | null;
-    method: string;
-    params?: unknown;
-}
-
-interface JsonRpcResponse {
-    jsonrpc: '2.0';
-    id: number | string | null;
-    result?: unknown;
-    error?: { code: number; message: string };
-}
-
-function send(response: JsonRpcResponse): void {
-    process.stdout.write(JSON.stringify(response) + '\n');
-}
-
-function sendResult(id: number | string | null, result: unknown): void {
-    send({ jsonrpc: '2.0', id: id ?? null, result });
-}
-
-function sendError(id: number | string | null, code: number, message: string): void {
-    send({ jsonrpc: '2.0', id: id ?? null, error: { code, message } });
-}
+import { runStdioMcpServer } from '../../mcp/stdioServer';
 
 const TOOL_DEFINITION = {
     name: 'confirm_task_complete',
@@ -66,64 +40,13 @@ const TOOL_DEFINITION = {
     },
 };
 
-const rl = readline.createInterface({ input: process.stdin, terminal: false });
-
-rl.on('line', (line: string) => {
-    const trimmed = line.trim();
-
-    if (!trimmed) {
-        return;
-    }
-
-    let request: JsonRpcRequest;
-
-    try {
-        request = JSON.parse(trimmed) as JsonRpcRequest;
-    } catch {
-        // Malformed — ignore
-        return;
-    }
-
-    const id = request.id ?? null;
-
-    switch (request.method) {
-        case 'initialize':
-            sendResult(id, {
-                protocolVersion: '2024-11-05',
-                capabilities: { tools: {} },
-                serverInfo: { name: 'kra-session-complete', version: '1.0.0' },
-            });
-            break;
-
-        case 'notifications/initialized':
-            // No response for notifications
-            break;
-
-        case 'tools/list':
-            sendResult(id, { tools: [TOOL_DEFINITION] });
-            break;
-
-        case 'tools/call': {
-            // The real work happens in onPreToolUse. This just needs to
-            // return a valid result so the SDK doesn't error out in case
-            // onPreToolUse allows the call through.
-            sendResult(id, {
-                content: [{ type: 'text', text: 'User has been prompted. Continue based on their reply.' }],
-                isError: false,
-            });
-            break;
-        }
-
-        case 'ping':
-            sendResult(id, {});
-            break;
-
-        default:
-            sendError(id, -32601, `Method not found: ${request.method}`);
-            break;
-    }
-});
-
-rl.on('close', () => {
-    process.exit(0);
+runStdioMcpServer({
+    serverName: 'kra-session-complete',
+    tools: [TOOL_DEFINITION],
+    allowPing: true,
+    respondParseError: false,
+    handleToolCall: async () => ({
+        content: [{ type: 'text', text: 'User has been prompted. Continue based on their reply.' }],
+        isError: false,
+    }),
 });

--- a/src/AI/AIAgent/shared/utils/webMcpServer.ts
+++ b/src/AI/AIAgent/shared/utils/webMcpServer.ts
@@ -15,35 +15,9 @@
  * can still rate-limit. We send a realistic browser User-Agent to reduce that.
  */
 
-import readline from 'readline';
 import * as cheerio from 'cheerio';
 import { convert as htmlToTextLib } from 'html-to-text';
-
-interface JsonRpcRequest {
-    jsonrpc: '2.0';
-    id?: number | string | null;
-    method: string;
-    params?: unknown;
-}
-
-interface JsonRpcResponse {
-    jsonrpc: '2.0';
-    id: number | string | null;
-    result?: unknown;
-    error?: { code: number; message: string };
-}
-
-function send(response: JsonRpcResponse): void {
-    process.stdout.write(JSON.stringify(response) + '\n');
-}
-
-function sendResult(id: number | string | null, result: unknown): void {
-    send({ jsonrpc: '2.0', id: id ?? null, result });
-}
-
-function sendError(id: number | string | null, code: number, message: string): void {
-    send({ jsonrpc: '2.0', id: id ?? null, error: { code, message } });
-}
+import { JsonRpcToolError, runStdioMcpServer } from '../../mcp/stdioServer';
 
 const DEFAULT_MAX_LENGTH = 8_000;
 const HARD_MAX_LENGTH = 50_000;
@@ -351,109 +325,46 @@ async function runWebSearch(args: WebSearchArgs): Promise<{ output: string; isEr
 
 const TOOLS = [WEB_FETCH_TOOL, WEB_SEARCH_TOOL];
 
-const rl = readline.createInterface({ input: process.stdin, terminal: false });
+runStdioMcpServer({
+    serverName: 'kra-web',
+    tools: TOOLS,
+    handleToolCall: async ({ toolName, params }) => {
+        const callParams = (params ?? {}) as { arguments?: unknown };
+        const rawArgs = callParams.arguments;
+        const args = (typeof rawArgs === 'object' && rawArgs !== null ? rawArgs : {}) as Partial<WebFetchArgs & WebSearchArgs>;
 
-rl.on('line', (line: string) => {
-    const trimmed = line.trim();
-
-    if (!trimmed) {
-        return;
-    }
-
-    let request: JsonRpcRequest;
-
-    try {
-        request = JSON.parse(trimmed) as JsonRpcRequest;
-    } catch {
-        sendError(null, -32700, 'Parse error');
-
-        return;
-    }
-
-    const id = request.id ?? null;
-
-    void (async (): Promise<void> => {
-        try {
-            switch (request.method) {
-                case 'initialize':
-                    sendResult(id, {
-                        protocolVersion: '2024-11-05',
-                        capabilities: { tools: {} },
-                        serverInfo: { name: 'kra-web', version: '1.0.0' },
-                    });
-
-                    return;
-
-                case 'notifications/initialized':
-                    return;
-
-                case 'tools/list':
-                    sendResult(id, { tools: TOOLS });
-
-                    return;
-
-                case 'tools/call': {
-                    const params = (request.params ?? {}) as {
-                        name?: string;
-                        arguments?: WebFetchArgs & WebSearchArgs;
-                    };
-                    const args: Partial<WebFetchArgs & WebSearchArgs> = params.arguments ?? {};
-
-                    if (params.name === 'web_fetch') {
-                        if (typeof args.url !== 'string') {
-                            sendError(id, -32602, 'Missing required argument: url');
-
-                            return;
-                        }
-
-                        const { output, isError } = await runWebFetch({
-                            url: args.url,
-                            ...(args.max_length !== undefined ? { max_length: args.max_length } : {}),
-                        });
-
-                        sendResult(id, {
-                            content: [{ type: 'text', text: output }],
-                            isError,
-                        });
-
-                        return;
-                    }
-
-                    if (params.name === 'web_search') {
-                        if (typeof args.query !== 'string') {
-                            sendError(id, -32602, 'Missing required argument: query');
-
-                            return;
-                        }
-
-                        const { output, isError } = await runWebSearch({
-                            query: args.query,
-                            ...(args.max_results !== undefined ? { max_results: args.max_results } : {}),
-                        });
-
-                        sendResult(id, {
-                            content: [{ type: 'text', text: output }],
-                            isError,
-                        });
-
-                        return;
-                    }
-
-                    sendError(id, -32601, `Unknown tool: ${params.name ?? '(none)'}`);
-
-                    return;
-                }
-
-                default:
-                    sendError(id, -32601, `Method not found: ${request.method}`);
+        if (toolName === 'web_fetch') {
+            if (typeof args.url !== 'string') {
+                throw new JsonRpcToolError(-32602, 'Missing required argument: url');
             }
-        } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            sendError(id, -32603, `Internal error: ${message}`);
-        }
-    })();
-});
 
-rl.on('close', () => {
-    process.exit(0);
+            const { output, isError } = await runWebFetch({
+                url: args.url,
+                ...(args.max_length !== undefined ? { max_length: args.max_length } : {}),
+            });
+
+            return {
+                content: [{ type: 'text', text: output }],
+                isError,
+            };
+        }
+
+        if (toolName === 'web_search') {
+            if (typeof args.query !== 'string') {
+                throw new JsonRpcToolError(-32602, 'Missing required argument: query');
+            }
+
+            const { output, isError } = await runWebSearch({
+                query: args.query,
+                ...(args.max_results !== undefined ? { max_results: args.max_results } : {}),
+            });
+
+            return {
+                content: [{ type: 'text', text: output }],
+                isError,
+            };
+        }
+
+        throw new JsonRpcToolError(-32601, `Unknown tool: ${toolName || '(none)'}`);
+    },
 });

--- a/src/AI/AIChat/commands/loadChat.ts
+++ b/src/AI/AIChat/commands/loadChat.ts
@@ -10,7 +10,7 @@ import * as nvim from '@/utils/neovimHelper';
 import * as bash from '@/utils/bashHelper';
 import { filterGitKeep } from '@/utils/common';
 import { aiHistoryPath } from '@/filePaths';
-import { getFileExtension } from '@/AI/shared/utils/conversationUtils/fileContexts';
+import { getFileExtension } from '@/AI/shared/conversation';
 
 export async function loadChat(): Promise<void> {
     try {

--- a/src/AI/AIChat/main/conversation.ts
+++ b/src/AI/AIChat/main/conversation.ts
@@ -8,8 +8,9 @@ import { ChatHistory, Role, StreamController } from '@/AI/shared/types/aiTypes'
 import * as bash from '@/utils/bashHelper';
 import { openVim } from '@/utils/neovimHelper';
 import { neovimConfig } from '@/filePaths';
-import * as aiNeovimHelper from '@/AI/shared/utils/conversationUtils/aiNeovimHelper';
-import * as fileContext from '@/AI/shared/utils/conversationUtils/fileContexts'
+import * as conversation from '@/AI/shared/conversation';
+const aiNeovimHelper = conversation;
+const fileContext = conversation;
 
 // stream controller for the current request
 let currentStreamController: StreamController | null = null;

--- a/src/AI/shared/conversation/index.ts
+++ b/src/AI/shared/conversation/index.ts
@@ -1,0 +1,2 @@
+export * from '@/AI/shared/utils/conversationUtils/aiNeovimHelper';
+export * from '@/AI/shared/utils/conversationUtils/fileContexts';

--- a/src/AI/shared/utils/conversationUtils/fileContextDisplay.ts
+++ b/src/AI/shared/utils/conversationUtils/fileContextDisplay.ts
@@ -1,0 +1,66 @@
+import fs from 'fs/promises';
+import type { FileContext } from '@/AI/shared/types/aiTypes';
+import { getContextFileName, getContextLineRange } from './fileContextStore';
+
+async function readFileStats(filePath: string): Promise<{ lineCount: number; sizeKB: number } | null> {
+    try {
+        const content = await fs.readFile(filePath, 'utf-8');
+
+        return {
+            lineCount: content.split('\n').length,
+            sizeKB: Math.round(content.length / 1024),
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function formatContextSummary(context: FileContext): string {
+    const fileName = getContextFileName(context.filePath);
+
+    if (!context.isPartial) {
+        return `${fileName} (full file)`;
+    }
+
+    const lineRange = getContextLineRange(context.startLine, context.endLine);
+
+    return `${fileName} (${lineRange})`;
+}
+
+export async function formatContextPickerItem(context: FileContext, index: number): Promise<string> {
+    const fileName = getContextFileName(context.filePath);
+
+    if (context.isPartial) {
+        const lineRange = getContextLineRange(context.startLine, context.endLine);
+
+        return `${index + 1}. 📄 ${fileName} (${lineRange})`;
+    }
+
+    const stats = await readFileStats(context.filePath);
+    if (!stats) {
+        return `${index + 1}. ❌ ${fileName} (error reading file)`;
+    }
+
+    return `${index + 1}. 📁 ${fileName} (${stats.lineCount} lines, ${stats.sizeKB}KB)`;
+}
+
+export async function formatContextPopupEntry(context: FileContext, index: number): Promise<string[]> {
+    const fileName = getContextFileName(context.filePath);
+
+    if (context.isPartial) {
+        const lineRange = getContextLineRange(context.startLine, context.endLine);
+
+        return [`${index + 1}. 📄 ${fileName} (${lineRange})`, `   ${context.filePath}`, ''];
+    }
+
+    const stats = await readFileStats(context.filePath);
+    if (!stats) {
+        return [`${index + 1}. ❌ ${fileName} (error reading file)`, `   ${context.filePath}`, ''];
+    }
+
+    return [
+        `${index + 1}. 📁 ${fileName} (${stats.lineCount} lines, ${stats.sizeKB}KB)`,
+        `   ${context.filePath}`,
+        '',
+    ];
+}

--- a/src/AI/shared/utils/conversationUtils/fileContextOps.ts
+++ b/src/AI/shared/utils/conversationUtils/fileContextOps.ts
@@ -1,7 +1,6 @@
 import { NeovimClient } from "neovim";
-import { FileContext } from "@/AI/shared/types/aiTypes";
 import fs from 'fs/promises';
-import { fileContexts, getFileExtension } from './fileContexts';
+import { getFileExtension, upsertFileContext } from './fileContextStore';
 
 const MAX_FILE_BYTES = 300_000;
 
@@ -28,18 +27,6 @@ function buildContextSummary(
     return `📁 ${fileName} (${lineCount} lines, ${sizeKB}KB)\n\n\`\`\`${ext}\n// Full file content loaded: ${filePath}\n${hintLine}// File contains ${lineCount} lines of ${ext} code\n\`\`\`\n\n`;
 }
 
-/**
- * Upsert a file context entry, replacing any existing entry with the same path
- * (and, for partial entries, the same line range).
- */
-function upsertFileContext(ctx: FileContext): void {
-    const existingIndex = ctx.isPartial
-        ? fileContexts.findIndex(c => c.filePath === ctx.filePath && c.startLine === ctx.startLine && c.endLine === ctx.endLine)
-        : fileContexts.findIndex(c => c.filePath === ctx.filePath);
-
-    if (existingIndex >= 0) fileContexts[existingIndex] = ctx;
-    else fileContexts.push(ctx);
-}
 
 /**
  * Recursively collect all files inside a folder (skips hidden dirs and node_modules)
@@ -184,8 +171,12 @@ export async function addPartialFileContext(nvim: NeovimClient, chatFile: string
                 resolve('timeout');
             }, 60000);
 
-            handler = async (method: string, args: any[]) => {
-                if (method === 'file_selection' && args[0] === 'add_selection') {
+            handler = (method: string, args: any[]) => {
+                if (method !== 'file_selection' || args[0] !== 'add_selection') {
+                    return;
+                }
+
+                void (async (): Promise<void> => {
                     clearTimeout(timeout);
                     if (handler) {
                         nvim.removeListener('notification', handler);
@@ -232,7 +223,7 @@ export async function addPartialFileContext(nvim: NeovimClient, chatFile: string
                         await nvim.command('echohl ErrorMsg | echo "Error processing selection" | echohl None');
                         resolve('error');
                     }
-                }
+                })();
             };
 
             nvim.on('notification', handler);

--- a/src/AI/shared/utils/conversationUtils/fileContextPickers.ts
+++ b/src/AI/shared/utils/conversationUtils/fileContextPickers.ts
@@ -1,7 +1,6 @@
 import { NeovimClient } from "neovim";
-import { FileContext } from "@/AI/shared/types/aiTypes";
-import fs from 'fs/promises';
-import { fileContexts } from './fileContexts';
+import { formatContextPickerItem } from './fileContextDisplay';
+import { fileContexts } from './fileContextStore';
 
 export interface FilePickerSelection {
     path: string;
@@ -47,25 +46,9 @@ function isString(value: unknown): value is string {
  */
 export async function selectContextToRemove(nvim: NeovimClient): Promise<number | null> {
     const channelId = await nvim.channelId;
-    const displayItems = await Promise.all(fileContexts.map(async (context: FileContext, index: number) => {
-        const fileName = context.filePath.split('/').pop() || context.filePath;
-
-        if (context.isPartial) {
-            const lineRange = context.startLine === context.endLine ? `line ${context.startLine}` : `lines ${context.startLine}-${context.endLine}`;
-
-            return `${index + 1}. 📄 ${fileName} (${lineRange})`;
-        }
-
-        try {
-            const content = await fs.readFile(context.filePath, 'utf-8');
-            const lineCount = content.split('\n').length;
-            const sizeKB = Math.round(content.length / 1024);
-
-            return `${index + 1}. 📁 ${fileName} (${lineCount} lines, ${sizeKB}KB)`;
-        } catch (_error) {
-            return `${index + 1}. ❌ ${fileName} (error reading file)`;
-        }
-    }));
+    const displayItems = await Promise.all(
+        fileContexts.map(async (context, index) => formatContextPickerItem(context, index))
+    );
 
     return new Promise((resolve) => {
         const handler = (method: string, args: unknown[]): void => {

--- a/src/AI/shared/utils/conversationUtils/fileContextStore.ts
+++ b/src/AI/shared/utils/conversationUtils/fileContextStore.ts
@@ -1,0 +1,49 @@
+import { fileTypes } from '@/AI/shared/data/filetypes';
+import type { FileContext } from '@/AI/shared/types/aiTypes';
+
+export const fileContexts: FileContext[] = [];
+
+export function clearStoredFileContexts(): void {
+    fileContexts.length = 0;
+}
+
+export function upsertFileContext(ctx: FileContext): void {
+    const existingIndex = ctx.isPartial
+        ? fileContexts.findIndex(
+            (candidate) =>
+                candidate.filePath === ctx.filePath &&
+                candidate.startLine === ctx.startLine &&
+                candidate.endLine === ctx.endLine
+        )
+        : fileContexts.findIndex((candidate) => candidate.filePath === ctx.filePath);
+
+    if (existingIndex >= 0) {
+        fileContexts[existingIndex] = ctx;
+
+        return;
+    }
+
+    fileContexts.push(ctx);
+}
+
+export function getFileExtension(filename: string): string {
+    const idx = filename.lastIndexOf('.');
+
+    if (idx === -1) return 'text';
+
+    const ext = filename.slice(idx + 1).toLowerCase();
+
+    return fileTypes[ext] || ext || 'text';
+}
+
+export function getContextFileName(filePath: string): string {
+    return filePath.split('/').pop() ?? filePath;
+}
+
+export function getContextLineRange(startLine: number | undefined, endLine: number | undefined): string {
+    if (typeof startLine !== 'number' || typeof endLine !== 'number') {
+        return 'unknown range';
+    }
+
+    return startLine === endLine ? `line ${startLine}` : `lines ${startLine}-${endLine}`;
+}

--- a/src/AI/shared/utils/conversationUtils/fileContexts.ts
+++ b/src/AI/shared/utils/conversationUtils/fileContexts.ts
@@ -1,11 +1,11 @@
-import { fileTypes } from "@/AI/shared/data/filetypes";
-import { FileContext } from "@/AI/shared/types/aiTypes";
 import { NeovimClient } from "neovim";
 import fs from 'fs/promises';
+import { formatContextPopupEntry, formatContextSummary } from './fileContextDisplay';
 import { selectContextToRemove, selectFileOrFolder, promptShareMode, selectFileFromFolder } from './fileContextPickers';
 import { addFolderContext, addEntireFileContext, addPartialFileContext } from './fileContextOps';
+import { clearStoredFileContexts, fileContexts, getContextFileName, getFileExtension } from './fileContextStore';
 
-export const fileContexts: FileContext[] = [];
+export { fileContexts, getFileExtension };
 
 export async function handleAddFileContext(nvim: NeovimClient, chatFile: string, options?: { agentMode?: boolean }): Promise<void> {
     try {
@@ -66,26 +66,15 @@ export async function handleAddFileContext(nvim: NeovimClient, chatFile: string,
 **/
 export async function clearAllFileContexts(nvim: NeovimClient): Promise<void> {
     const count = fileContexts.length;
-    fileContexts.length = 0;
+    clearStoredFileContexts();
     await nvim.command(`echohl MoreMsg | echo "Cleared ${count} file context(s)" | echohl None`);
 }
 
 /**
  * Clear file contexts array
 **/
-export const clearFileContexts = (): void => { fileContexts.length = 0; };
-
-/**
- * Get file extension for syntax highlighting
-**/
-export const getFileExtension = (filename: string): string => {
-    const idx = filename.lastIndexOf('.');
-
-    if (idx === -1) return 'text';
-
-    const ext = filename.slice(idx + 1).toLowerCase();
-
-    return fileTypes[ext] || ext || 'text';
+export const clearFileContexts = (): void => {
+    clearStoredFileContexts();
 };
 
 /**
@@ -120,13 +109,7 @@ export async function showFileContexts(nvim: NeovimClient): Promise<void> {
         return;
     }
 
-    const summaries = fileContexts.map(ctx => {
-        const fileName = ctx.filePath.split('/').pop() || ctx.filePath;
-
-        return ctx.isPartial
-            ? `${fileName} (${ctx.startLine === ctx.endLine ? `line ${ctx.startLine}` : `lines ${ctx.startLine}-${ctx.endLine}`})`
-            : `${fileName} (full file)`;
-    });
+    const summaries = fileContexts.map((context) => formatContextSummary(context));
 
     await nvim.command(`echohl MoreMsg | echo "Loaded contexts: ${summaries.join(', ')}" | echohl None`);
 }
@@ -194,7 +177,7 @@ export async function handleRemoveFileContext(nvim: NeovimClient): Promise<void>
 
         if (selectedIndex >= 0 && selectedIndex < fileContexts.length) {
             const removedContext = fileContexts.splice(selectedIndex, 1)[0];
-            const fileName = removedContext.filePath.split('/').pop() || removedContext.filePath;
+            const fileName = getContextFileName(removedContext.filePath);
             await nvim.command(`echohl MoreMsg | echo "Removed context: ${fileName}" | echohl None`);
             await showFileContextsPopup(nvim);
         } else {
@@ -219,21 +202,8 @@ export async function showFileContextsPopup(nvim: NeovimClient): Promise<void> {
     const popupLines: string[] = ['📁 Active File Contexts:', '', '💡 Tip: press "r" to remove files from the context', ''];
 
     for (const [index, context] of fileContexts.entries()) {
-        const fileName = context.filePath.split('/').pop() || context.filePath;
-
-        if (context.isPartial) {
-            const lineRange = context.startLine === context.endLine ? `line ${context.startLine}` : `lines ${context.startLine}-${context.endLine}`;
-            popupLines.push(`${index + 1}. 📄 ${fileName} (${lineRange})`, `   ${context.filePath}`, '');
-        } else {
-            try {
-                const content = await fs.readFile(context.filePath, 'utf-8');
-                const lineCount = content.split('\n').length;
-                const sizeKB = Math.round(content.length / 1024);
-                popupLines.push(`${index + 1}. 📁 ${fileName} (${lineCount} lines, ${sizeKB}KB)`, `   ${context.filePath}`, '');
-            } catch (_error) {
-                popupLines.push(`${index + 1}. ❌ ${fileName} (error reading file)`, `   ${context.filePath}`, '');
-            }
-        }
+        const entryLines = await formatContextPopupEntry(context, index);
+        popupLines.push(...entryLines);
     }
 
     popupLines.push('Press any key to close...');


### PR DESCRIPTION
extract shared stdio MCP runtime runStdioMcpServer and migrate bash/web/file-context/memory/session-complete servers to it add shared MCP wiring serverConfig and executable tool bridge used by both BYOK and Copilot sessions split prompt action handling into agentPromptActionDispatch and introduce a shared conversation boundary with file-context store/display modules trim AGENT.md and move detailed content into docs/agent/* add coverage for stdio runtime, executable tool bridge, provider integration, prompt action dispatch and conversation boundary contract