### PR TITLE
feat!: package tool

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,94 @@
+name: publish
+
+# publishes kra-workflow to npm on every push to main, using conventional commits
+# since the last git tag to decide the version bump:
+#   feat!: / fix!: / any "BREAKING CHANGE" in body  -> major
+#   feat:                                            -> minor
+#   fix:                                             -> patch
+#   anything else                                    -> no publish
+# No bump commit is pushed back to main — only a lightweight git tag (vX.Y.Z).
+# Tags don't trigger this workflow, so there's no loop and no bot commit clutter.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write   # needed to push the version tag
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need full history to read commits since last tag
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Decide version bump from conventional commits
+        id: bump
+        run: |
+          set -euo pipefail
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="${LAST_TAG}..HEAD"
+            BASE_VERSION="${LAST_TAG#v}"
+          else
+            RANGE="HEAD"
+            BASE_VERSION="$(node -p "require('./package.json').version")"
+          fi
+
+          MSGS=$(git log --format='%B%n---' "$RANGE")
+          BUMP=""
+          if echo "$MSGS" | grep -qE '^(feat|fix)(\([^)]+\))?!:|BREAKING CHANGE'; then
+            BUMP=major
+          elif echo "$MSGS" | grep -qE '^feat(\([^)]+\))?:'; then
+            BUMP=minor
+          elif echo "$MSGS" | grep -qE '^fix(\([^)]+\))?:'; then
+            BUMP=patch
+          fi
+
+          if [ -z "$BUMP" ]; then
+            echo "No conventional commits since ${LAST_TAG:-<root>}; skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IFS='.' read -r MAJ MIN PAT <<< "$BASE_VERSION"
+          case "$BUMP" in
+            major) MAJ=$((MAJ+1)); MIN=0; PAT=0 ;;
+            minor) MIN=$((MIN+1)); PAT=0 ;;
+            patch) PAT=$((PAT+1)) ;;
+          esac
+          NEW="${MAJ}.${MIN}.${PAT}"
+          echo "Bumping ${BASE_VERSION} -> ${NEW} (${BUMP})"
+          echo "version=${NEW}" >> "$GITHUB_OUTPUT"
+          echo "bump=${BUMP}"     >> "$GITHUB_OUTPUT"
+
+      - name: Set version in package.json (no commit)
+        if: steps.bump.outputs.skip != 'true'
+        run: npm pkg set version=${{ steps.bump.outputs.version }}
+
+      - name: Publish to npm
+        if: steps.bump.outputs.skip != 'true'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag the release
+        if: steps.bump.outputs.skip != 'true'
+        run: |
+          git tag "v${{ steps.bump.outputs.version }}"
+          git push origin "v${{ steps.bump.outputs.version }}"

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,38 +1,109 @@
 # Installation
 
-> ⚙️ Work in Progress — This project is currently under development.
-
 ## 📦 Prerequisites
 
 Make sure you have the following installed:
 
-- [Node.js](https://nodejs.org/) (v16 or higher)
+- [Node.js](https://nodejs.org/) (v18 or higher)
 - [npm](https://www.npmjs.com/)
 - [Git](https://git-scm.com/)
 - [Neovim](https://neovim.io/)
 - [Tmux](https://github.com/tmux/tmux/wiki/Installing)
 - [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim)
 
-## 🚀 Getting Started
+## 🚀 Install
 
-### Clone the repository:
+### From npm (recommended)
 
-SSH:
 ```bash
-git clone git@github.com:ChrisRistoff/kra-tmux.git
+npm install -g kra-workflow
 ```
 
-HTTPS:
+> **Avoid `sudo`.** If your global npm prefix isn't writable (default on
+> Homebrew/Linux), either use a Node version manager like
+> [nvm](https://github.com/nvm-sh/nvm) / [fnm](https://github.com/Schniz/fnm),
+> or point npm at a user dir: `npm config set prefix ~/.npm-global` and add
+> `~/.npm-global/bin` to your `PATH`. Then `npm install -g kra-workflow` runs
+> entirely under your home directory — no root, no surprises.
+
+The `npm install` runs a postinstall step that does the heavy lifting:
+
+1. Creates `~/.kra/` with the standard layout (`settings.toml`, `git-files/`,
+   `tmux-files/`, `ai-files/`, `system-files/`, `lock-files/`, `model-catalog/`,
+   `cache/`).
+2. Copies a default `settings.toml` from the package template if one isn't already present.
+3. Appends `source <package>/automationScripts/source-all.sh` to your `~/.bashrc`
+   and `~/.zshrc` (idempotent).
+4. Installs `neovimHooks.lua` into `~/.config/nvim/lua/` and adds
+   `require("neovimHooks")` to `~/.config/nvim/init.lua` (idempotent).
+5. If `~/programming/kra-tmux/` exists and `~/.kra/` is being created for the
+   first time, copies your existing data into `~/.kra/`. Originals are NOT
+   removed.
+6. Touches `~/.kra/.installed` so future installs/runs skip the heavy work.
+
+Restart your shell (or `source ~/.bashrc` / `source ~/.zshrc`) afterwards so
+the shell autocompletion and tmux/neovim hooks become active. Then run `kra`.
+
+> **Note on `sudo npm install -g`** — when run as root the installer detects
+> `SUDO_USER` and resolves the invoking user's real home directory, so dotfiles
+> still land in the right place.
+>
+> **Note on `npm install --ignore-scripts`** — if you skip postinstall, the
+> first invocation of any `kra` command will detect the missing `~/.kra/.installed`
+> marker and run setup automatically. You can also re-trigger it manually by
+> reinstalling the package or running `node $(npm root -g)/kra-workflow/bin/postinstall.js`.
+
+### From source
+
 ```bash
 git clone https://github.com/ChrisRistoff/kra-tmux.git
-```
-
-### Run:
-```bash
 cd kra-tmux
-npm i -g
+npm install
+npm run build       # compiles TypeScript into dest/
+npm install -g .    # link the local build globally as `kra`
+kra                 # triggers first-run setup
 ```
 
-You are good to go.
+## 🗂️ Filesystem layout
 
-Tool is available as an NPM package under the name **kra-cli**, not updated regularly so chances are you will not get the latest version installing it as one.
+User data (override the root with `KRA_HOME=/some/dir`):
+
+```
+~/.kra/
+├── settings.toml          # main config
+├── git-files/             # untracked-files store for git workflow
+├── tmux-files/            # tmux + neovim session snapshots
+├── ai-files/              # chat history + lua helpers
+├── system-files/          # custom scripts
+├── lock-files/            # autosave coordination
+├── model-catalog/         # cached model lists per AI provider
+├── cache/fastembed/       # embedding model cache
+├── quota-cache.json       # AI agent quota snapshots
+└── .installed             # first-run marker
+```
+
+Per-repo memory (independent of `~/.kra`): each repo using the AI agent gets a
+`<repo>/.kra-memory/` LanceDB store, registered globally in
+`~/.kra-memory/registry.json`.
+
+## 🛠️ Commands
+
+- `kra` — show the main menu.
+
+Setup is fully automatic — it runs via npm `postinstall`, with a fallback on
+the first `kra` invocation if the postinstall step was skipped.
+
+## 🧪 Troubleshooting
+
+- **Autocompletion not working** — re-source your shell rc or open a new shell.
+- **Hook didn't load in nvim** — check that `~/.config/nvim/init.lua` ends with
+  `require("neovimHooks")` and that `KRA_PACKAGE_ROOT` is set in your shell env
+  (it is exported by `automationScripts/source-all.sh`, which the installer
+  added to your shell rc).
+- **Setup didn't run / want to re-run** — delete `~/.kra/.installed` and run
+  any `kra` command again (the first-run fallback re-creates the skeleton, copies
+  defaults, and patches your shell rc + nvim config). Your data under `~/.kra/`
+  is preserved; only the marker is touched.
+- **Want a portable layout** — set `KRA_HOME` (e.g. in a dotfiles repo) before
+  running any `kra` command.
+

--- a/README.md
+++ b/README.md
@@ -432,20 +432,39 @@ kra sys
 - **Zsh/Bash** shell environment
 
 ### ⚡ **Quick Installation**
+
+Install the published package globally:
+
 ```bash
-# Clone and setup
-git clone <repository-url>
-cd kra-workflow
+npm install -g kra-workflow
 
-# Install dependencies and configure integrations
-npm install -g
+# postinstall auto-creates ~/.kra/, copies a default settings.toml,
+# and patches your ~/.bashrc / ~/.zshrc / nvim init.lua.
 
-# Verify installation
+# Restart your shell (or `source ~/.bashrc`) to pick up the autocompletion
+# and tmux/neovim hooks, then run `kra`.
 kra
 ```
 
+Or install from a clone:
+
+```bash
+git clone https://github.com/ChrisRistoff/kra-tmux.git
+cd kra-tmux
+npm install
+npm run build
+npm install -g .
+kra
+```
+
+User data lives under `~/.kra/` by default. Override with `KRA_HOME=/path/to/dir`.
+If you previously had the project at `~/programming/kra-tmux/`, the first install
+will copy `settings.toml`, `git-files/`, `tmux-files/`, `ai-files/`,
+`system-files/`, and `lock-files/` from there into `~/.kra/` (originals are
+left in place).
+
 ### 📚 **Detailed Setup**
-For comprehensive installation instructions, environment configuration, and troubleshooting guides, please refer to our **[Installation Guide](installation.md)**.
+For comprehensive installation instructions, environment configuration, and troubleshooting guides, please refer to our **[Installation Guide](INSTALLATION.md)**.
 
 ---
 

--- a/__tests__/AI/shared/modelCatalog.test.ts
+++ b/__tests__/AI/shared/modelCatalog.test.ts
@@ -87,7 +87,7 @@ describe('modelCatalog', () => {
 
             await getModelCatalog('open-router', { forceRefresh: true });
 
-            const cacheFile = path.join(tmpHome, '.config', 'kra-tmux', 'model-catalog', 'open-router.json');
+            const cacheFile = path.join(tmpHome, '.kra', 'model-catalog', 'open-router.json');
 
             expect(fs.existsSync(cacheFile)).toBe(true);
 

--- a/automationScripts/autosave/autoSaveManager.ts
+++ b/automationScripts/autosave/autoSaveManager.ts
@@ -1,8 +1,8 @@
 import 'module-alias/register';
-import os from 'os';
 import { lockFileExist, LockFiles, oneOfMultipleLocksExist } from '../../eventSystem/lockFiles';
 import { loadSettings } from '@/utils/common';
 import { createIPCClient, IPCClient, IPCsockets } from '../../eventSystem/ipc';
+import { autosaveJsPath } from '@/packagePaths';
 
 async function main() {
     if (
@@ -25,9 +25,7 @@ async function main() {
 
 async function ensureServerRunning(client: IPCClient): Promise<void> {
     if (!await lockFileExist(LockFiles.AutoSaveInProgress)) {
-        const script = `${'~/programming/kra-tmux/dest/automationScripts/autosave/autosave.js'.replace('~', os.homedir())}`;
-
-        return await client.ensureServerRunning(script);
+        return await client.ensureServerRunning(autosaveJsPath);
     }
 }
 

--- a/automationScripts/hooks/neovimHooks.lua
+++ b/automationScripts/hooks/neovimHooks.lua
@@ -1,6 +1,19 @@
 local function setup_autosave()
-    local home = vim.fn.expand("~")
-    local script_path = home .. "/programming/kra-tmux/dest/automationScripts/autosave/autoSaveManager.js"
+    local pkg_root = vim.env.KRA_PACKAGE_ROOT
+    if not pkg_root or pkg_root == "" then
+        -- Fallback: derive from this file's location (.../automationScripts/hooks/neovimHooks.lua
+        -- when sourced directly from the package; or .../.config/nvim/lua/neovimHooks.lua
+        -- when copied during `kra init`). The copied case has no usable hint, so we
+        -- only use the derivation when the file lives under an automationScripts/ tree.
+        local source_path = debug.getinfo(1, "S").source:sub(2)
+        local maybe_root = source_path:match("^(.*)/automationScripts/hooks/neovimHooks%.lua$")
+        if maybe_root then pkg_root = maybe_root end
+    end
+    if not pkg_root or pkg_root == "" then
+        print("Autosave: KRA_PACKAGE_ROOT not set; skipping nvim autosave hook.")
+        return
+    end
+    local script_path = pkg_root .. "/dest/automationScripts/autosave/autoSaveManager.js"
 
     if vim.fn.filereadable(script_path) == 0 then
         print("Autosave: Script not found at " .. script_path)

--- a/automationScripts/hooks/tmuxHooks.sh
+++ b/automationScripts/hooks/tmuxHooks.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-UPDATE_SCRIPT="$HOME/programming/kra-tmux/dest/automationScripts/autosave/autoSaveManager.js"
+if [[ -z "$KRA_PACKAGE_ROOT" ]]; then
+    echo "tmuxHooks.sh: KRA_PACKAGE_ROOT not set; source kra-workflow's source-all.sh first." >&2
+    return 1 2>/dev/null || exit 1
+fi
+UPDATE_SCRIPT="$KRA_PACKAGE_ROOT/dest/automationScripts/autosave/autoSaveManager.js"
 
 # session hooks
 tmux set-hook -u session-created

--- a/automationScripts/source-all.sh
+++ b/automationScripts/source-all.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
-chmod +x $HOME/programming/kra-tmux/automationScripts/autocomplete/autocomplete.sh
-chmod +x $HOME/programming/kra-tmux/automationScripts/hooks/tmuxHooks.sh
-chmod +x $HOME/programming/kra-tmux/automationScripts/hooks/attachTmuxSession.sh
+# Resolve the kra-workflow package root from this script's own location.
+if [ -n "${BASH_SOURCE[0]}" ]; then
+    _kra_self="${BASH_SOURCE[0]}"
+elif [ -n "${ZSH_VERSION-}" ]; then
+    _kra_self="${(%):-%x}"
+else
+    _kra_self="$0"
+fi
+export KRA_PACKAGE_ROOT="$(cd "$(dirname "$_kra_self")/.." && pwd)"
+unset _kra_self
 
-source "$HOME/programming/kra-tmux/automationScripts/autocomplete/autocomplete.sh"
-source "$HOME/programming/kra-tmux/automationScripts/hooks/tmuxHooks.sh"
-source "$HOME/programming/kra-tmux/automationScripts/hooks/attachTmuxSession.sh"
+chmod +x "$KRA_PACKAGE_ROOT/automationScripts/autocomplete/autocomplete.sh"
+chmod +x "$KRA_PACKAGE_ROOT/automationScripts/hooks/tmuxHooks.sh"
+chmod +x "$KRA_PACKAGE_ROOT/automationScripts/hooks/attachTmuxSession.sh"
+
+source "$KRA_PACKAGE_ROOT/automationScripts/autocomplete/autocomplete.sh"
+source "$KRA_PACKAGE_ROOT/automationScripts/hooks/tmuxHooks.sh"
+source "$KRA_PACKAGE_ROOT/automationScripts/hooks/attachTmuxSession.sh"

--- a/bin/kra.js
+++ b/bin/kra.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const moduleAlias = require('module-alias');
+
+// Resolve @/* to the compiled source dir relative to THIS bin script, not cwd.
+// This is the only reliable way for a globally-installed CLI: module-alias's
+// auto-discovery walks up from process.cwd() and finds the wrong package.json
+// when the consumer runs us from inside another project.
+const pkgRoot = path.resolve(__dirname, '..');
+moduleAlias.addAliases({
+    '@': path.join(pkgRoot, 'dest', 'src'),
+});
+
+require(path.join(pkgRoot, 'dest', 'src', 'main.js'));

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+'use strict';
+
+// npm postinstall entrypoint. Mirrors bin/kra.js so module-alias can find @/*.
+// Wrapped in try/catch so a setup failure NEVER breaks `npm install`.
+
+const path = require('path');
+
+try {
+    const moduleAlias = require('module-alias');
+    const pkgRoot = path.resolve(__dirname, '..');
+    moduleAlias.addAliases({ '@': path.join(pkgRoot, 'dest', 'src') });
+
+    // npm runs postinstall under the invoking user's HOME unless `sudo` was used.
+    // When sudo'd globally, HOME is root's; redirect to the real user when possible
+    // so we don't litter /root or /var/root with dotfiles.
+    if (process.getuid && process.getuid() === 0 && process.env.SUDO_USER) {
+        const { execSync } = require('child_process');
+        try {
+            const realHome = execSync(`/usr/bin/env getent passwd ${process.env.SUDO_USER} 2>/dev/null || dscl . -read /Users/${process.env.SUDO_USER} NFSHomeDirectory 2>/dev/null`).toString();
+            const match = realHome.match(/(?:^[^:]+:[^:]*:[^:]*:[^:]*:[^:]*:)([^:\n]+)|NFSHomeDirectory:\s*(\S+)/);
+            const home = match && (match[1] || match[2]);
+            if (home) {
+                process.env.HOME = home;
+                console.log(`[kra-workflow] running setup as root; targeting HOME=${home} (SUDO_USER=${process.env.SUDO_USER})`);
+            }
+        } catch {
+            // best-effort only
+        }
+    }
+
+    const { runInstall } = require(path.join(pkgRoot, 'dest', 'src', 'setup', 'install.js'));
+    runInstall();
+} catch (err) {
+    console.warn('[kra-workflow] postinstall setup skipped:', err && err.message ? err.message : err);
+    console.warn('[kra-workflow] run any `kra` command to retry setup, or reinstall the package.');
+}

--- a/package.json
+++ b/package.json
@@ -1,20 +1,34 @@
 {
-    "name": "kra-cli",
+    "name": "kra-workflow",
     "_moduleAliases": {
         "@": "dest/src"
     },
-    "version": "1.0.2",
-    "description": "A cli helper for tmux and git, for now",
+    "version": "2.0.0",
+    "description": "CLI for tmux session management, git workflow helpers, and an AI agent layer.",
+    "keywords": ["tmux", "cli", "workflow", "git", "ai", "agent", "productivity"],
+    "engines": {
+        "node": ">=18"
+    },
     "bin": {
-        "kra": "dest/src/main.js"
+        "kra": "bin/kra.js"
     },
     "preferGlobal": true,
     "files": [
+        "bin",
         "dest",
-        "src"
+        "automationScripts",
+        "ai-files/init.lua",
+        "ai-files/lua",
+        "settings.toml.example",
+        "start.js",
+        "README.md",
+        "LICENSE.md",
+        "AGENT.md"
     ],
     "scripts": {
-        "postinstall": "tsc && node ./dest/automationScripts/automate.js",
+        "build": "tsc",
+        "prepublishOnly": "rm -rf dest && tsc",
+        "postinstall": "node bin/postinstall.js",
         "lint": "eslint --fix",
         "test": "jest"
     },

--- a/src/AI/AIAgent/commands/showQuota.ts
+++ b/src/AI/AIAgent/commands/showQuota.ts
@@ -1,7 +1,9 @@
-import os from 'os';
-import path from 'path';
 import fs from 'fs/promises';
+import path from 'path';
 import { getGithubToken } from '@/AI/AIAgent/shared/utils/agentSettings';
+import { kraHome } from '@/filePaths';
+
+const quotaCachePath = (): string => path.join(kraHome(), 'quota-cache.json');
 
 interface QuotaSnapshot {
     percent_remaining: number;
@@ -30,7 +32,6 @@ interface QuotaCache {
     snapshots: Record<string, CachedQuotaSnapshot>;
 }
 
-const QUOTA_CACHE_PATH = path.join(os.homedir(), '.local', 'share', 'kra-tmux', 'quota-cache.json');
 const SESSION_SNAPSHOT_KEYS = new Set(['weekly', 'session']);
 
 function buildBar(percentRemaining: number, width = 30): string {
@@ -70,7 +71,7 @@ function formatCachedSnapshot(name: string, snap: CachedQuotaSnapshot, updatedAt
 
 async function readQuotaCache(): Promise<QuotaCache | null> {
     try {
-        return JSON.parse(await fs.readFile(QUOTA_CACHE_PATH, 'utf8')) as QuotaCache;
+        return JSON.parse(await fs.readFile(quotaCachePath(), 'utf8')) as QuotaCache;
     } catch {
         return null;
     }

--- a/src/AI/AIAgent/shared/memory/embedder.ts
+++ b/src/AI/AIAgent/shared/memory/embedder.ts
@@ -8,9 +8,9 @@
  */
 
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { EmbeddingModel, FlagEmbedding } from 'fastembed';
+import { kraHome } from '@/filePaths';
 
 const MODEL = EmbeddingModel.BGESmallENV15;
 export const VECTOR_DIM = 384;
@@ -25,7 +25,7 @@ function defaultCacheDir(): string {
         return override;
     }
 
-    return path.join(os.homedir(), '.cache', 'kra-tmux', 'fastembed');
+    return path.join(kraHome(), 'cache', 'fastembed');
 }
 
 async function loadModel(): Promise<FlagEmbedding> {

--- a/src/AI/AIAgent/shared/memory/settings.ts
+++ b/src/AI/AIAgent/shared/memory/settings.ts
@@ -9,11 +9,10 @@
  * MCP server child. Both share the same defaults.
  */
 
-import os from 'os';
-import path from 'path';
 import fs from 'fs/promises';
 import * as toml from 'smol-toml';
 import type { MemorySettings } from './types';
+import { settingsFilePath } from '@/filePaths';
 
 const DEFAULT_INCLUDE_EXTENSIONS = [
     '.ts', '.tsx', '.mts', '.cts',
@@ -70,8 +69,7 @@ export async function loadMemorySettings(): Promise<MemorySettings> {
     let raw: RawMemorySettings = {};
 
     try {
-        const settingsPath = path.join(os.homedir(), 'programming', 'kra-tmux', 'settings.toml');
-        const content = await fs.readFile(settingsPath, 'utf8');
+        const content = await fs.readFile(settingsFilePath, 'utf8');
         const parsed = toml.parse(content) as { ai?: { agent?: { memory?: RawMemorySettings } } };
         const memory = parsed.ai?.agent?.memory;
 

--- a/src/AI/AIAgent/shared/utils/agentQuotaTracker.ts
+++ b/src/AI/AIAgent/shared/utils/agentQuotaTracker.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs/promises';
-import os from 'os';
 import path from 'path';
 import type { AgentConversationState } from '@/AI/AIAgent/shared/types/agentTypes';
+import { kraHome } from '@/filePaths';
 
 const QUOTA_WARN_THRESHOLDS = [50, 25, 10];
-const QUOTA_CACHE_PATH = path.join(os.homedir(), '.local', 'share', 'kra-tmux', 'quota-cache.json');
+const quotaCachePath = (): string => path.join(kraHome(), 'quota-cache.json');
 
 /**
  * Listen for `assistant.usage` events on the session, persist quota snapshots
@@ -28,8 +28,9 @@ export function setupQuotaTracking(state: AgentConversationState): void {
             };
         }
 
-        fs.mkdir(path.dirname(QUOTA_CACHE_PATH), { recursive: true })
-            .then(async () => fs.writeFile(QUOTA_CACHE_PATH, JSON.stringify({ updatedAt: new Date().toISOString(), snapshots: cache }, null, 2)))
+        const cachePath = quotaCachePath();
+        fs.mkdir(path.dirname(cachePath), { recursive: true })
+            .then(async () => fs.writeFile(cachePath, JSON.stringify({ updatedAt: new Date().toISOString(), snapshots: cache }, null, 2)))
             .catch(() => { /* non-critical */ });
 
         for (const [quotaId, snap] of Object.entries(snapshots)) {

--- a/src/AI/shared/data/modelCatalog.ts
+++ b/src/AI/shared/data/modelCatalog.ts
@@ -7,7 +7,7 @@
  * endpoint does not include such metadata, a small static fallback table fills
  * in the well-known values.
  *
- * Results are cached on disk under `~/.config/kra-tmux/model-catalog/<provider>.json`
+ * Results are cached on disk under `~/.kra/model-catalog/<provider>.json`
  * with a 24-hour TTL. On network failure we return the most recently cached
  * snapshot (even if expired) and only fall through to the built-in static
  * lists if no cache exists.
@@ -19,8 +19,8 @@
  */
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
+import { kraHome } from '@/filePaths';
 import {
     type SupportedProvider,
     getProviderApiKey,
@@ -55,7 +55,7 @@ interface CacheEntry {
 }
 
 function cacheDir(): string {
-    return path.join(os.homedir(), '.config', 'kra-tmux', 'model-catalog');
+    return path.join(kraHome(), 'model-catalog');
 }
 
 function cachePath(provider: SupportedProvider): string {

--- a/src/filePaths.ts
+++ b/src/filePaths.ts
@@ -1,31 +1,46 @@
 import os from 'os';
 import path from 'path';
 
-const homeDir = os.homedir();
-const projectRoot = path.join(homeDir, 'programming', 'kra-tmux');
+/**
+ * Resolves the user-data root for kra-workflow. Defaults to ~/.kra; can be
+ * overridden by setting the KRA_HOME environment variable (useful for
+ * dotfiles repos or testing).
+ */
+export function kraHome(): string {
+    return process.env.KRA_HOME || path.join(os.homedir(), '.kra');
+}
+
+const root = kraHome();
 
 //settings
-export const settingsFilePath = path.join(projectRoot, 'settings.toml');
+export const settingsFilePath = path.join(root, 'settings.toml');
 
 // git
-export const gitFilesFolder = path.join(projectRoot, 'git-files');
+export const gitFilesFolder = path.join(root, 'git-files');
 
 // tmux
-export const sessionFilesFolder = path.join(projectRoot, 'tmux-files/sessions');
+export const sessionFilesFolder = path.join(root, 'tmux-files', 'sessions');
 
 // nvim
-export const nvimSessionsPath = path.join(projectRoot, 'tmux-files/nvim-sessions');
+export const nvimSessionsPath = path.join(root, 'tmux-files', 'nvim-sessions');
 
 // ai
-export const aiHistoryPath = path.join(projectRoot, 'ai-files/chat-history');
-export const neovimConfig = path.join(projectRoot, 'ai-files/init.lua');
+export const aiHistoryPath = path.join(root, 'ai-files', 'chat-history');
+
+// Agent neovim UI (init.lua + lua/) ships with the package — see packagePaths.
+export { aiInitLuaPath as neovimConfig, aiLuaDir } from './packagePaths';
 
 // system
-export const systemFilesPath = path.join(projectRoot, 'system-files');
-export const systemScriptsPath = path.join(projectRoot, 'system-files', 'scripts');
+export const systemFilesPath = path.join(root, 'system-files');
+export const systemScriptsPath = path.join(root, 'system-files', 'scripts');
 
 // lock
-export const lockFilesPath = path.join(projectRoot, 'lock-files');
+export const lockFilesPath = path.join(root, 'lock-files');
 
-// worker
-export const loadSessionWorkerPath = path.join(projectRoot, 'src/tmux/workers/loadSessionWorker.js');
+// AI paths consolidated under ~/.kra (previously under ~/.config, ~/.cache, ~/.local/share)
+export const modelCatalogDir = path.join(root, 'model-catalog');
+export const fastembedCacheDir = path.join(root, 'cache', 'fastembed');
+export const quotaCachePath = path.join(root, 'quota-cache.json');
+
+// Re-export for backwards compatibility — actual location is packagePaths.ts
+export { loadSessionWorkerPath } from './packagePaths';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import 'module-alias/register';
 import { aiCommands, handleAiCommandNotExist } from '@/commandsMaps/aiCommands';
 import { gitCommands, handleGitCommandNotExist } from '@/commandsMaps/gitCommands';
 import { handleTmuxCommandNotExist , tmuxCommands } from '@/commandsMaps/tmuxCommands';
@@ -9,6 +8,7 @@ import { handleChangeSettings } from '@/manageSettings';
 import { SystemCommands, TmuxCommands, GitCommands, AiCommands, Command } from '@/commandsMaps/types/commandTypes';
 import { workflowAscii } from '@/data/workflow-ascii';
 import { UserCancelled } from '@/UI/menuChain';
+import { runInstall, isInstalled } from '@/setup/install';
 
 const main = async (): Promise<void> => {
     const args = process.argv.slice(2);
@@ -17,6 +17,12 @@ const main = async (): Promise<void> => {
         console.log(workflowAscii);
         process.exit(1);
     }
+
+
+    if (!isInstalled()) {
+        runInstall();
+    }
+
 
     const commandType = args[0];
     let commandName = args[1];
@@ -44,6 +50,11 @@ const main = async (): Promise<void> => {
             await handleChangeSettings();
 
             return;
+        case 'init':
+        case 'migrate':
+            console.log(`'${commandType}' is no longer a kra subcommand. Setup runs automatically via npm postinstall (and on first run as a fallback).`);
+            console.log('To force re-run setup: delete ~/.kra/.installed and run any kra command again, or reinstall the package.');
+            process.exit(1);
         default:
             console.log(workflowAscii);
             console.table({[`${commandType}`]: 'Is not a valid command'});

--- a/src/packagePaths.ts
+++ b/src/packagePaths.ts
@@ -1,0 +1,62 @@
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * Resolves to the installed kra-workflow package root (the directory that
+ * contains package.json). At runtime this file lives at
+ * `<pkgRoot>/dest/src/packagePaths.js`, so we walk up two directories.
+ *
+ * We verify by checking for package.json — guards against odd symlink layouts.
+ */
+function resolvePackageRoot(): string {
+    const candidate = path.resolve(__dirname, '..', '..');
+    if (fs.existsSync(path.join(candidate, 'package.json'))) {
+        return candidate;
+    }
+
+    let dir = __dirname;
+    for (let i = 0; i < 6; i++) {
+        if (fs.existsSync(path.join(dir, 'package.json'))) {
+            return dir;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+    }
+
+    return candidate;
+}
+
+const PACKAGE_ROOT = resolvePackageRoot();
+
+export function packageRoot(): string {
+    return PACKAGE_ROOT;
+}
+
+export function assetPath(...segments: string[]): string {
+    return path.join(PACKAGE_ROOT, ...segments);
+}
+
+// Worker scripts (compiled JS shipped under dest/)
+export const loadSessionWorkerPath = assetPath('dest', 'src', 'tmux', 'workers', 'loadSessionWorker.js');
+
+// Automation script directory (raw .sh, .lua source ships in the package tarball)
+export const automationScriptsDir = assetPath('automationScripts');
+export const sourceAllShPath = path.join(automationScriptsDir, 'source-all.sh');
+export const autocompleteShPath = path.join(automationScriptsDir, 'autocomplete', 'autocomplete.sh');
+export const tmuxHooksShPath = path.join(automationScriptsDir, 'hooks', 'tmuxHooks.sh');
+export const attachTmuxSessionShPath = path.join(automationScriptsDir, 'hooks', 'attachTmuxSession.sh');
+export const neovimHooksLuaPath = path.join(automationScriptsDir, 'hooks', 'neovimHooks.lua');
+
+// AI agent neovim UI (init.lua + lua/ siblings) — shipped as package assets.
+// init.lua resolves its own dir via debug.getinfo, so package.path picks up lua/ automatically.
+export const aiFilesDir = assetPath('ai-files');
+export const aiInitLuaPath = path.join(aiFilesDir, 'init.lua');
+export const aiLuaDir = path.join(aiFilesDir, 'lua');
+
+// Compiled autosave entry points
+export const autoSaveManagerJsPath = assetPath('dest', 'automationScripts', 'autosave', 'autoSaveManager.js');
+export const autosaveJsPath = assetPath('dest', 'automationScripts', 'autosave', 'autosave.js');
+
+// Default settings template that ships with the package
+export const settingsExamplePath = assetPath('settings.toml.example');

--- a/src/setup/install.ts
+++ b/src/setup/install.ts
@@ -1,0 +1,160 @@
+/**
+ * First-run installer for kra-workflow.
+ *
+ * Idempotent. Performs:
+ *   1. Create ~/.kra/ skeleton
+ *   2. Migrate from legacy ~/programming/kra-tmux/ if present and ~/.kra is fresh
+ *   3. Drop in default settings.toml from settings.toml.example if missing
+ *   4. Patch ~/.bashrc and ~/.zshrc with `source <pkg>/automationScripts/source-all.sh`
+ *   5. Copy neovimHooks.lua into ~/.config/nvim/lua/ and require it from init.lua
+ *   6. Touch ~/.kra/.installed marker so future runs skip the heavy work
+ *
+ * Safe to re-run; nothing is overwritten.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { kraHome } from '@/filePaths';
+import { packageRoot, sourceAllShPath, neovimHooksLuaPath, settingsExamplePath } from '@/packagePaths';
+
+const LEGACY_PROJECT_ROOT = path.join(os.homedir(), 'programming', 'kra-tmux');
+
+function copyDirRecursive(src: string, dest: string): void {
+    if (!fs.existsSync(src)) return;
+    fs.mkdirSync(dest, { recursive: true });
+    for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+        const s = path.join(src, entry.name);
+        const d = path.join(dest, entry.name);
+        if (entry.isDirectory()) {
+            copyDirRecursive(s, d);
+        } else if (entry.isFile() && !fs.existsSync(d)) {
+            fs.copyFileSync(s, d);
+        }
+    }
+}
+
+function copyFileIfMissing(src: string, dest: string): void {
+    if (!fs.existsSync(src) || fs.existsSync(dest)) return;
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+}
+
+function appendLineIfMissing(filePath: string, line: string): boolean {
+    if (!fs.existsSync(filePath)) return false;
+    const content = fs.readFileSync(filePath, 'utf8');
+    if (content.includes(line)) return false;
+    fs.appendFileSync(filePath, `\n${line}\n`);
+
+    return true;
+}
+
+function ensureKraHomeSkeleton(home: string): boolean {
+    const created = !fs.existsSync(home);
+    const subdirs = [
+        '',
+        'git-files',
+        'tmux-files/sessions',
+        'tmux-files/nvim-sessions',
+        'ai-files/chat-history',
+        'ai-files/chat-history',
+        'system-files/scripts',
+        'lock-files',
+        'model-catalog',
+        'cache/fastembed',
+    ];
+
+    for (const sub of subdirs) {
+        fs.mkdirSync(path.join(home, sub), { recursive: true });
+    }
+
+    return created;
+}
+
+function migrateFromLegacy(home: string): void {
+    if (!fs.existsSync(LEGACY_PROJECT_ROOT)) return;
+    console.log(`[kra] migrating user data from ${LEGACY_PROJECT_ROOT} -> ${home}`);
+
+    const dirCopies: Array<[string, string]> = [
+        ['git-files', 'git-files'],
+        ['tmux-files', 'tmux-files'],
+        ['ai-files', 'ai-files'],
+        ['system-files', 'system-files'],
+        ['lock-files', 'lock-files'],
+    ];
+
+    for (const [src, dst] of dirCopies) {
+        copyDirRecursive(path.join(LEGACY_PROJECT_ROOT, src), path.join(home, dst));
+    }
+
+    copyFileIfMissing(path.join(LEGACY_PROJECT_ROOT, 'settings.toml'), path.join(home, 'settings.toml'));
+
+    const legacyModelCatalog = path.join(os.homedir(), '.config', 'kra-tmux', 'model-catalog');
+    const legacyFastembed = path.join(os.homedir(), '.cache', 'kra-tmux', 'fastembed');
+    const legacyQuotaCache = path.join(os.homedir(), '.local', 'share', 'kra-tmux', 'quota-cache.json');
+    copyDirRecursive(legacyModelCatalog, path.join(home, 'model-catalog'));
+    copyDirRecursive(legacyFastembed, path.join(home, 'cache', 'fastembed'));
+    copyFileIfMissing(legacyQuotaCache, path.join(home, 'quota-cache.json'));
+}
+
+function ensureDefaultSettings(home: string): void {
+    const target = path.join(home, 'settings.toml');
+    if (fs.existsSync(target)) return;
+    if (fs.existsSync(settingsExamplePath)) {
+        fs.copyFileSync(settingsExamplePath, target);
+        console.log(`[kra] wrote default settings.toml from template`);
+    }
+}
+
+function patchShellRcs(): void {
+    const sourceLine = `source ${sourceAllShPath}`;
+    for (const rc of [`${os.homedir()}/.bashrc`, `${os.homedir()}/.zshrc`]) {
+        if (appendLineIfMissing(rc, sourceLine)) {
+            console.log(`[kra] added kra-workflow source line to ${rc}`);
+        }
+    }
+}
+
+function patchNeovimConfig(): void {
+    const nvimLuaDir = path.join(os.homedir(), '.config', 'nvim', 'lua');
+    const nvimInit = path.join(os.homedir(), '.config', 'nvim', 'init.lua');
+    fs.mkdirSync(nvimLuaDir, { recursive: true });
+    const target = path.join(nvimLuaDir, 'neovimHooks.lua');
+    if (fs.existsSync(neovimHooksLuaPath)) {
+        fs.copyFileSync(neovimHooksLuaPath, target);
+    }
+    const requireLine = 'require("neovimHooks")';
+    if (fs.existsSync(nvimInit)) {
+        appendLineIfMissing(nvimInit, requireLine);
+    } else if (fs.existsSync(path.dirname(nvimInit))) {
+        fs.writeFileSync(nvimInit, `${requireLine}\n`);
+    }
+}
+
+export interface InstallOptions {
+    force?: boolean;
+}
+
+export function installedMarkerPath(home: string = kraHome()): string {
+    return path.join(home, '.installed');
+}
+
+export function isInstalled(): boolean {
+    return fs.existsSync(installedMarkerPath());
+}
+
+export function runInstall(opts: InstallOptions = {}): void {
+    const home = kraHome();
+    if (isInstalled() && !opts.force) return;
+
+    const fresh = ensureKraHomeSkeleton(home);
+    if (fresh) {
+        migrateFromLegacy(home);
+    }
+    ensureDefaultSettings(home);
+    patchShellRcs();
+    patchNeovimConfig();
+
+    fs.writeFileSync(installedMarkerPath(home), `installed-from=${packageRoot()}\nat=${new Date().toISOString()}\n`);
+    console.log('[kra] setup complete. Restart your shell (or `source ~/.bashrc`) to enable autocompletion.');
+}


### PR DESCRIPTION
add .github/workflows/publish.yml: tag-based, conventional-commits-driven auto-publish on push to main (feat!/BREAKING -> major, feat -> minor, fix -> patch, else skip)

restructure file paths, they now live in ~/.kra/
database lives in ~/.kra-memory/