### PR TITLE
feat: ai docs - add open-source documentation crawler/indexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ local_cache/
 
 .env
 settings.toml
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/AGENT.md
+++ b/AGENT.md
@@ -148,6 +148,7 @@ graph TB
 | Turn workflow, keymaps, tool-approval UX, diff review | [`docs/agent/workflow-and-keymaps.md`](docs/agent/workflow-and-keymaps.md) |
 | File-context tools, BYOK bash/web tools, MCP config | [`docs/agent/tools-and-mcp.md`](docs/agent/tools-and-mcp.md) |
 | Persistent memory, memory tools, indexing behavior | [`docs/agent/memory-and-indexing.md`](docs/agent/memory-and-indexing.md) |
-| Copilot-only skills and quota operations | [`docs/agent/copilot-operations.md`](docs/agent/copilot-operations.md) |
+| Persistent memory, memory tools, indexing behavior | [`docs/agent/memory-and-indexing.md`](docs/agent/memory-and-indexing.md) |
+| Documentation crawling (`kra ai docs`) | [`docs/agent/docs-crawling.md`](docs/agent/docs-crawling.md) |
 
 If you want to start coding quickly, open `docs/agent/README.md` first, then jump to the topical doc for the subsystem you are touching.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ kra ai
 
 **Agent-first coding workflow:**
 1. **Provider selection** — pick `copilot` (GitHub Copilot SDK) or `byok` (any OpenAI-compatible API)
-2. **Model selection** — live catalog with context window + pricing annotations; Copilot also picks a reasoning effort. Set `ai.agent.defaultModel` in `settings.toml` to skip the picker.
+2. **Model selection** — live catalog with context window + pricing annotations; Copilot also picks a reasoning effort.
 3. **Repo workspace** — the agent writes changes directly to your repo as uncommitted git diffs; nothing is staged automatically
 4. **Diff review in Neovim** — review the generated `git diff`, optionally edit the agent's proposed change in the 3-pane diff editor, then explicitly apply or reject
 5. **Per-file revert** — `<leader>s` opens session diff history with an `ORIG` entry per file so you can undo a single file at any time

--- a/__tests__/AI/AIAgent/agentSettings.test.ts
+++ b/__tests__/AI/AIAgent/agentSettings.test.ts
@@ -1,4 +1,4 @@
-import { getAgentDefaultModel, getConfiguredMcpServers } from '@/AI/AIAgent/shared/utils/agentSettings';
+import { getConfiguredMcpServers } from '@/AI/AIAgent/shared/utils/agentSettings';
 import { loadSettings } from '@/utils/common';
 
 jest.mock('@/utils/common', () => ({
@@ -10,27 +10,6 @@ describe('agentSettings', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-    });
-
-    it('returns the configured default model', async () => {
-        mockedLoadSettings.mockResolvedValue({
-            watchCommands: {
-                work: { active: false, watch: { windowName: '', command: '' } },
-                personal: { active: false, watch: { windowName: '', command: '' } },
-            },
-            autosave: {
-                active: true,
-                currentSession: 'session',
-                timeoutMs: 20000,
-            },
-            ai: {
-                agent: {
-                    defaultModel: 'gpt-5-mini',
-                },
-            },
-        });
-
-        await expect(getAgentDefaultModel()).resolves.toBe('gpt-5-mini');
     });
 
     it('maps only active MCP servers into SDK config', async () => {

--- a/__tests__/AI/AIAgent/docsIngest.test.ts
+++ b/__tests__/AI/AIAgent/docsIngest.test.ts
@@ -1,0 +1,182 @@
+import { buildDocChunks, ingestPage, pageHash } from '@/AI/AIAgent/shared/docs/ingest';
+import { chunkMarkdown } from '@/AI/AIAgent/shared/docs/chunker';
+import { embedMany } from '@/AI/AIAgent/shared/memory/embedder';
+import { getDocChunksTable } from '@/AI/AIAgent/shared/memory/db';
+
+jest.mock('@/AI/AIAgent/shared/memory/embedder', () => ({
+    embedMany: jest.fn(async (texts: string[]) => texts.map(() => [0.1, 0.2, 0.3])),
+}));
+
+jest.mock('@/AI/AIAgent/shared/memory/db', () => ({
+    getDocChunksTable: jest.fn(),
+}));
+
+const mockedEmbedMany = jest.mocked(embedMany);
+const mockedGetDocChunksTable = jest.mocked(getDocChunksTable);
+
+describe('chunkMarkdown', () => {
+    it('preserves heading hierarchy in sectionPath', () => {
+        const md = [
+            '# Top',
+            '',
+            'intro paragraph',
+            '',
+            '## Sub A',
+            '',
+            'body of sub a',
+            '',
+            '### Deep',
+            '',
+            'deep body',
+        ].join('\n');
+        const chunks = chunkMarkdown(md, { pageTitle: 'Page' });
+        expect(chunks.length).toBeGreaterThan(0);
+        const paths = chunks.map((c) => c.sectionPath);
+        expect(paths.some((p) => p.includes('Top'))).toBe(true);
+        expect(paths.some((p) => p.includes('Sub A'))).toBe(true);
+        expect(paths.some((p) => p.includes('Deep'))).toBe(true);
+        for (const c of chunks) {
+            expect(c.contentForEmbedding.startsWith('# ')).toBe(true);
+            expect(c.tokenCount).toBeGreaterThan(0);
+        }
+    });
+
+    it('keeps fenced code blocks atomic even when oversized', () => {
+        const big = Array.from({ length: 400 }, (_, i) => `code line ${i}`).join('\n');
+        const md = ['# H', '', '```ts', big, '```'].join('\n');
+        const chunks = chunkMarkdown(md, { maxTokens: 100 });
+        const codeChunk = chunks.find((c) => c.content.includes('```ts'));
+        expect(codeChunk).toBeDefined();
+        expect(codeChunk!.content).toContain('code line 399');
+    });
+
+    it('returns no chunks for empty markdown', () => {
+        expect(chunkMarkdown('   \n\n   ')).toEqual([]);
+    });
+});
+
+describe('buildDocChunks', () => {
+    it('produces stable, alias-prefixed ids and propagates section metadata', () => {
+        const md = [
+            '# Title',
+            '',
+            'Intro paragraph one.',
+            '',
+            '## Section One',
+            '',
+            'Body of section one.',
+            '',
+            '## Section Two',
+            '',
+            'Body of section two.',
+        ].join('\n');
+        const built = buildDocChunks({
+            alias: 'lancedb',
+            url: 'https://example.com/page',
+            title: 'Example',
+            markdown: md,
+            indexedAt: 1000,
+        });
+
+        expect(built.length).toBeGreaterThan(0);
+        for (const b of built) {
+            expect(b.row.id.startsWith('lancedb:')).toBe(true);
+            expect(b.row.sourceAlias).toBe('lancedb');
+            expect(b.row.url).toBe('https://example.com/page');
+            expect(b.row.indexedAt).toBe(1000);
+            expect(b.row.content.length).toBeGreaterThan(0);
+            expect(typeof b.row.sectionPath).toBe('string');
+            expect(b.row.tokenCount).toBeGreaterThan(0);
+            expect(b.contentForEmbedding.length).toBeGreaterThan(b.row.content.length);
+        }
+
+        const indices = built.map((b) => b.row.chunkIndex);
+        expect(indices).toEqual([...indices].sort((a, b) => a - b));
+        expect(new Set(indices).size).toBe(indices.length);
+    });
+
+    it('returns no chunks for whitespace-only markdown', () => {
+        const built = buildDocChunks({
+            alias: 'x',
+            url: 'https://x',
+            title: '',
+            markdown: '\n\n   \n',
+        });
+        expect(built).toEqual([]);
+    });
+});
+
+describe('pageHash', () => {
+    it('is stable for identical inputs and varies with content', () => {
+        expect(pageHash('hello')).toBe(pageHash('hello'));
+        expect(pageHash('hello')).not.toBe(pageHash('hello world'));
+    });
+});
+
+describe('ingestPage', () => {
+    beforeEach(() => {
+        mockedEmbedMany.mockClear();
+        mockedGetDocChunksTable.mockReset();
+    });
+
+    it('embeds chunks and adds them to an existing table after deleting prior rows for the url', async () => {
+        const added: unknown[][] = [];
+        let rowCount = 5;
+        const fakeTable = {
+            add: jest.fn(async (rows: unknown[]) => { added.push(rows); rowCount += rows.length; }),
+            delete: jest.fn(async () => { rowCount = Math.max(0, rowCount - 2); }),
+            countRows: jest.fn(async () => rowCount),
+        };
+        mockedGetDocChunksTable.mockResolvedValue({
+            table: fakeTable as unknown as Awaited<ReturnType<typeof getDocChunksTable>>['table'],
+            justCreated: false,
+        });
+
+        const result = await ingestPage({
+            alias: 'lancedb',
+            url: 'https://example.com/a',
+            title: 'A',
+            markdown: '# A\n\nhello world\n\nsecond paragraph here\n',
+        });
+
+        expect(mockedEmbedMany).toHaveBeenCalledTimes(1);
+        expect(fakeTable.delete).toHaveBeenCalledTimes(1);
+        expect(fakeTable.add).toHaveBeenCalledTimes(1);
+        expect(result.chunksWritten).toBeGreaterThan(0);
+        expect(result.chunksDeleted).toBe(2);
+        expect(typeof result.pageHash).toBe('string');
+        expect(result.pageHash.length).toBe(64);
+    });
+
+    it('skips delete and seeds the table on first creation', async () => {
+        const fakeTable = {
+            add: jest.fn(async () => undefined),
+            delete: jest.fn(async () => undefined),
+            countRows: jest.fn(async () => 0),
+        };
+        mockedGetDocChunksTable.mockResolvedValue({
+            table: fakeTable as unknown as Awaited<ReturnType<typeof getDocChunksTable>>['table'],
+            justCreated: true,
+        });
+
+        const result = await ingestPage({
+            alias: 'lancedb',
+            url: 'https://example.com/b',
+            title: 'B',
+            markdown: '# B\n\nonly a tiny page',
+        });
+
+        expect(fakeTable.delete).not.toHaveBeenCalled();
+        expect(result.chunksWritten).toBeGreaterThan(0);
+        expect(result.chunksDeleted).toBe(0);
+    });
+
+    it('returns zero work for empty markdown', async () => {
+        mockedGetDocChunksTable.mockResolvedValue({ table: null, justCreated: false });
+        const result = await ingestPage({
+            alias: 'x', url: 'https://x', title: '', markdown: '   \n',
+        });
+        expect(result.chunksWritten).toBe(0);
+        expect(mockedEmbedMany).not.toHaveBeenCalled();
+    });
+});

--- a/__tests__/AI/AIAgent/docsSearch.test.ts
+++ b/__tests__/AI/AIAgent/docsSearch.test.ts
@@ -1,0 +1,159 @@
+import { docsSearch } from '@/AI/AIAgent/shared/docs/search';
+import { embedOne } from '@/AI/AIAgent/shared/memory/embedder';
+import { getDocChunksTable } from '@/AI/AIAgent/shared/memory/db';
+
+jest.mock('@/AI/AIAgent/shared/memory/embedder', () => ({
+    embedOne: jest.fn(async () => [0.1, 0.2, 0.3]),
+}));
+
+jest.mock('@/AI/AIAgent/shared/memory/db', () => ({
+    getDocChunksTable: jest.fn(),
+}));
+
+const mockedEmbedOne = jest.mocked(embedOne);
+const mockedGetDocChunksTable = jest.mocked(getDocChunksTable);
+
+interface MockRow {
+    id: string;
+    sourceAlias: string;
+    url: string;
+    pageTitle: string;
+    sectionPath: string;
+    chunkIndex: number;
+    tokenCount: number;
+    content: string;
+    contentHash: string;
+    indexedAt: number;
+    vector: number[];
+    _distance: number;
+}
+
+function row(overrides: Partial<MockRow>): MockRow {
+    return {
+        id: 'id',
+        sourceAlias: 'aws',
+        url: 'https://docs.aws/p',
+        pageTitle: 'A page',
+        sectionPath: 'A page > Intro',
+        chunkIndex: 0,
+        tokenCount: 100,
+        content: 'body',
+        contentHash: 'h',
+        indexedAt: 0,
+        vector: [],
+        _distance: 0.1,
+        ...overrides,
+    };
+}
+
+function mockTable(rows: MockRow[]): void {
+    const search = jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue(rows),
+        }),
+    });
+    mockedGetDocChunksTable.mockResolvedValue({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        table: { search } as any,
+        justCreated: false,
+    });
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockedEmbedOne.mockResolvedValue([0.1, 0.2, 0.3]);
+});
+
+describe('docsSearch', () => {
+    it('throws on empty query', async () => {
+        await expect(docsSearch({ query: '' })).rejects.toThrow(/query is required/);
+        await expect(docsSearch({ query: '   ' })).rejects.toThrow(/query is required/);
+    });
+
+    it('returns [] when the doc_chunks table does not exist yet', async () => {
+        mockedGetDocChunksTable.mockResolvedValue({ table: null, justCreated: false });
+        const out = await docsSearch({ query: 'anything' });
+        expect(out).toEqual([]);
+    });
+
+    it('groups multiple chunks of the same page into a single hit with sections sorted by score', async () => {
+        mockTable([
+            row({ id: '1', url: 'https://docs.aws/p1', sectionPath: 'P1 > A', chunkIndex: 0, content: 'a', _distance: 0.5 }),
+            row({ id: '2', url: 'https://docs.aws/p1', sectionPath: 'P1 > B', chunkIndex: 1, content: 'b', _distance: 0.1 }),
+            row({ id: '3', url: 'https://docs.aws/p1', sectionPath: 'P1 > C', chunkIndex: 2, content: 'c', _distance: 0.3 }),
+        ]);
+
+        const hits = await docsSearch({ query: 'foo' });
+        expect(hits).toHaveLength(1);
+        expect(hits[0].url).toBe('https://docs.aws/p1');
+        expect(hits[0].sections.map((s) => s.sectionPath)).toEqual(['P1 > B', 'P1 > C', 'P1 > A']);
+        expect(hits[0].score).toBeCloseTo(1 / (1 + 0.1));
+    });
+
+    it('caps sections per page at 3 (best by score)', async () => {
+        mockTable([
+            row({ id: '1', url: 'https://x/p', sectionPath: 'S1', chunkIndex: 0, _distance: 0.4 }),
+            row({ id: '2', url: 'https://x/p', sectionPath: 'S2', chunkIndex: 1, _distance: 0.1 }),
+            row({ id: '3', url: 'https://x/p', sectionPath: 'S3', chunkIndex: 2, _distance: 0.2 }),
+            row({ id: '4', url: 'https://x/p', sectionPath: 'S4', chunkIndex: 3, _distance: 0.3 }),
+            row({ id: '5', url: 'https://x/p', sectionPath: 'S5', chunkIndex: 4, _distance: 0.5 }),
+        ]);
+        const hits = await docsSearch({ query: 'foo' });
+        expect(hits[0].sections).toHaveLength(3);
+        expect(hits[0].sections.map((s) => s.sectionPath)).toEqual(['S2', 'S3', 'S4']);
+    });
+
+    it('truncates very long content and flags it', async () => {
+        const long = 'x'.repeat(2000);
+        mockTable([row({ content: long, _distance: 0.1 })]);
+        const hits = await docsSearch({ query: 'foo' });
+        expect(hits[0].sections[0].truncated).toBe(true);
+        expect(hits[0].sections[0].content.length).toBeLessThan(long.length);
+        expect(hits[0].sections[0].content).toContain('[truncated]');
+    });
+
+    it('does not truncate short content', async () => {
+        mockTable([row({ content: 'short body', _distance: 0.1 })]);
+        const hits = await docsSearch({ query: 'foo' });
+        expect(hits[0].sections[0].truncated).toBe(false);
+        expect(hits[0].sections[0].content).toBe('short body');
+    });
+
+    it('drops hits below MIN_SCORE (high distance)', async () => {
+        mockTable([
+            row({ url: 'https://x/good', _distance: 0.1 }),
+            row({ url: 'https://x/bad', _distance: 5.0 }),
+        ]);
+        const hits = await docsSearch({ query: 'foo' });
+        expect(hits.map((h) => h.url)).toEqual(['https://x/good']);
+    });
+
+    it('respects sourceAlias filter', async () => {
+        mockTable([
+            row({ sourceAlias: 'aws', url: 'https://aws/p', _distance: 0.1 }),
+            row({ sourceAlias: 'gcp', url: 'https://gcp/p', _distance: 0.05 }),
+        ]);
+        const hits = await docsSearch({ query: 'foo', sourceAlias: 'aws' });
+        expect(hits.map((h) => h.sourceAlias)).toEqual(['aws']);
+    });
+
+    it('clamps k to [1, 50] and orders pages by best section score', async () => {
+        mockTable([
+            row({ url: 'https://x/a', _distance: 0.4 }),
+            row({ url: 'https://x/b', _distance: 0.1 }),
+            row({ url: 'https://x/c', _distance: 0.2 }),
+        ]);
+        const hits = await docsSearch({ query: 'foo', k: 2 });
+        expect(hits.map((h) => h.url)).toEqual(['https://x/b', 'https://x/c']);
+    });
+
+    it('handles missing _distance as score 0 (filtered out)', async () => {
+        mockTable([
+            // @ts-expect-error force missing distance
+            row({ url: 'https://x/no-dist', _distance: undefined }),
+            row({ url: 'https://x/keep', _distance: 0.1 }),
+        ]);
+        const hits = await docsSearch({ query: 'foo' });
+        expect(hits.map((h) => h.url)).toEqual(['https://x/keep']);
+    });
+});

--- a/__tests__/AI/AIAgent/docsSearchTool.test.ts
+++ b/__tests__/AI/AIAgent/docsSearchTool.test.ts
@@ -1,0 +1,44 @@
+import { buildDocsSearchTool } from '@/AI/AIAgent/shared/utils/memoryMcpServer';
+import type { DocsSource } from '@/types/settingsTypes';
+
+describe('buildDocsSearchTool', () => {
+    const sources: DocsSource[] = [
+        { alias: 'lancedb', url: 'https://lancedb.github.io/lancedb/', description: 'LanceDB vector store.' },
+        { alias: 'fastembed', url: 'https://github.com/qdrant/fastembed#readme' },
+    ];
+
+    it('constrains sourceAlias to a string enum of configured aliases', () => {
+        const tool = buildDocsSearchTool(sources);
+        const aliasProp = tool.inputSchema.properties.sourceAlias as { type: string, enum: string[] };
+        expect(aliasProp.type).toBe('string');
+        expect(aliasProp.enum).toEqual(['lancedb', 'fastembed']);
+    });
+
+    it('lists every configured source in the description with its description blurb', () => {
+        const desc = buildDocsSearchTool(sources).description;
+        expect(desc).toContain('Available sources');
+        expect(desc).toContain('lancedb \u2014 LanceDB vector store.');
+        expect(desc).toContain('fastembed \u2014 https://github.com/qdrant/fastembed#readme');
+    });
+
+    it('falls back to the URL when description is missing or whitespace', () => {
+        const desc = buildDocsSearchTool([
+            { alias: 'a', url: 'https://example.com/a' },
+            { alias: 'b', url: 'https://example.com/b', description: '   ' },
+        ]).description;
+        expect(desc).toContain('a \u2014 https://example.com/a');
+        expect(desc).toContain('b \u2014 https://example.com/b');
+    });
+
+    it('produces an empty enum when given no sources (caller is expected to skip registration)', () => {
+        const tool = buildDocsSearchTool([]);
+        const aliasProp = tool.inputSchema.properties.sourceAlias as { enum: string[] };
+        expect(aliasProp.enum).toEqual([]);
+    });
+
+    it('keeps the base description text intact and required: query', () => {
+        const tool = buildDocsSearchTool(sources);
+        expect(tool.description).toContain('Vector search over the indexed documentation corpus');
+        expect(tool.inputSchema.required).toEqual(['query']);
+    });
+});

--- a/__tests__/AI/AIAgent/docsState.test.ts
+++ b/__tests__/AI/AIAgent/docsState.test.ts
@@ -1,0 +1,193 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+    docsStateFilePath,
+    loadDocsState,
+    saveDocsState,
+    getPageState,
+    setPageState,
+    knownPagesForAlias,
+    dropAliasState,
+    applyPageFetched,
+    applyPageUnchanged,
+    applyPageSkipped,
+} from '@/AI/AIAgent/shared/docs/state';
+import type { DocsStateFile } from '@/AI/AIAgent/shared/docs/types';
+
+let tmpRoot: string;
+let prevWorkingDir: string | undefined;
+
+beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kra-docs-state-'));
+    prevWorkingDir = process.env['WORKING_DIR'];
+    process.env['WORKING_DIR'] = tmpRoot;
+});
+
+afterEach(() => {
+    if (prevWorkingDir === undefined) {
+        delete process.env['WORKING_DIR'];
+    } else {
+        process.env['WORKING_DIR'] = prevWorkingDir;
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function freshState(): DocsStateFile {
+    return { version: 1, pages: {} };
+}
+
+describe('docs state I/O', () => {
+    it('loadDocsState returns empty when file is missing', () => {
+        const state = loadDocsState();
+        expect(state).toEqual({ version: 1, pages: {} });
+        expect(fs.existsSync(docsStateFilePath())).toBe(false);
+    });
+
+    it('round-trips through save/load', () => {
+        const state = freshState();
+        setPageState(state, 'aws', 'https://aws/foo', {
+            etag: 'W/"abc"',
+            lastModified: 'Wed, 21 Oct 2024 07:28:00 GMT',
+            pageHash: 'hash-foo',
+            chunkCount: 3,
+            lastIndexedAt: 1700000000000,
+        });
+        saveDocsState(state);
+
+        expect(fs.existsSync(docsStateFilePath())).toBe(true);
+        const reloaded = loadDocsState();
+        expect(reloaded.version).toBe(1);
+        expect(getPageState(reloaded, 'aws', 'https://aws/foo')).toEqual({
+            etag: 'W/"abc"',
+            lastModified: 'Wed, 21 Oct 2024 07:28:00 GMT',
+            pageHash: 'hash-foo',
+            chunkCount: 3,
+            lastIndexedAt: 1700000000000,
+        });
+    });
+
+    it('loadDocsState resets when version mismatches', () => {
+        fs.mkdirSync(path.dirname(docsStateFilePath()), { recursive: true });
+        fs.writeFileSync(
+            docsStateFilePath(),
+            JSON.stringify({ version: 99, pages: { 'x|y': { pageHash: 'h', chunkCount: 1, lastIndexedAt: 0 } } }),
+        );
+        const state = loadDocsState();
+        expect(state.pages).toEqual({});
+    });
+
+    it('loadDocsState recovers gracefully from corrupt JSON', () => {
+        fs.mkdirSync(path.dirname(docsStateFilePath()), { recursive: true });
+        fs.writeFileSync(docsStateFilePath(), '{not json');
+        const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        const state = loadDocsState();
+        expect(state).toEqual({ version: 1, pages: {} });
+        errSpy.mockRestore();
+    });
+});
+
+describe('alias-scoped helpers', () => {
+    it('knownPagesForAlias filters by alias prefix and strips it', () => {
+        const state = freshState();
+        setPageState(state, 'aws', 'https://aws/a', { pageHash: 'a', chunkCount: 1, lastIndexedAt: 1 });
+        setPageState(state, 'aws', 'https://aws/b', { pageHash: 'b', chunkCount: 2, lastIndexedAt: 2 });
+        setPageState(state, 'gcp', 'https://gcp/x', { pageHash: 'x', chunkCount: 3, lastIndexedAt: 3 });
+
+        const aws = knownPagesForAlias(state, 'aws');
+        expect(Object.keys(aws).sort()).toEqual(['https://aws/a', 'https://aws/b']);
+        expect(aws['https://aws/a']?.pageHash).toBe('a');
+        expect(aws['https://gcp/x']).toBeUndefined();
+    });
+
+    it('dropAliasState removes only the matching alias', () => {
+        const state = freshState();
+        setPageState(state, 'aws', 'https://aws/a', { pageHash: 'a', chunkCount: 1, lastIndexedAt: 1 });
+        setPageState(state, 'gcp', 'https://gcp/x', { pageHash: 'x', chunkCount: 1, lastIndexedAt: 1 });
+
+        dropAliasState(state, 'aws');
+        expect(knownPagesForAlias(state, 'aws')).toEqual({});
+        expect(Object.keys(knownPagesForAlias(state, 'gcp'))).toEqual(['https://gcp/x']);
+    });
+});
+
+describe('coordinator IPC state mutators', () => {
+    it('applyPageFetched stores fresh hash + headers', () => {
+        const state = freshState();
+        applyPageFetched(state, 'aws', 'https://aws/p', {
+            pageHash: 'h1',
+            chunkCount: 5,
+            indexedAt: 1234,
+            etag: 'W/"v1"',
+            lastModified: 'Sun, 01 Jan 2024 00:00:00 GMT',
+        });
+        expect(getPageState(state, 'aws', 'https://aws/p')).toEqual({
+            lastIndexedAt: 1234,
+            pageHash: 'h1',
+            chunkCount: 5,
+            etag: 'W/"v1"',
+            lastModified: 'Sun, 01 Jan 2024 00:00:00 GMT',
+        });
+    });
+
+    it('applyPageFetched omits etag/lastModified when not provided', () => {
+        const state = freshState();
+        applyPageFetched(state, 'aws', 'https://aws/p', {
+            pageHash: 'h1',
+            chunkCount: 2,
+            indexedAt: 1,
+        });
+        const ps = getPageState(state, 'aws', 'https://aws/p');
+        expect(ps).toBeDefined();
+        expect(ps).not.toHaveProperty('etag');
+        expect(ps).not.toHaveProperty('lastModified');
+    });
+
+    it('applyPageUnchanged preserves prior chunkCount and refreshes lastIndexedAt', () => {
+        const state = freshState();
+        applyPageFetched(state, 'aws', 'https://aws/p', {
+            pageHash: 'h1',
+            chunkCount: 7,
+            indexedAt: 100,
+        });
+        applyPageUnchanged(state, 'aws', 'https://aws/p', {
+            pageHash: 'h1',
+            indexedAt: 999,
+            etag: 'W/"v2"',
+        });
+        const ps = getPageState(state, 'aws', 'https://aws/p');
+        expect(ps?.chunkCount).toBe(7);
+        expect(ps?.lastIndexedAt).toBe(999);
+        expect(ps?.etag).toBe('W/"v2"');
+    });
+
+    it('applyPageUnchanged for a previously-unknown URL defaults chunkCount to 0', () => {
+        const state = freshState();
+        applyPageUnchanged(state, 'aws', 'https://aws/new', {
+            pageHash: 'h-new',
+            indexedAt: 5,
+        });
+        expect(getPageState(state, 'aws', 'https://aws/new')).toEqual({
+            lastIndexedAt: 5,
+            pageHash: 'h-new',
+            chunkCount: 0,
+        });
+    });
+
+    it('applyPageSkipped only refreshes lastIndexedAt when the page is known', () => {
+        const state = freshState();
+        applyPageFetched(state, 'aws', 'https://aws/p', {
+            pageHash: 'h1',
+            chunkCount: 3,
+            indexedAt: 100,
+        });
+
+        applyPageSkipped(state, 'aws', 'https://aws/p', 555);
+        expect(getPageState(state, 'aws', 'https://aws/p')?.lastIndexedAt).toBe(555);
+        expect(getPageState(state, 'aws', 'https://aws/p')?.pageHash).toBe('h1');
+
+        applyPageSkipped(state, 'aws', 'https://aws/never-seen', 999);
+        expect(getPageState(state, 'aws', 'https://aws/never-seen')).toBeUndefined();
+    });
+});

--- a/automationScripts/python/kra_docs_worker.py
+++ b/automationScripts/python/kra_docs_worker.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""
+kra_docs_worker.py — Crawl4AI wrapper used by the docs coordinator.
+
+Spawned by the Node coordinator (one process per source). Streams JSON Lines
+to stdout; the coordinator reads stdout line-by-line. The schema mirrors the
+DocsWorkerMessage discriminated union in src/AI/AIAgent/shared/docs/types.ts.
+
+Each line on stdout is a single JSON object with a `type` field:
+    worker-ready     {alias, pid}
+    page-fetched     {alias, url, title, markdown, links[], hash, etag?, lastModified?}
+    page-unchanged   {alias, url, pageHash, etag?, lastModified?}
+    page-skipped     {alias, url, reason}
+    worker-progress  {alias, pagesDone, pagesTotal, currentUrl}
+    worker-error     {alias, url?, error, fatal}
+    source-done      {alias, summary: {pagesScraped, pagesSkipped, chunksWritten, elapsedMs}}
+
+stdin: a single JSON line `{knownPages: {<url>: {etag?, lastModified?, pageHash, lastIndexedAt, chunkCount}}, bypassIncremental: bool}`.
+The coordinator writes that and closes stdin before any output is expected.
+
+stderr is reserved for human-readable diagnostics; the coordinator merely logs
+it. Anything written to stdout MUST be valid JSONL — no banner prints.
+
+Incremental strategy (3 layers):
+  1. Sitemap discovery: try <base>/sitemap.xml and /sitemap_index.xml, parse
+     <lastmod>. If the sitemap lastmod is older than knownPages[url].lastIndexedAt,
+     emit page-skipped(reason=sitemap-unchanged).
+  2. Conditional GET: send If-None-Match / If-Modified-Since when we have
+     them; on 304 emit page-skipped(reason=http-not-modified).
+  3. Content hash: after fetching markdown via crawl4ai, compare sha256 against
+     knownPages[url].pageHash; on match emit page-unchanged.
+
+Falls back to BFSDeepCrawlStrategy when no sitemap is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import hashlib
+import json
+import os
+import sys
+import time
+from typing import Any
+from urllib.parse import urljoin, urlparse
+from xml.etree import ElementTree as ET
+
+
+def _build_ssl_context() -> Any:
+    """Build an SSL context that trusts both certifi's CA bundle AND the
+    OS trust store. The OS-trust path is critical for users behind a
+    TLS-intercepting corporate proxy (e.g. Zscaler/Netskope) whose CA only
+    lives in the system keychain. Falls back gracefully on any failure."""
+    try:
+        import ssl
+        try:
+            import truststore
+            return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        except Exception:  # noqa: BLE001
+            import certifi
+            return ssl.create_default_context(cafile=certifi.where())
+    except Exception:  # noqa: BLE001
+        return True
+
+
+_SSL_CTX: Any = _build_ssl_context()
+
+def emit(msg: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(msg, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+_GLOB_CACHE: dict[str, "re.Pattern[str]"] = {}
+
+def _glob_to_regex(pattern: str) -> "re.Pattern[str]":
+    """Compile a globstar pattern to a regex.
+
+    Semantics (URL-aware, matches what users expect from `**`):
+      `**` matches any sequence of characters (including `/`).
+      `*`  matches any sequence of characters except `/`.
+      `?`  matches exactly one character (any).
+      All other characters are literal.
+
+    Anchored at both ends (full match).
+    """
+    cached = _GLOB_CACHE.get(pattern)
+    if cached is not None:
+        return cached
+    out: list[str] = []
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < len(pattern) and pattern[i + 1] == "*":
+                out.append(".*")
+                i += 2
+                continue
+            out.append("[^/]*")
+            i += 1
+            continue
+        if c == "?":
+            out.append(".")
+            i += 1
+            continue
+        out.append(re.escape(c))
+        i += 1
+    compiled = re.compile("^" + "".join(out) + "$")
+    _GLOB_CACHE[pattern] = compiled
+    return compiled
+
+def url_matches(url: str, patterns: list[str]) -> bool:
+    if not patterns:
+        return True
+    return any(_glob_to_regex(p).match(url) is not None for p in patterns)
+
+
+def stable_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+
+
+def read_stdin_payload() -> dict[str, Any]:
+    """Read the single-line JSON payload the coordinator writes to our stdin.
+    Returns an empty default if anything is missing/unparseable.
+    """
+    try:
+        raw = sys.stdin.readline()
+        if not raw.strip():
+            return {"knownPages": {}, "bypassIncremental": False}
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return {"knownPages": {}, "bypassIncremental": False}
+        data.setdefault("knownPages", {})
+        data.setdefault("bypassIncremental", False)
+        return data
+    except Exception as exc:  # noqa: BLE001
+        print(f"docs-worker: stdin parse failed: {exc}", file=sys.stderr)
+        return {"knownPages": {}, "bypassIncremental": False}
+
+
+def parse_iso_to_epoch(s: str) -> float | None:
+    try:
+        from datetime import datetime
+        # Accept e.g. "2024-09-30", "2024-09-30T12:00:00+00:00", with/without Z.
+        s = s.strip()
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        return datetime.fromisoformat(s).timestamp()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def discover_sitemap_urls(base_url: str) -> list[tuple[str, float | None]]:
+    """Return [(url, lastmod_epoch_or_None), ...] from a sitemap discovered
+    at the URL's directory or any ancestor directory (and finally the host
+    root). Empty list if no sitemap was found.
+
+    AWS-style docs publish a per-product sitemap at e.g.
+    `<host>/lambda/latest/dg/sitemap.xml` rather than at the host root, so we
+    try the most-specific path first and walk up."""
+    try:
+        import httpx
+    except Exception:
+        return []
+
+    parsed = urlparse(base_url)
+    base_root = f"{parsed.scheme}://{parsed.netloc}"
+    # Build a list of directories to probe: most-specific first, then ancestors,
+    # then host root. Strip the trailing filename if any.
+    path = parsed.path or "/"
+    if not path.endswith("/"):
+        path = path.rsplit("/", 1)[0] + "/"
+    dirs: list[str] = []
+    while True:
+        if path not in dirs:
+            dirs.append(path)
+        if path == "/":
+            break
+        path = path.rstrip("/").rsplit("/", 1)[0] + "/"
+        if not path:
+            path = "/"
+    candidates: list[str] = []
+    for d in dirs:
+        candidates.append(f"{base_root}{d}sitemap.xml")
+        candidates.append(f"{base_root}{d}sitemap_index.xml")
+
+    headers = {"User-Agent": "kra-docs-crawler/1.0"}
+    found: dict[str, float | None] = {}
+
+    async with httpx.AsyncClient(timeout=20.0, follow_redirects=True, headers=headers, verify=_SSL_CTX) as client:
+        for sm_url in candidates:
+            try:
+                r = await client.get(sm_url)
+                if r.status_code != 200 or not r.text.strip():
+                    continue
+                # Cheap guard: many 404 pages return 200 with HTML. Require XML.
+                head = r.text.lstrip()[:200].lower()
+                if "<?xml" not in head and "<urlset" not in head and "<sitemapindex" not in head:
+                    continue
+                await _parse_sitemap_into(client, r.text, found, sm_url)
+                if found:
+                    break
+            except Exception:  # noqa: BLE001
+                continue
+
+    return [(u, lm) for u, lm in found.items()]
+
+
+async def _parse_sitemap_into(
+    client: Any,
+    xml_text: str,
+    out: dict[str, float | None],
+    src_url: str,
+) -> None:
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return
+
+    tag = root.tag.lower()
+    ns = ""
+    if "}" in root.tag:
+        ns = root.tag.split("}", 1)[0] + "}"
+
+    if tag.endswith("sitemapindex"):
+        for sm in root.findall(f"{ns}sitemap"):
+            loc_el = sm.find(f"{ns}loc")
+            if loc_el is None or not (loc_el.text or "").strip():
+                continue
+            sub_url = loc_el.text.strip()
+            try:
+                rr = await client.get(sub_url)
+                if rr.status_code == 200 and rr.text.strip():
+                    await _parse_sitemap_into(client, rr.text, out, sub_url)
+            except Exception:  # noqa: BLE001
+                continue
+        return
+
+    if tag.endswith("urlset"):
+        for url_el in root.findall(f"{ns}url"):
+            loc_el = url_el.find(f"{ns}loc")
+            if loc_el is None or not (loc_el.text or "").strip():
+                continue
+            url = loc_el.text.strip()
+            lastmod_el = url_el.find(f"{ns}lastmod")
+            lm: float | None = None
+            if lastmod_el is not None and lastmod_el.text:
+                lm = parse_iso_to_epoch(lastmod_el.text)
+            out[url] = lm
+
+
+async def conditional_fetch(
+    client: Any,
+    url: str,
+    known: dict[str, Any] | None,
+) -> tuple[int, str | None, str | None, str | None]:
+    """Try a conditional GET; return (status, etag, last_modified, body_or_None).
+    Body is None on 304. status=0 means a network error."""
+    headers: dict[str, str] = {"User-Agent": "kra-docs-crawler/1.0"}
+    if known:
+        if known.get("etag"):
+            headers["If-None-Match"] = known["etag"]
+        if known.get("lastModified"):
+            headers["If-Modified-Since"] = known["lastModified"]
+    try:
+        r = await client.get(url, headers=headers)
+    except Exception:  # noqa: BLE001
+        return (0, None, None, None)
+    etag = r.headers.get("etag") or r.headers.get("ETag")
+    last_modified = r.headers.get("last-modified") or r.headers.get("Last-Modified")
+    if r.status_code == 304:
+        return (304, etag, last_modified, None)
+    if r.status_code != 200:
+        return (r.status_code, etag, last_modified, None)
+    return (200, etag, last_modified, r.text)
+
+
+def extract_markdown(result: Any) -> str:
+    md_obj = getattr(result, "markdown", None)
+    if md_obj is None:
+        return ""
+    return (
+        getattr(md_obj, "fit_markdown", None)
+        or getattr(md_obj, "raw_markdown", None)
+        or str(md_obj)
+        or ""
+    )
+
+
+def extract_title(result: Any) -> str:
+    meta = getattr(result, "metadata", None) or {}
+    if isinstance(meta, dict):
+        return meta.get("title") or ""
+    return ""
+
+
+def extract_internal_links(result: Any) -> list[str]:
+    links_block = getattr(result, "links", None) or {}
+    internal = links_block.get("internal", []) if isinstance(links_block, dict) else []
+    out: list[str] = []
+    for link in internal:
+        if isinstance(link, dict) and link.get("href"):
+            out.append(link["href"])
+        elif isinstance(link, str):
+            out.append(link)
+    return out
+
+
+async def decide_mode_via_probe(probe_url: str, timeout: float = 10.0) -> tuple[str, str]:
+    """Returns ('http' | 'browser', reason_str). Strategy: HTTP-GET the probe
+    URL, strip <script>/<style>, count remaining text length. If >= 2 KB of
+    text the page is server-rendered enough to skip Chromium; otherwise we
+    assume it needs JS execution and fall back to a real browser."""
+    import re
+    try:
+        import httpx
+    except Exception as exc:  # noqa: BLE001
+        return ("browser", f"probe_import_failed: {exc}")
+    try:
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=True,
+            headers={"User-Agent": "kra-docs-crawler/1.0"},
+            verify=_SSL_CTX,
+        ) as client:
+            r = await client.get(probe_url)
+            if r.status_code != 200:
+                return ("browser", f"probe_http_status={r.status_code}")
+            html = r.text or ""
+    except Exception as exc:  # noqa: BLE001
+        return ("browser", f"probe_failed: {type(exc).__name__}: {exc}")
+    stripped = re.sub(r"<(script|style)[^>]*>.*?</\1>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    stripped = re.sub(r"<[^>]+>", " ", stripped)
+    text_len = len(re.sub(r"\s+", " ", stripped).strip())
+    if text_len >= 2048:
+        return ("http", f"probe_text_chars={text_len}")
+    return ("browser", f"probe_text_chars={text_len}_below_threshold")
+
+
+def build_crawler_kwargs(mode: str, BrowserConfig: Any, AsyncHTTPCrawlerStrategy: Any, HTTPCrawlerConfig: Any) -> dict[str, Any]:
+    """Constructor kwargs for AsyncWebCrawler depending on mode."""
+    if mode == "http":
+        http_cfg = HTTPCrawlerConfig(
+            method="GET",
+            headers={"User-Agent": "kra-docs-crawler/1.0"},
+            follow_redirects=True,
+            verify_ssl=_SSL_CTX,
+        )
+        return {"crawler_strategy": AsyncHTTPCrawlerStrategy(browser_config=http_cfg, max_connections=32)}
+    return {"config": BrowserConfig(headless=True, verbose=False)}
+
+
+async def fetch_response_headers(http_client: Any, url: str) -> tuple[str | None, str | None]:
+    try:
+        resp = await http_client.head(url)
+        etag = resp.headers.get("etag") or resp.headers.get("ETag")
+        last_modified = resp.headers.get("last-modified") or resp.headers.get("Last-Modified")
+        return (etag, last_modified)
+    except Exception:  # noqa: BLE001
+        return (None, None)
+
+
+async def crawl_single_page(crawler: Any, url: str, run_cfg: Any) -> Any:
+    """Crawl exactly one URL via crawl4ai (no deep crawl)."""
+    try:
+        async for result in await crawler.arun(url=url, config=run_cfg):
+            return result
+    except Exception as exc:  # noqa: BLE001
+        raise exc
+    return None
+
+
+async def crawl(args: argparse.Namespace, payload: dict[str, Any]) -> int:
+    try:
+        from crawl4ai import (
+            AsyncWebCrawler,
+            BrowserConfig,
+            CacheMode,
+            CrawlerRunConfig,
+            HTTPCrawlerConfig,
+            MemoryAdaptiveDispatcher,
+            RateLimiter,
+        )
+        from crawl4ai.async_crawler_strategy import AsyncHTTPCrawlerStrategy
+        from crawl4ai.content_filter_strategy import PruningContentFilter
+        from crawl4ai.deep_crawling import BFSDeepCrawlStrategy
+        from crawl4ai.markdown_generation_strategy import DefaultMarkdownGenerator
+    except Exception as exc:  # noqa: BLE001
+        emit({
+            "type": "worker-error",
+            "alias": args.alias,
+            "error": f"crawl4ai import failed: {exc}",
+            "fatal": True,
+        })
+        return 2
+
+    include_patterns: list[str] = args.include or []
+    exclude_patterns: list[str] = args.exclude or []
+    known_pages: dict[str, dict[str, Any]] = payload.get("knownPages", {}) or {}
+    bypass = bool(payload.get("bypassIncremental", False))
+
+    started = time.time()
+    pages_scraped = 0
+    pages_skipped = 0
+
+    requested_mode = (args.mode or "auto").lower()
+    if requested_mode not in ("auto", "http", "browser"):
+        requested_mode = "auto"
+    if requested_mode == "auto":
+        decided_mode, decision_reason = await decide_mode_via_probe(args.url)
+    else:
+        decided_mode, decision_reason = (requested_mode, "explicit")
+
+    crawler_kwargs = build_crawler_kwargs(
+        decided_mode, BrowserConfig, AsyncHTTPCrawlerStrategy, HTTPCrawlerConfig,
+    )
+    md_generator = DefaultMarkdownGenerator(
+        content_filter=PruningContentFilter(threshold=0.45, threshold_type="dynamic"),
+    )
+
+    default_concurrency = 8 if decided_mode == "http" else 4
+    concurrency = max(1, int(args.concurrency or default_concurrency))
+    dispatcher = MemoryAdaptiveDispatcher(
+        max_session_permit=concurrency,
+        rate_limiter=RateLimiter(base_delay=(0.1, 0.4), max_delay=10.0, max_retries=2),
+    )
+
+    emit({"type": "worker-ready", "alias": args.alias, "pid": os.getpid()})
+    emit({
+        "type": "mode-decided",
+        "alias": args.alias,
+        "mode": decided_mode,
+        "reason": decision_reason,
+    })
+
+    # ----- Phase 1: try the sitemap-first path -----
+    sitemap_entries: list[tuple[str, float | None]] = []
+    if args.max_depth > 0:
+        try:
+            sitemap_entries = await discover_sitemap_urls(args.url)
+        except Exception as exc:  # noqa: BLE001
+            print(f"docs-worker: sitemap discovery error: {exc}", file=sys.stderr)
+            sitemap_entries = []
+
+    use_sitemap = len(sitemap_entries) > 0
+
+    # Filter sitemap urls by include/exclude + max_pages
+    if use_sitemap:
+        filtered: list[tuple[str, float | None]] = []
+        for u, lm in sitemap_entries:
+            if not url_matches(u, include_patterns):
+                continue
+            if exclude_patterns and url_matches(u, exclude_patterns):
+                continue
+            filtered.append((u, lm))
+        sitemap_entries = filtered[: args.max_pages]
+        pages_total = max(1, len(sitemap_entries))
+    else:
+        pages_total = max(1, args.max_pages)
+
+    run_cfg_single = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        markdown_generator=md_generator,
+        verbose=False,
+        stream=True,
+        wait_until="domcontentloaded",
+        page_timeout=int(args.page_timeout_ms),
+    )
+
+    try:
+        if use_sitemap:
+            try:
+                import httpx
+            except Exception as exc:  # noqa: BLE001
+                emit({
+                    "type": "worker-error",
+                    "alias": args.alias,
+                    "error": f"httpx import failed: {exc}",
+                    "fatal": True,
+                })
+                return 2
+
+            # Pass 1: pre-filter via sitemap-lastmod and conditional GET.
+            to_render: list[str] = []
+            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True, verify=_SSL_CTX) as http_client:
+                for url, sm_lastmod in sitemap_entries:
+                    if pages_scraped + pages_skipped + len(to_render) >= args.max_pages:
+                        break
+                    known = None if bypass else known_pages.get(url)
+                    if known and sm_lastmod is not None:
+                        last_indexed = (known.get("lastIndexedAt") or 0) / 1000.0
+                        if last_indexed > 0 and sm_lastmod <= last_indexed:
+                            emit({"type": "page-skipped", "alias": args.alias, "url": url, "reason": "sitemap-unchanged"})
+                            pages_skipped += 1
+                            emit_progress(args.alias, pages_scraped + pages_skipped, pages_total, url)
+                            continue
+                    if known:
+                        status, _et, _lm, _ = await conditional_fetch(http_client, url, known)
+                        if status == 304:
+                            emit({"type": "page-skipped", "alias": args.alias, "url": url, "reason": "http-not-modified"})
+                            pages_skipped += 1
+                            emit_progress(args.alias, pages_scraped + pages_skipped, pages_total, url)
+                            continue
+                    to_render.append(url)
+
+                # Pass 2: parallel render via arun_many + dispatcher.
+                if to_render:
+                    async with AsyncWebCrawler(**crawler_kwargs) as crawler:
+                        async for result in await crawler.arun_many(to_render, config=run_cfg_single, dispatcher=dispatcher):
+                            url = getattr(result, "url", None) or ""
+                            if not getattr(result, "success", False):
+                                emit({
+                                    "type": "worker-error",
+                                    "alias": args.alias,
+                                    "url": url,
+                                    "error": getattr(result, "error_message", "unknown") or "unknown",
+                                    "fatal": False,
+                                })
+                                continue
+                            markdown = extract_markdown(result)
+                            if not markdown.strip():
+                                continue
+                            ph = stable_hash(markdown)
+                            etag2, last_modified2 = await fetch_response_headers(http_client, url)
+                            known = None if bypass else known_pages.get(url)
+                            if known and known.get("pageHash") == ph:
+                                payload_msg: dict[str, Any] = {
+                                    "type": "page-unchanged",
+                                    "alias": args.alias,
+                                    "url": url,
+                                    "pageHash": ph,
+                                }
+                                if etag2:
+                                    payload_msg["etag"] = etag2
+                                if last_modified2:
+                                    payload_msg["lastModified"] = last_modified2
+                                emit(payload_msg)
+                                pages_skipped += 1
+                                emit_progress(args.alias, pages_scraped + pages_skipped, pages_total, url)
+                                continue
+                            page_msg: dict[str, Any] = {
+                                "type": "page-fetched",
+                                "alias": args.alias,
+                                "url": url,
+                                "title": extract_title(result),
+                                "markdown": markdown,
+                                "links": extract_internal_links(result),
+                                "hash": ph,
+                            }
+                            if etag2:
+                                page_msg["etag"] = etag2
+                            if last_modified2:
+                                page_msg["lastModified"] = last_modified2
+                            emit(page_msg)
+                            pages_scraped += 1
+                            emit_progress(args.alias, pages_scraped + pages_skipped, pages_total, url)
+        else:
+            # ----- Fallback: BFSDeepCrawl (or single-page when max_depth==0) -----
+            deep_crawl = None
+            if args.max_depth > 0:
+                deep_crawl = BFSDeepCrawlStrategy(
+                    max_depth=args.max_depth,
+                    max_pages=args.max_pages,
+                    include_external=False,
+                )
+            run_cfg = CrawlerRunConfig(
+                cache_mode=CacheMode.BYPASS,
+                markdown_generator=md_generator,
+                deep_crawl_strategy=deep_crawl,
+                verbose=False,
+                stream=True,
+                wait_until="domcontentloaded",
+                page_timeout=int(args.page_timeout_ms),
+            )
+            async with AsyncWebCrawler(**crawler_kwargs) as crawler:
+                arun_ret = await crawler.arun(url=args.url, config=run_cfg)
+                # When deep_crawl_strategy is None, arun() returns a single
+                # CrawlResult; otherwise it returns an async iterator (stream=True).
+                if hasattr(arun_ret, "__aiter__"):
+                    result_iter = arun_ret
+                else:
+                    async def _single():
+                        yield arun_ret
+                    result_iter = _single()
+                async for result in result_iter:
+                    url = getattr(result, "url", args.url)
+                    # Apply include/exclude filter BEFORE emitting an error so
+                    # cross-product links on shared docs hosts (e.g.
+                    # developer.hashicorp.com) don't pollute the error log.
+                    if not url_matches(url, include_patterns):
+                        continue
+                    if exclude_patterns and url_matches(url, exclude_patterns):
+                        continue
+                    if not getattr(result, "success", False):
+                        emit({
+                            "type": "worker-error",
+                            "alias": args.alias,
+                            "url": url,
+                            "error": getattr(result, "error_message", "unknown") or "unknown",
+                            "fatal": False,
+                        })
+                        continue
+
+
+                    markdown = extract_markdown(result)
+                    if not markdown.strip():
+                        continue
+
+                    ph = stable_hash(markdown)
+                    known = None if bypass else known_pages.get(url)
+                    if known and known.get("pageHash") == ph:
+                        emit({
+                            "type": "page-unchanged",
+                            "alias": args.alias,
+                            "url": url,
+                            "pageHash": ph,
+                        })
+                        pages_skipped += 1
+                        emit_progress(args.alias, pages_scraped + pages_skipped, pages_total, url)
+                        continue
+
+                    emit({
+                        "type": "page-fetched",
+                        "alias": args.alias,
+                        "url": url,
+                        "title": extract_title(result),
+                        "markdown": markdown,
+                        "links": extract_internal_links(result),
+                        "hash": ph,
+                    })
+                    pages_scraped += 1
+                    emit_progress(args.alias, pages_scraped + pages_skipped, pages_total, url)
+
+                    if pages_scraped + pages_skipped >= args.max_pages:
+                        break
+    except Exception as exc:  # noqa: BLE001
+        emit({
+            "type": "worker-error",
+            "alias": args.alias,
+            "error": f"{type(exc).__name__}: {exc}",
+            "fatal": True,
+        })
+        return 1
+
+    elapsed_ms = int((time.time() - started) * 1000)
+    emit({
+        "type": "source-done",
+        "alias": args.alias,
+        "summary": {
+            "pagesScraped": pages_scraped,
+            "pagesSkipped": pages_skipped,
+            "chunksWritten": 0,
+            "elapsedMs": elapsed_ms,
+        },
+    })
+    return 0
+
+
+def emit_progress(alias: str, done: int, total: int, current_url: str) -> None:
+    emit({
+        "type": "worker-progress",
+        "alias": alias,
+        "pagesDone": done,
+        "pagesTotal": max(total, done),
+        "currentUrl": current_url,
+    })
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Crawl4AI worker for kra ai docs")
+    parser.add_argument("--alias", required=True)
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--max-depth", type=int, default=0)
+    parser.add_argument("--max-pages", type=int, default=50)
+    parser.add_argument("--include", action="append", default=[])
+    parser.add_argument("--exclude", action="append", default=[])
+    parser.add_argument("--mode", choices=["auto", "http", "browser"], default="auto")
+    parser.add_argument("--concurrency", type=int, default=0)
+    parser.add_argument("--page-timeout-ms", type=int, default=20000)
+    args = parser.parse_args()
+
+    parsed = urlparse(args.url)
+    if parsed.scheme not in ("http", "https"):
+        emit({
+            "type": "worker-error",
+            "alias": args.alias,
+            "error": f"unsupported url scheme: {parsed.scheme!r}",
+            "fatal": True,
+        })
+        return 2
+
+    payload = read_stdin_payload()
+
+    try:
+        return asyncio.run(crawl(args, payload))
+    except KeyboardInterrupt:
+        emit({
+            "type": "worker-error",
+            "alias": args.alias,
+            "error": "interrupted",
+            "fatal": True,
+        })
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/automationScripts/python/requirements-lean.txt
+++ b/automationScripts/python/requirements-lean.txt
@@ -1,0 +1,55 @@
+# Lean Crawl4AI dependency set used by `kra ai docs` (Setup menu entry).
+#
+# Installed into an isolated venv at ~/.kra/crawl4ai-venv/ so it never
+# touches the user's global Python. Total disk usage including
+# `playwright install chromium-headless-shell` is ~507 MB
+# (Python deps ≈ 318 MB, headless Chromium ≈ 189 MB).
+#
+# Install strategy: `pip install -r requirements-lean.txt` (WITH deps so
+# pydantic-core / annotated-types / typing-inspection etc. are pulled in),
+# followed by `pip uninstall -y` of a hard-coded list of heavy optional
+# packages that the worker never imports. The uninstall list lives in
+# src/AI/AIAgent/commands/docsSetup.ts (heavyOptional) so it stays in sync
+# with the runtime code. Trimmed packages: unclecode-litellm + litellm +
+# openai (LLM extraction strategies), patchright + tf-playwright-stealth +
+# playwright-stealth (anti-bot evasion), alphashape + shapely + scipy
+# (geometric clustering used by some experimental extractors), networkx
+# (graph analysis for link discovery). If a real user hits a 403/429 wall
+# we can document an opt-in `pip install patchright tf-playwright-stealth`.
+#
+# Pin Crawl4AI itself so a future release does not silently add a hard
+# import we depend on dropping.
+
+
+crawl4ai==0.7.6
+pydantic>=2.6
+aiohttp>=3.9
+aiofiles>=23.2
+aiosqlite>=0.20
+httpx>=0.27
+truststore>=0.10  # bridges Python ssl to OS trust store; needed behind TLS-intercepting corporate proxies (Zscaler/Netskope/etc.)
+beautifulsoup4>=4.12
+lxml>=5.2
+playwright>=1.45
+pillow>=10.3
+rich>=13.7
+click>=8.1
+pyyaml>=6.0
+psutil>=5.9
+chardet>=5.2
+brotli>=1.1
+humanize>=4.9
+lark>=1.1
+python-dotenv>=1.0
+pyOpenSSL>=24.0
+requests>=2.32
+xxhash>=3.4
+cssselect>=1.2
+fake-useragent>=1.5
+anyio>=4.4
+packaging>=24.0
+numpy>=1.26
+nltk>=3.8
+rank-bm25>=0.2.2
+snowballstemmer>=2.2
+tiktoken>=0.7

--- a/docs/agent/docs-crawling.md
+++ b/docs/agent/docs-crawling.md
@@ -1,0 +1,197 @@
+# Documentation Crawling (`kra ai docs`)
+
+Crawl public documentation sites, embed the resulting markdown with the same
+BGE-Small encoder used for `code_chunks`, and store the chunks in a new
+LanceDB table (`doc_chunks`) so the agent can retrieve them via the same
+`semantic_search` MCP tool that already serves the codebase index.
+
+## Components
+
+| Piece | Path | Purpose |
+|---|---|---|
+| `kra ai docs` | `src/AI/AIAgent/commands/manageDocs.ts` | Single interactive blessed menu: install Crawl4AI, list sources (with per-source actions), crawl all, watch live progress, stop coordinator. |
+| Setup helper | `src/AI/AIAgent/commands/docsSetup.ts` | `installCrawl4ai({force})` — programmatic installer for the isolated Python venv, called from the Setup menu entry. |
+| Coordinator | `src/AI/AIAgent/shared/docs/coordinator.ts` | Long-lived background process. Single LanceDB writer. Spawned on demand by `IPCClient.ensureServerRunning`. |
+| Worker | `automationScripts/python/kra_docs_worker.py` | Python child process per source. Runs Crawl4AI's deep crawl + content filter. Emits JSONL to stdout. |
+| Ingest | `src/AI/AIAgent/shared/docs/ingest.ts` | Markdown → chunks → embed → upsert into `doc_chunks`. Re-crawl deletes by `(sourceAlias, url)` first. |
+
+## Install
+
+The Python venv is **not** installed by `npm install`. Run:
+
+```
+kra ai docs        # interactive menu → "Setup Crawl4AI venv"
+```
+
+From the same menu, picking the entry again on an installed venv prompts to
+re-install (forces a clean reinstall — ~507 MB).
+
+The setup command:
+
+1. Locates a usable `python3` (≥3.10) on `PATH`.
+2. Creates a venv at `~/.kra/crawl4ai-venv/`.
+3. Installs the lean dependency set pinned in
+   `automationScripts/python/requirements-lean.txt` with `pip install --no-deps -r ...`.
+4. Runs `playwright install chromium-headless-shell` (≈189 MB), falling back
+   to full chromium if that fails.
+5. Touches `~/.kra/crawl4ai-venv/.installed` so subsequent crawls (and the
+   coordinator) can verify availability.
+
+## Settings
+
+Configure sources under a new `[ai.docs]` block in `settings.toml`:
+
+```toml
+[ai.docs]
+enabled = true
+maxConcurrentSources = 2
+idleTimeoutMs = 30000
+cacheRawMarkdown = true
+
+[[ai.docs.sources]]
+alias = "lancedb"
+url = "https://lancedb.github.io/lancedb/"
+maxDepth = 2
+maxPages = 200
+includePatterns = ["**/lancedb/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "fastembed"
+url = "https://github.com/qdrant/fastembed#readme"
+maxDepth = 0
+maxPages = 1
+```
+
+Types live in `src/types/settingsTypes.ts` (`DocsSource`, `DocsSettings`).
+The `enabled` flag is a hard gate: crawl actions in the menu exit early if
+it is `false`.
+
+## Commands
+
+| Menu entry | Effect |
+|---|---|
+| Setup Crawl4AI venv | Install (or re-install with confirmation) the venv at `~/.kra/crawl4ai-venv/`. |
+| List configured sources | Browse `[[ai.docs.sources]]` with chunk counts; per-source submenu offers Crawl, Crawl --full, Drop chunks, Show details. |
+| Crawl all sources | Queue every configured source on the coordinator (with optional `--full` cache bypass). |
+| Live crawl progress | Blessed screen polling `<repo>/.kra-memory/docs-status.json` every 500 ms. `q` closes, `s` sends shutdown. |
+| Stop coordinator | Send `shutdown-request` over the IPC socket. |
+
+Crawling is fire-and-forget: the menu spawns the coordinator if needed,
+queues the requested sources, then returns. Concurrent invocations from
+different shells coalesce — the second invocation just submits more work to
+the already-running coordinator.
+
+
+## IPC and process layout
+
+Single Unix socket at `/tmp/kra-docs.sock` (`IPCsockets.DocsCoordinatorSocket`).
+
+```
+kra ai docs (Crawl)  ──emit JSON──▶ /tmp/kra-docs.sock ──▶ coordinator
+                                                            │
+                                                            ├─ spawn ─▶ python worker (alias=A)
+                                                            ├─ spawn ─▶ python worker (alias=B)
+                                                            ▼
+                                                   ingest.ts → doc_chunks.lance
+                                                            ▼
+                                                   <repo>/.kra-memory/docs-status.json
+```
+
+- **Client → coordinator**: a single JSON-encoded `DocsClientMessage` per
+  `IPCClient.emit` call. No reply channel.
+- **Worker → coordinator**: JSON Lines on the worker's stdout. Coordinator
+  reads via `readline.createInterface({ input: child.stdout })`.
+- **Coordinator → CLI status**: a JSON snapshot file refreshed every 2s at
+  `<repo>/.kra-memory/docs-status.json`. Read by the live progress screen.
+
+Wire types: `src/AI/AIAgent/shared/docs/types.ts`.
+
+## Single-writer LanceDB
+
+Crawl4AI's worker writes to LanceDB through ingest.ts in this process —
+the existing module-level `mutex` in `src/AI/AIAgent/shared/memory/db.ts`
+serializes all LanceDB writes (so `code_chunks` and `doc_chunks` cannot
+collide if both happen in the same process). Cross-process safety comes from
+`LockFiles.DocsWriteInProgress`, refreshed every 30s with a 60s stale
+timeout. If the coordinator crashes, the next run reclaims the lock
+automatically.
+
+## `doc_chunks` schema
+
+```ts
+type DocChunkRow = {
+    id: string;            // `${alias}:${hashShort(url)}:${chunkIndex}:${hash.slice(0,12)}`
+    sourceAlias: string;
+    url: string;
+    pageTitle: string;
+    sectionPath: string;   // 'Page > H1 > H2' breadcrumb
+    chunkIndex: number;
+    content: string;       // raw markdown for this section/chunk
+    contentForEmbedding: string; // breadcrumb + content, used as embedder input
+    contentHash: string;
+    tokenCount: number;
+    indexedAt: number;     // epoch ms
+    vector: number[];      // 384 floats, BGE-Small
+};
+```
+
+Chunking is **markdown-aware**: the chunker (`shared/docs/chunker.ts`) parses
+the page into typed blocks (headings, fenced code, HTML, tables, paragraphs)
+and groups them by heading hierarchy. Code blocks, tables, and HTML are kept
+atomic — never split mid-block. Each chunk's embedding input is its breadcrumb
+(`# Page > H1 > H2`) prepended to the chunk content, which materially improves
+semantic match quality on long, deeply-nested pages.
+
+## Incremental updates
+
+Re-running `kra ai docs` → Crawl is cheap: state is tracked at
+`<repo>/.kra-memory/docs-state.json` (per-source, per-URL ETag, Last-Modified,
+content hash, lastIndexedAt) and three skip layers fire in order:
+
+1. **Sitemap `<lastmod>`** — if the sitemap reports the page is older than
+   our `lastIndexedAt`, the worker emits `page-skipped(reason=sitemap-unchanged)`
+   without fetching the page body.
+2. **Conditional GET** — `If-None-Match` / `If-Modified-Since` from stored
+   ETag/Last-Modified headers. A 304 emits `page-skipped(reason=http-not-modified)`.
+3. **Content hash** — after rendering markdown, `sha256(markdown)` is compared
+   to the stored `pageHash`. A match emits `page-unchanged` and bumps
+   `lastIndexedAt` without rewriting any chunks.
+
+For large sites like AWS CloudFormation (~4 k pages) this typically turns a
+15-25 minute full crawl into a 1-2 minute weekly refresh (~10-20× speedup,
+~95% bandwidth saved). The state file is per-repo and is intentionally
+gitignored — it is a cache, not a source of truth.
+
+### Forcing a full re-crawl
+
+```
+kra ai docs                                          # interactive menu
+kra ai docs → source → Crawl this source              # incremental, single source
+kra ai docs → source → Crawl this source (--full)    # bypass all 3 skip layers
+The sitemap-first discovery path is used whenever `<base>/sitemap.xml` or
+`/sitemap_index.xml` returns 200; otherwise the worker falls back to
+`BFSDeepCrawlStrategy` and the second/third layers still apply per fetched
+page.
+
+
+## Known limitations / risks
+
+- Crawl4AI version is pinned. Bumping it requires re-validating the lean
+  dependency list — pip will print unmet-pin warnings during install (we
+  pass `--no-deps`).
+- Anti-bot sites that block the headless-shell are out of scope for v1.
+  Detect 403/429 and consider a manual `pip install patchright` follow-up.
+
+## Querying from the agent
+
+The `kra-memory` MCP server exposes a `docs_search(query, k?, sourceAlias?)` tool
+backed by `src/AI/AIAgent/shared/docs/search.ts`. It vector-searches the
+`doc_chunks` table, dedupes hits per `(sourceAlias, url)` page, and returns up
+to 3 best-scoring sections per page with the markdown content inlined (capped
+at 1200 characters per section, flagged with `truncated: true` when cut).
+Default `k = 8`, hard cap 50.
+
+Use `docs_search` for questions about external library/framework behavior;
+use `semantic_search` for repo code. Pass `sourceAlias` to scope to a single
+configured source.

--- a/eventSystem/ipc.ts
+++ b/eventSystem/ipc.ts
@@ -4,6 +4,7 @@ import { spawn } from 'child_process';
 
 export enum IPCsockets {
     AutosaveSocket = '/tmp/autosave.sock',
+    DocsCoordinatorSocket = '/tmp/kra-docs.sock',
 }
 
 export enum IPCEvents {

--- a/eventSystem/lockFiles.ts
+++ b/eventSystem/lockFiles.ts
@@ -6,6 +6,7 @@ export enum LockFiles {
     LoadInProgress = 'LoadInProgress',
     AutoSaveInProgress = 'AutoSaveInProgress',
     ServerKillInProgress = 'ServerKillInProgress',
+    DocsWriteInProgress = 'DocsWriteInProgress',
 }
 
 export async function deleteLockFile(type: LockFiles): Promise<void> {
@@ -31,7 +32,8 @@ export async function lockFileExist(type: LockFiles): Promise<boolean> {
         const timeouts = {
             [LockFiles.LoadInProgress]: 10 * 1000,          // 5s - loading takes ms, this should be more than safe to assume
             [LockFiles.AutoSaveInProgress]: await loadSettings().then((set) => set.autosave.timeoutMs) + 10000, // autosave timeout + 10 sec buffer
-            [LockFiles.ServerKillInProgress]: 5 * 1000   // 5s - kill session is instant, 5s is enough to complete the autosave
+            [LockFiles.ServerKillInProgress]: 5 * 1000,   // 5s - kill session is instant, 5s is enough to complete the autosave
+            [LockFiles.DocsWriteInProgress]: 60 * 1000,   // 60s - docs coordinator refreshes the lock every 30s while crawling
         };
 
         // check if lock is stale (older than X seconds)

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -17,9 +17,6 @@ active = true
 currentSession = "this will update automatically on load/save session"
 timeoutMs = 20000
 
-[ai.agent]
-defaultModel = "gpt-5-mini"
-
 # ─── Persistent project memory (kra-memory MCP) ───────────────────────────────
 # The kra-memory layer gives the agent persistent notes (`remember` / `recall`
 # / `update_memory`) and conceptual codebase search (`semantic_search`) backed
@@ -39,6 +36,182 @@ gitignoreMemory = true      # documentation-only: whether you keep .kra-memory/ 
 # chunkOverlap = 5
 # includeExtensions = [".ts", ".js", ".py", ".go", ".rs", ".md"]
 # excludeGlobs = ["node_modules/**", "dest/**", "coverage/**", ".kra-memory/**"]
+
+# ─── Documentation indexing (kra ai docs) ───────────────────────────────────────────
+# Crawls the documentation sites listed below with Crawl4AI, embeds each page,
+# and stores chunks in a `doc_chunks` LanceDB table next to `code_chunks`.
+# The agent retrieves docs via the same kra-memory `semantic_search` MCP tool.
+#
+# Run `kra ai docs` to open the interactive menu. From there you can:
+#   - install/re-install the isolated Crawl4AI venv (~507 MB at ~/.kra/crawl4ai-venv/)
+#   - list configured sources (with chunk counts) and crawl/drop them per-source
+#   - crawl all sources (with optional --full bypass of the incremental cache)
+#   - watch live progress (auto-refreshing) and stop the coordinator cleanly
+[ai.docs]
+enabled = true                  # opt-in; flip to true once Crawl4AI is installed
+maxConcurrentSources = 2        # how many Crawl4AI subprocesses run in parallel
+idleTimeoutMs = 30000           # coordinator self-exits after this idle period
+cacheRawMarkdown = true         # keep raw .md per page so re-chunking skips re-crawl
+
+[[ai.docs.sources]]
+alias = "aws-lambda"
+url = "https://docs.aws.amazon.com/lambda/latest/dg/welcome.html"
+description = "AWS Lambda Developer Guide — runtimes, triggers, layers, deployment, IAM, monitoring, pricing."
+maxDepth = 3
+maxPages = 600
+includePatterns = ["**/lambda/latest/dg/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "aws-dynamodb"
+url = "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html"
+description = "AWS DynamoDB Developer Guide — tables, items, indexes, streams, transactions, capacity modes, DAX."
+maxDepth = 3
+maxPages = 600
+includePatterns = ["**/amazondynamodb/latest/developerguide/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "aws-eventbridge"
+url = "https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html"
+description = "AWS EventBridge User Guide — event buses, rules, targets, schemas, pipes, scheduler."
+maxDepth = 3
+maxPages = 400
+includePatterns = ["**/eventbridge/latest/userguide/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "aws-stepfunctions"
+url = "https://docs.aws.amazon.com/step-functions/latest/dg/welcome.html"
+description = "AWS Step Functions Developer Guide — state machines, ASL, tasks, integrations, error handling."
+maxDepth = 3
+maxPages = 500
+includePatterns = ["**/step-functions/latest/dg/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "aws-apigateway"
+url = "https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html"
+description = "AWS API Gateway Developer Guide — REST/HTTP/WebSocket APIs, integrations, authorizers, stages, throttling."
+maxDepth = 3
+maxPages = 600
+includePatterns = ["**/apigateway/latest/developerguide/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "aws-xray"
+url = "https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html"
+description = "AWS X-Ray Developer Guide — tracing, segments, subsegments, SDK integration, sampling."
+maxDepth = 3
+maxPages = 300
+includePatterns = ["**/xray/latest/devguide/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "aws-iam"
+url = "https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html"
+description = "AWS IAM User Guide — users, roles, policies, permissions, identity providers, best practices."
+maxDepth = 3
+maxPages = 600
+includePatterns = ["**/IAM/latest/UserGuide/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "aws-cloudwatch"
+url = "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html"
+description = "AWS CloudWatch Monitoring Guide — metrics, alarms, dashboards, logs (Logs Insights), events."
+maxDepth = 3
+maxPages = 500
+includePatterns = ["**/AmazonCloudWatch/latest/monitoring/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "aws-sdk-js-v3"
+url = "https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/welcome.html"
+description = "AWS SDK for JavaScript v3 Developer Guide — clients, commands, middleware, credentials, paginators."
+maxDepth = 3
+maxPages = 400
+includePatterns = ["**/sdk-for-javascript/v3/developer-guide/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "terraform"
+url = "https://developer.hashicorp.com/terraform/docs"
+description = "Terraform docs — language (HCL), CLI, modules, state, providers, workflows."
+maxDepth = 3
+maxPages = 800
+includePatterns = ["**/developer.hashicorp.com/terraform/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "postgresql"
+url = "https://www.postgresql.org/docs/current/index.html"
+description = "PostgreSQL official docs (current stable) — SQL reference, server admin, internals, extensions."
+maxDepth = 2
+maxPages = 500
+includePatterns = ["**postgresql.org/docs/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "winston"
+url = "https://github.com/winstonjs/winston#readme"
+description = "Winston Node.js logger — transports, formats, levels, child loggers, exception handling."
+maxDepth = 0
+maxPages = 1
+includePatterns = []
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "mocha"
+url = "https://mochajs.org/"
+description = "Mocha JavaScript test framework — suites, hooks, async, CLI flags, reporters, configuration."
+maxDepth = 2
+maxPages = 80
+includePatterns = ["**/mochajs.org/**"]
+excludePatterns = []
+
+[[ai.docs.sources]]
+alias = "sinon"
+url = "https://sinonjs.org/releases/latest/"
+description = "Sinon.JS — spies, stubs, mocks, fakes, fake timers, sandboxes for JavaScript tests."
+maxDepth = 2
+maxPages = 150
+includePatterns = ["**/sinonjs.org/releases/latest/**"]
+excludePatterns = []
+
+# Each [[ai.docs.sources]] entry is one site to crawl.
+#   alias            – stable id, shown in the `kra ai docs` menu and `docs_search`
+#   url              – starting URL
+#   description      – short blurb shown to the AI agent in the docs_search
+#                      tool description so it knows what each source covers
+#                      (kept to one line; omit to fall back to the URL)
+#   maxDepth         – 0 = single page, 1 = follow links one level, etc.
+#   maxPages         – hard cap on pages crawled per source
+#   includePatterns  – glob list; only URLs matching are kept (optional)
+#   excludePatterns  – glob list; URLs matching are skipped (optional)
+#   mode             – 'auto' (default), 'http' (no Chrome, ~10x faster on
+#                      server-rendered docs), or 'browser' (full Chromium for
+#                      JS-rendered SPAs). 'auto' probes the entrypoint and
+#                      picks based on how much text the raw HTML has.
+#   concurrency      – parallel pages per source (default 8 for http, 4 for
+#                      browser). Tune down if a site rate-limits you.
+#   pageTimeoutMs    – per-page render timeout in ms (default 20000). Crank
+#                      up only if pages legitimately need >20s to load.
+# [[ai.docs.sources]]
+# alias = "lancedb"
+# url = "https://lancedb.github.io/lancedb/"
+# description = "LanceDB vector store — table API, indexing, embeddings."
+# maxDepth = 2
+# maxPages = 200
+# includePatterns = ["**/lancedb/**"]
+# excludePatterns = []
+#
+# [[ai.docs.sources]]
+# alias = "fastembed"
+# url = "https://github.com/qdrant/fastembed#readme"
+# description = "fastembed Python/Rust embedder — model list, BGE-Small usage."
+# maxDepth = 0
+# maxPages = 1
 
 [ai.agent.mcpServers.filesystem]
 active = false

--- a/src/AI/AIAgent/commands/docsSetup.ts
+++ b/src/AI/AIAgent/commands/docsSetup.ts
@@ -1,0 +1,119 @@
+/**
+ * Programmatic installer for the Crawl4AI Python venv used by the docs
+ * pipeline. Called from `manageDocs()` (the interactive `kra ai docs` menu).
+ * The user-facing disk-usage prompt lives in `manageDocs`; this function
+ * just does the work and returns a structured result.
+ *
+ * Disk usage: ~507 MB total under `~/.kra/crawl4ai-venv/` (Python deps
+ * ≈ 318 MB, headless Chromium ≈ 189 MB).
+ */
+
+import fs from 'fs';
+import { spawn, execSync } from 'child_process';
+
+import {
+    crawl4aiVenvDir,
+    crawl4aiVenvPython,
+    crawl4aiInstalledMarker,
+} from '@/filePaths';
+import { docsPythonRequirementsPath } from '@/packagePaths';
+
+export type InstallCrawl4aiOptions = {
+    force?: boolean,
+};
+
+export type InstallCrawl4aiResult =
+    | { kind: 'already-installed', venvDir: string }
+    | { kind: 'installed', venvDir: string }
+    | { kind: 'error', message: string };
+
+function run(cmd: string, args: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(cmd, args, { stdio: 'inherit', env: process.env });
+        child.on('error', reject);
+        child.on('close', (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+        });
+    });
+}
+
+function findHostPython(): string | null {
+    const candidates = ['python3.12', 'python3.11', 'python3.13', 'python3.10', 'python3'];
+    for (const candidate of candidates) {
+        try {
+            execSync(`${candidate} --version`, { stdio: 'ignore' });
+            return candidate;
+        } catch { /* try next */ }
+    }
+    return null;
+}
+
+export function isCrawl4aiInstalled(): boolean {
+    return fs.existsSync(crawl4aiInstalledMarker);
+}
+
+export async function installCrawl4ai(opts: InstallCrawl4aiOptions = {}): Promise<InstallCrawl4aiResult> {
+    const force = opts.force === true;
+
+    if (isCrawl4aiInstalled() && !force) {
+        return { kind: 'already-installed', venvDir: crawl4aiVenvDir };
+    }
+
+    if (!fs.existsSync(docsPythonRequirementsPath)) {
+        return {
+            kind: 'error',
+            message: `requirements file not found at ${docsPythonRequirementsPath} (broken kra-workflow install)`,
+        };
+    }
+
+    const hostPython = findHostPython();
+    if (!hostPython) {
+        return {
+            kind: 'error',
+            message: 'no python3 interpreter found on PATH (install Python 3.10+)',
+        };
+    }
+
+    try {
+        if (!fs.existsSync(crawl4aiVenvPython) || force) {
+            console.log(`kra-docs: creating venv with ${hostPython} -m venv ${crawl4aiVenvDir}`);
+            await run(hostPython, ['-m', 'venv', crawl4aiVenvDir]);
+        }
+
+        console.log('kra-docs: upgrading pip in venv…');
+        await run(crawl4aiVenvPython, ['-m', 'pip', 'install', '--upgrade', 'pip']);
+
+        console.log('kra-docs: installing Crawl4AI (resolving full dependency tree)…');
+        await run(crawl4aiVenvPython, ['-m', 'pip', 'install', '-r', docsPythonRequirementsPath]);
+
+
+        const heavyOptional = [
+            'unclecode-litellm', 'litellm', 'openai',
+            'patchright', 'tf-playwright-stealth', 'playwright-stealth',
+            'alphashape', 'shapely', 'scipy', 'networkx',
+        ];
+        console.log(`kra-docs: pruning ${heavyOptional.length} heavy optional packages to keep the venv lean…`);
+        try {
+            await run(crawl4aiVenvPython, ['-m', 'pip', 'uninstall', '-y', ...heavyOptional]);
+        } catch { /* non-fatal */ }
+
+        console.log('kra-docs: installing chromium headless-shell via playwright…');
+        try {
+            await run(crawl4aiVenvPython, ['-m', 'playwright', 'install', 'chromium-headless-shell']);
+        } catch (err) {
+            console.warn('kra-docs: chromium-headless-shell install failed; falling back to full chromium.', err);
+            await run(crawl4aiVenvPython, ['-m', 'playwright', 'install', 'chromium']);
+        }
+
+        fs.writeFileSync(crawl4aiInstalledMarker, JSON.stringify({
+            installedAt: Date.now(),
+            pythonVersion: hostPython,
+        }, null, 2));
+
+        return { kind: 'installed', venvDir: crawl4aiVenvDir };
+    } catch (err) {
+        return { kind: 'error', message: (err as Error).message };
+    }
+}
+

--- a/src/AI/AIAgent/commands/manageDocs.ts
+++ b/src/AI/AIAgent/commands/manageDocs.ts
@@ -1,0 +1,370 @@
+/**
+ * `kra ai docs` — interactive blessed UI for the docs (Crawl4AI) pipeline.
+ *
+ * One entry point that mirrors `manageMemory()`:
+ *   - Setup Crawl4AI venv (or re-install)
+ *   - List configured sources, with a per-source action submenu
+ *     (Crawl this, Crawl --full, Drop indexed chunks, Show details)
+ *   - Crawl all sources
+ *   - Live crawl progress (polls docs-status.json every ~500 ms)
+ *   - Stop coordinator
+ *
+ * The legacy verbs (`update-docs`, `docs setup|status|list|stop`) have
+ * been removed — this menu is the only surface.
+ */
+
+import * as ui from '@/UI/generalUI';
+import { menuChain, UserCancelled } from '@/UI/menuChain';
+import { loadSettings } from '@/utils/common';
+import { getDocChunksTable } from '@/AI/AIAgent/shared/memory/db';
+import { docsCoordinatorJsPath } from '@/packagePaths';
+import { crawl4aiVenvDir } from '@/filePaths';
+import { createIPCClient, IPCsockets } from '../../../../eventSystem/ipc';
+import {
+    installCrawl4ai,
+    isCrawl4aiInstalled,
+} from './docsSetup';
+import {
+    showLiveProgress,
+    coordinatorAlive,
+    readSnapshot,
+} from '@/AI/AIAgent/shared/docs/liveProgressScreen';
+import type { DocsSettings, DocsSource } from '@/types/settingsTypes';
+import type { DocsSourceRequest } from '@/AI/AIAgent/shared/docs/types';
+
+
+async function loadDocsSettings(): Promise<DocsSettings | null> {
+    const settings = await loadSettings();
+    const cfg = settings.ai?.docs;
+    if (!cfg) return null;
+
+    return cfg;
+}
+
+async function chunkCountsByAlias(): Promise<Map<string, number>> {
+    const counts = new Map<string, number>();
+    try {
+        const { table } = await getDocChunksTable(null);
+        if (!table) return counts;
+        const rows = await table.query().select(['sourceAlias']).limit(100_000).toArray();
+        for (const row of rows as Array<{ sourceAlias: string }>) {
+            counts.set(row.sourceAlias, (counts.get(row.sourceAlias) ?? 0) + 1);
+        }
+    } catch { /* table may not exist yet */ }
+
+    return counts;
+}
+
+// ============================================================================
+// Top-level menu
+// ============================================================================
+
+export async function manageDocs(): Promise<void> {
+    await menuChain()
+        .step('action', async () => {
+            const items: string[] = [];
+            items.push(isCrawl4aiInstalled() ? 'Re-install Crawl4AI venv' : 'Setup Crawl4AI venv');
+            items.push('List configured sources');
+            items.push('Crawl all sources');
+
+            const live = coordinatorAlive() || readSnapshot() !== null;
+            items.push(live ? 'Live crawl progress' : 'Live crawl progress (no active crawl)');
+            items.push(live ? 'Stop coordinator' : 'Stop coordinator (not running)');
+
+            const choice = await ui.searchSelectAndReturnFromArray({
+                itemsArray: items,
+                prompt: 'kra-docs',
+            });
+
+            if (!choice) throw new UserCancelled();
+
+            return choice;
+        })
+        .step('_', async ({ action }) => {
+            if (action.startsWith('Setup') || action.startsWith('Re-install')) {
+                await setupAction();
+            } else if (action === 'List configured sources') {
+                await listSourcesMenu();
+            } else if (action === 'Crawl all sources') {
+                await crawlAllAction();
+            } else if (action.startsWith('Live crawl progress')) {
+                if (action.includes('no active crawl')) {
+                    await ui.showInfoScreen(
+                        'Live progress',
+                        'No active crawl. Start one via "Crawl all sources" or pick a source from the list.\n',
+                    );
+                } else {
+                    await showLiveProgress();
+                }
+            } else if (action.startsWith('Stop coordinator')) {
+                if (action.includes('not running')) {
+                    await ui.showInfoScreen('Stop coordinator', 'Coordinator does not appear to be running.\n');
+                } else {
+                    await stopCoordinatorAction();
+                }
+            }
+
+            throw new UserCancelled();
+        })
+        .run()
+        .catch((e) => { if (!(e instanceof UserCancelled)) throw e; });
+}
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+async function setupAction(): Promise<void> {
+    const installed = isCrawl4aiInstalled();
+    const message = installed
+        ? `Re-install Crawl4AI into ${crawl4aiVenvDir}?\nThis will redownload ~507 MB of dependencies and headless Chromium.`
+        : `Install Crawl4AI into ${crawl4aiVenvDir}?\nThis will download ~507 MB (Python deps ~318 MB, headless Chromium ~189 MB).`;
+
+    const ok = await ui.promptUserYesOrNo(message);
+    if (!ok) return;
+
+    console.log('');
+    const result = await installCrawl4ai({ force: installed });
+    console.log('');
+
+    if (result.kind === 'installed') {
+        await ui.showInfoScreen('Crawl4AI installed', `Installed under ${result.venvDir}\n\nYou can now crawl your configured sources.\n`);
+    } else if (result.kind === 'already-installed') {
+        await ui.showInfoScreen('Already installed', `Crawl4AI is already present at ${result.venvDir}.\n`);
+    } else {
+        await ui.showInfoScreen('Install failed', `Error: ${result.message}\n`);
+    }
+}
+
+// ============================================================================
+// List sources + per-source actions
+// ============================================================================
+
+async function listSourcesMenu(): Promise<void> {
+    await menuChain()
+        .step('pick', async () => {
+            const cfg = await loadDocsSettings();
+            if (!cfg?.sources || cfg.sources.length === 0) {
+                await ui.showInfoScreen(
+                    'No sources',
+                    'No sources configured under [[ai.docs.sources]] in settings.toml.\nAdd at least one entry and re-run.\n',
+                );
+                throw new UserCancelled();
+            }
+
+            const counts = await chunkCountsByAlias();
+            const labelToSource = new Map<string, DocsSource>();
+            const labels: string[] = [];
+            for (const src of cfg.sources) {
+                const count = counts.get(src.alias) ?? 0;
+                const depth = src.maxDepth ?? '\u221e';
+                const max = src.maxPages ?? '\u221e';
+                const label = `${src.alias.padEnd(22)} ${String(count).padStart(5)} chunks  \u00b7  depth=${depth}  \u00b7  maxPages=${max}`;
+                labels.push(label);
+                labelToSource.set(label, src);
+            }
+
+            const picked = await ui.searchSelectAndReturnFromArray({
+                itemsArray: labels,
+                prompt: 'kra-docs sources',
+            });
+
+            if (!picked) throw new UserCancelled();
+            const src = labelToSource.get(picked);
+            if (!src) throw new UserCancelled();
+
+            return src;
+        })
+        .step('_', async ({ pick }) => {
+            await sourceActions(pick);
+
+            throw new UserCancelled();
+        })
+        .run()
+        .catch((e) => { if (!(e instanceof UserCancelled)) throw e; });
+}
+
+async function sourceActions(src: DocsSource): Promise<void> {
+    await menuChain()
+        .step('action', async () => {
+            const action = await ui.searchSelectAndReturnFromArray({
+                itemsArray: [
+                    'Crawl this source',
+                    'Drop indexed chunks for this source',
+                    'Show source details',
+                ],
+                prompt: src.alias,
+            });
+
+            if (!action) throw new UserCancelled();
+
+            return action;
+        })
+        .step('_', async ({ action }) => {
+            if (action === 'Crawl this source') {
+                const bypass = await ui.promptUserYesOrNo(
+                    'Bypass the incremental cache (full re-crawl)?\n\n'
+                    + 'yes = re-fetch every page, ignore the page-hash cache.\n'
+                    + 'no  = skip pages whose content hasn\'t changed since last crawl (recommended).',
+                );
+                await crawlSources([src], { bypassIncremental: bypass });
+
+                return;
+            }
+            if (action.startsWith('Drop indexed chunks')) {
+                const ok = await ui.promptUserYesOrNo(
+                    `Delete every doc_chunks row where sourceAlias='${src.alias}'?\nNext crawl will re-index from scratch.`,
+                );
+                if (!ok) throw new UserCancelled();
+
+                const removed = await dropChunksForSource(src.alias);
+                await ui.showInfoScreen('Dropped chunks', `Removed ${removed} chunk(s) for '${src.alias}'.\n`);
+
+                return;
+            }
+            if (action === 'Show source details') {
+                const details = [
+                    `alias:        ${src.alias}`,
+                    `url:          ${src.url}`,
+                    `description:  ${src.description ?? '(none)'}`,
+                    `mode:         ${src.mode ?? '(auto)'}`,
+                    `maxDepth:     ${src.maxDepth ?? '\u221e'}`,
+                    `maxPages:     ${src.maxPages ?? '\u221e'}`,
+                    `concurrency:  ${src.concurrency ?? '(default)'}`,
+                    `pageTimeout:  ${src.pageTimeoutMs ?? '(default)'} ms`,
+                    `include:      ${(src.includePatterns ?? []).join(', ') || '(all)'}`,
+                    `exclude:      ${(src.excludePatterns ?? []).join(', ') || '(none)'}`,
+                ].join('\n');
+                await ui.showInfoScreen(src.alias, details + '\n');
+                throw new UserCancelled();
+            }
+        })
+        .run()
+        .catch((e) => { if (!(e instanceof UserCancelled)) throw e; });
+}
+
+async function dropChunksForSource(alias: string): Promise<number> {
+    try {
+        const { table } = await getDocChunksTable(null);
+        if (!table) return 0;
+        const before = await table.countRows().catch(() => 0);
+        const escaped = alias.replace(/'/g, "''");
+        await table.delete(`sourceAlias = '${escaped}'`);
+        const after = await table.countRows().catch(() => 0);
+
+        return Math.max(0, before - after);
+    } catch (err) {
+        console.warn(`kra-docs: failed to drop chunks for ${alias}: ${(err as Error).message}`);
+
+        return 0;
+    }
+}
+
+// ============================================================================
+// Crawl
+// ============================================================================
+
+async function crawlAllAction(): Promise<void> {
+    const cfg = await loadDocsSettings();
+    if (!cfg?.sources || cfg.sources.length === 0) {
+        await ui.showInfoScreen('No sources', 'No sources configured under [[ai.docs.sources]].\n');
+
+        return;
+    }
+    if (cfg.enabled === false) {
+        await ui.showInfoScreen('Disabled', '[ai.docs] is disabled in settings.toml. Set `enabled = true` to crawl.\n');
+
+        return;
+    }
+
+    const proceed = await ui.promptUserYesOrNo(
+        `Crawl all ${cfg.sources.length} source(s)?`,
+    );
+    if (!proceed) return;
+
+    const bypass = await ui.promptUserYesOrNo(
+        'Bypass the incremental cache (full re-crawl)?\n\n'
+        + 'yes = re-fetch every page, ignore the page-hash cache.\n'
+        + 'no  = skip pages whose content hasn\'t changed since last crawl (recommended).',
+    );
+
+    await crawlSources(cfg.sources, { bypassIncremental: bypass });
+}
+
+async function crawlSources(
+    sources: DocsSource[],
+    opts: { bypassIncremental: boolean },
+): Promise<void> {
+    if (!isCrawl4aiInstalled()) {
+        await ui.showInfoScreen(
+            'Crawl4AI not installed',
+            'Crawl4AI is not installed yet. Run "Setup Crawl4AI venv" from the main menu first.\n',
+        );
+
+        return;
+    }
+    if (sources.length === 0) return;
+
+    const client = createIPCClient(IPCsockets.DocsCoordinatorSocket);
+    try {
+        await client.ensureServerRunning(docsCoordinatorJsPath);
+    } catch (err) {
+        await ui.showInfoScreen('Coordinator failed', `Failed to start docs coordinator:\n${(err as Error).message}\n`);
+
+        return;
+    }
+
+    let submitted = 0;
+    const errors: string[] = [];
+    for (const source of sources) {
+        const msg: DocsSourceRequest = {
+            type: 'source-enqueue',
+            alias: source.alias,
+            url: source.url,
+            ...(source.maxDepth !== undefined ? { maxDepth: source.maxDepth } : {}),
+            ...(source.maxPages !== undefined ? { maxPages: source.maxPages } : {}),
+            ...(source.includePatterns !== undefined ? { includePatterns: source.includePatterns } : {}),
+            ...(source.excludePatterns !== undefined ? { excludePatterns: source.excludePatterns } : {}),
+            ...(source.mode !== undefined ? { mode: source.mode } : {}),
+            ...(source.concurrency !== undefined ? { concurrency: source.concurrency } : {}),
+            ...(source.pageTimeoutMs !== undefined ? { pageTimeoutMs: source.pageTimeoutMs } : {}),
+            ...(opts.bypassIncremental ? { bypassIncremental: true } : {}),
+        };
+        try {
+            await client.emit(JSON.stringify(msg));
+            submitted++;
+        } catch (err) {
+            errors.push(`${source.alias}: ${(err as Error).message}`);
+        }
+    }
+
+    const summary = [
+        `Submitted ${submitted}/${sources.length} source(s) to the coordinator.`,
+        '',
+        errors.length ? 'Errors:\n' + errors.map((e) => '  - ' + e).join('\n') : 'No errors.',
+        '',
+        'Open "Live crawl progress" from the main menu to follow progress.',
+        '',
+    ].join('\n');
+
+    const watch = await ui.promptUserYesOrNo(summary + '\nOpen the live progress screen now?');
+    if (watch) await showLiveProgress();
+}
+
+// ============================================================================
+// Stop
+// ============================================================================
+
+async function stopCoordinatorAction(): Promise<void> {
+    const ok = await ui.promptUserYesOrNo('Send shutdown-request to the docs coordinator?');
+    if (!ok) return;
+
+    const client = createIPCClient(IPCsockets.DocsCoordinatorSocket);
+    try {
+        await client.emit(JSON.stringify({ type: 'shutdown-request' }));
+        await ui.showInfoScreen('Stop sent', 'Shutdown request sent. The coordinator will exit after in-flight work completes.\n');
+    } catch (err) {
+        await ui.showInfoScreen('Stop failed', `Coordinator does not appear to be running.\n\n${(err as Error).message}\n`);
+    }
+}
+

--- a/src/AI/AIAgent/commands/manageMemory.ts
+++ b/src/AI/AIAgent/commands/manageMemory.ts
@@ -36,9 +36,6 @@ import {
     type MemoryEntry,
 } from '@/AI/AIAgent/shared/memory/types';
 
-const QUIT = 'Quit';
-
-
 /**
  * Open `initial` in nvim for editing. Returns the saved contents (or the
  * original if the user wrote nothing). Throws on nvim non-zero exit.
@@ -63,12 +60,11 @@ export async function manageMemory(): Promise<void> {
                 itemsArray: [
                     'Manage indexed codebases',
                     'Manage long-term memories',
-                    QUIT,
                 ],
                 prompt: 'kra-memory',
             });
 
-            if (!choice || choice === QUIT) throw new UserCancelled();
+            if (!choice) throw new UserCancelled();
 
             return choice;
         })

--- a/src/AI/AIAgent/mcp/serverConfig.ts
+++ b/src/AI/AIAgent/mcp/serverConfig.ts
@@ -36,6 +36,7 @@ export async function buildCoreMcpServers(): Promise<Record<string, MCPServerCon
             'update_memory',
             'edit_memory',
             'semantic_search',
+            'docs_search',
         ]),
     };
 }

--- a/src/AI/AIAgent/providers/copilot/copilotStartFlow.ts
+++ b/src/AI/AIAgent/providers/copilot/copilotStartFlow.ts
@@ -1,6 +1,6 @@
 import { type ModelInfo } from '@github/copilot-sdk';
 import * as conversation from '@/AI/AIAgent/shared/main/agentConversation';
-import { getAgentDefaultModel, getGithubToken } from '@/AI/AIAgent/shared/utils/agentSettings';
+import { getGithubToken } from '@/AI/AIAgent/shared/utils/agentSettings';
 import * as ui from '@/UI/generalUI';
 import type { ReasoningEffort } from '@/AI/AIAgent/shared/types/agentTypes';
 import { CopilotClientWrapper } from '@/AI/AIAgent/providers/copilot/copilotClient';
@@ -46,14 +46,6 @@ async function pickReasoningEffort(model: ModelInfo): Promise<ReasoningEffort | 
 
 async function pickCopilotModel(client: CopilotClientWrapper): Promise<PickedModel> {
     const models = sortModels(await client.listModels());
-    const defaultModelId = await getAgentDefaultModel();
-
-    if (defaultModelId && models.some((model) => model.id === defaultModelId)) {
-        const defaultModel = models.find((m) => m.id === defaultModelId)!;
-        const reasoningEffort = await pickReasoningEffort(defaultModel);
-
-        return { modelId: defaultModelId, ...(reasoningEffort ? { reasoningEffort } : {}) };
-    }
 
     const labelToModel = new Map<string, ModelInfo>();
     const itemsArray = models.map((model) => {

--- a/src/AI/AIAgent/shared/docs/chunker.ts
+++ b/src/AI/AIAgent/shared/docs/chunker.ts
@@ -1,0 +1,251 @@
+/**
+ * Markdown-aware chunker for documentation pages.
+ *
+ * Goals (vs. the line-window chunker we use for code):
+ *   - Respect heading hierarchy. We split on H1/H2/H3/H4 boundaries and
+ *     carry a `sectionPath` ("Guide > Indexing > IVF_PQ") through to the
+ *     resulting row metadata so retrieval can filter / display it.
+ *   - Never split inside a fenced code block (```), HTML block (`<...>`),
+ *     or a markdown table — these become atomic units even if oversized,
+ *     to keep semantics intact.
+ *   - Cap each chunk at a soft token budget (default ≈ 450 tokens for
+ *     BGE-Small's 512-token context, leaving headroom for the prepended
+ *     breadcrumb). When a section blows past the budget we split it on
+ *     paragraph boundaries with a single-paragraph overlap.
+ *   - Prepend the breadcrumb to the chunk content used for embedding so
+ *     the vector picks up topical context, but keep the raw section text
+ *     in `content` for snippet display.
+ *
+ * Token estimation is intentionally crude: we use a 4-chars-per-token
+ * heuristic. BGE-Small uses WordPiece, but for budgeting purposes this
+ * approximation is well within tolerance and avoids shipping a tokenizer.
+ */
+
+const DEFAULT_MAX_TOKENS = 450;
+const CHARS_PER_TOKEN = 4;
+
+export interface MarkdownChunk {
+    sectionPath: string;
+    content: string;
+    contentForEmbedding: string;
+    tokenCount: number;
+}
+
+export interface ChunkOptions {
+    pageTitle?: string;
+    maxTokens?: number;
+}
+
+export function chunkMarkdown(markdown: string, opts: ChunkOptions = {}): MarkdownChunk[] {
+    const maxTokens = Math.max(64, opts.maxTokens ?? DEFAULT_MAX_TOKENS);
+    const maxChars = maxTokens * CHARS_PER_TOKEN;
+
+    const blocks = parseBlocks(markdown);
+    const sections = groupBySection(blocks, opts.pageTitle ?? '');
+
+    const out: MarkdownChunk[] = [];
+    for (const section of sections) {
+        for (const piece of splitSection(section, maxChars)) {
+            const tokenCount = Math.ceil(piece.text.length / CHARS_PER_TOKEN);
+            const breadcrumb = piece.sectionPath ? `# ${piece.sectionPath}\n\n` : '';
+            out.push({
+                sectionPath: piece.sectionPath,
+                content: piece.text,
+                contentForEmbedding: breadcrumb + piece.text,
+                tokenCount,
+            });
+        }
+    }
+    return out;
+}
+
+interface MdBlock {
+    kind: 'heading' | 'code' | 'html' | 'table' | 'paragraph' | 'blank';
+    level?: number;
+    text: string;
+}
+
+function parseBlocks(markdown: string): MdBlock[] {
+    const lines = markdown.split('\n');
+    const blocks: MdBlock[] = [];
+
+    let i = 0;
+    while (i < lines.length) {
+        const line = lines[i];
+
+        if (/^\s*$/.test(line)) {
+            blocks.push({ kind: 'blank', text: '' });
+            i += 1;
+            continue;
+        }
+
+        const fenceMatch = /^(\s*)(```+|~~~+)(.*)$/.exec(line);
+        if (fenceMatch) {
+            const fence = fenceMatch[2];
+            const buf: string[] = [line];
+            i += 1;
+            while (i < lines.length) {
+                buf.push(lines[i]);
+                if (lines[i].trimStart().startsWith(fence)) {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            blocks.push({ kind: 'code', text: buf.join('\n') });
+            continue;
+        }
+
+        const heading = /^(#{1,6})\s+(.*?)\s*#*\s*$/.exec(line);
+        if (heading) {
+            blocks.push({ kind: 'heading', level: heading[1].length, text: heading[2].trim() });
+            i += 1;
+            continue;
+        }
+
+        if (/^\s*<[a-zA-Z][^>]*>/.test(line)) {
+            const buf: string[] = [line];
+            i += 1;
+            while (i < lines.length && lines[i].trim() !== '') {
+                buf.push(lines[i]);
+                i += 1;
+            }
+            blocks.push({ kind: 'html', text: buf.join('\n') });
+            continue;
+        }
+
+        if (/^\s*\|.*\|\s*$/.test(line)) {
+            const buf: string[] = [line];
+            i += 1;
+            while (i < lines.length && /^\s*\|.*\|\s*$/.test(lines[i])) {
+                buf.push(lines[i]);
+                i += 1;
+            }
+            blocks.push({ kind: 'table', text: buf.join('\n') });
+            continue;
+        }
+
+        const buf: string[] = [line];
+        i += 1;
+        while (i < lines.length && lines[i].trim() !== '' && !/^(#{1,6})\s+/.test(lines[i])) {
+            const next = lines[i];
+            if (/^(```+|~~~+)/.test(next.trimStart())) break;
+            if (/^\s*<[a-zA-Z][^>]*>/.test(next)) break;
+            if (/^\s*\|.*\|\s*$/.test(next)) break;
+            buf.push(next);
+            i += 1;
+        }
+        blocks.push({ kind: 'paragraph', text: buf.join('\n') });
+    }
+
+    return blocks;
+}
+
+interface MdSection {
+    sectionPath: string;
+    blocks: MdBlock[];
+}
+
+function groupBySection(blocks: MdBlock[], pageTitle: string): MdSection[] {
+    const stack: { level: number, title: string }[] = [];
+    const sections: MdSection[] = [];
+
+    let current: MdSection = {
+        sectionPath: pageTitle.trim(),
+        blocks: [],
+    };
+
+    for (const block of blocks) {
+        if (block.kind === 'heading') {
+            if (current.blocks.length > 0) {
+                sections.push(current);
+            }
+            const level = block.level ?? 1;
+            while (stack.length > 0 && stack[stack.length - 1].level >= level) {
+                stack.pop();
+            }
+            stack.push({ level, title: block.text });
+            const path = [pageTitle.trim(), ...stack.map((s) => s.title)]
+                .filter((s) => s.length > 0)
+                .join(' > ');
+            current = { sectionPath: path, blocks: [] };
+        } else {
+            current.blocks.push(block);
+        }
+    }
+    if (current.blocks.length > 0) {
+        sections.push(current);
+    }
+
+    return sections;
+}
+
+interface SectionPiece {
+    sectionPath: string;
+    text: string;
+}
+
+function splitSection(section: MdSection, maxChars: number): SectionPiece[] {
+    const pieces: SectionPiece[] = [];
+    const blocks = section.blocks.filter((b) => b.kind !== 'blank' || true);
+
+    let buf: MdBlock[] = [];
+    let bufChars = 0;
+    let lastFlushedTail: MdBlock | null = null;
+
+    const flush = (): void => {
+        if (buf.length === 0) return;
+        const text = renderBlocks(buf).trim();
+        if (text.length > 0) {
+            pieces.push({ sectionPath: section.sectionPath, text });
+            const last = buf[buf.length - 1];
+            lastFlushedTail = last && last.kind === 'paragraph' ? last : null;
+        }
+        buf = [];
+        bufChars = 0;
+    };
+
+    for (const block of blocks) {
+        const blockText = block.text;
+        const blockChars = blockText.length + 1;
+
+        const isAtomic = block.kind === 'code' || block.kind === 'html' || block.kind === 'table';
+
+        if (isAtomic && blockChars > maxChars) {
+            flush();
+            pieces.push({ sectionPath: section.sectionPath, text: blockText });
+            continue;
+        }
+
+        if (bufChars + blockChars > maxChars && buf.length > 0) {
+            flush();
+            if (lastFlushedTail !== null) {
+                const tail: MdBlock = lastFlushedTail;
+                buf.push(tail);
+                bufChars += tail.text.length + 1;
+                lastFlushedTail = null;
+            }
+        }
+
+        buf.push(block);
+        bufChars += blockChars;
+    }
+
+    flush();
+
+    if (pieces.length === 0 && blocks.length > 0) {
+        const text = renderBlocks(blocks).trim();
+        if (text.length > 0) {
+            pieces.push({ sectionPath: section.sectionPath, text });
+        }
+    }
+
+    return pieces;
+}
+
+function renderBlocks(blocks: MdBlock[]): string {
+    return blocks
+        .map((b) => (b.kind === 'blank' ? '' : b.text))
+        .join('\n\n')
+        .replace(/\n{3,}/g, '\n\n');
+}

--- a/src/AI/AIAgent/shared/docs/coordinator.ts
+++ b/src/AI/AIAgent/shared/docs/coordinator.ts
@@ -1,0 +1,433 @@
+// Docs coordinator — long-lived process that owns the LanceDB writer.
+//
+// Spawned on demand by `kra ai docs` via `IPCClient.ensureServerRunning`.
+// Lifecycle:
+//   1. Acquire `LockFiles.DocsWriteInProgress`. Refresh every 30 s while
+//      alive so a crashed coordinator's lock goes stale and is reclaimed.
+//   2. Listen on `IPCsockets.DocsCoordinatorSocket` for `source-enqueue`
+//      messages (JSON payloads) from CLI invocations.
+//   3. Maintain an in-memory queue of sources. Up to
+//      `[ai.docs] maxConcurrentSources` Python workers run in parallel.
+//   4. Each worker is `~/.kra/crawl4ai-venv/bin/python kra_docs_worker.py`,
+//      streaming JSONL to its stdout. The coordinator parses each line as
+//      a `DocsWorkerMessage` and ingests `page-fetched` events.
+//   5. Status snapshot is written to
+//      `<repo>/.kra-memory/docs-status.json` every 2 s for the
+//      `kra ai docs` live progress screen (no IPC reply path needed).
+//   6. After the queue drains and stays empty for `idleTimeoutMs`, the
+//      coordinator releases the lock, removes the status file, and exits.
+
+import 'module-alias/register';
+
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { spawn } from 'child_process';
+
+import { loadSettings } from '@/utils/common';
+import { crawl4aiInstalledMarker, crawl4aiVenvPython } from '@/filePaths';
+import { docsPythonWorkerPath } from '@/packagePaths';
+import { createIPCServer, IPCsockets, type IPCServer } from '../../../../../eventSystem/ipc';
+import {
+    LockFiles,
+    createLockFile,
+    deleteLockFile,
+} from '../../../../../eventSystem/lockFiles';
+import { ingestPage, removeSource } from './ingest';
+import {
+    loadDocsState,
+    saveDocsState,
+    knownPagesForAlias,
+    applyPageFetched,
+    applyPageUnchanged,
+    applyPageSkipped,
+    dropAliasState,
+} from './state';
+import { memoryDirectoryRoot } from '../memory/db';
+import type {
+    DocsClientMessage,
+    DocsSourcePhase,
+    DocsSourceRequest,
+    DocsSourceStatus,
+    DocsStateFile,
+    DocsStatusFile,
+    DocsWorkerMessage,
+} from './types';
+
+const DEFAULT_MAX_CONCURRENT = 2;
+const DEFAULT_IDLE_TIMEOUT_MS = 30_000;
+const LOCK_REFRESH_MS = 30_000;
+const STATUS_FLUSH_MS = 2_000;
+
+interface QueueEntry extends DocsSourceRequest {}
+
+const docsState: DocsStateFile = loadDocsState();
+
+const queue: QueueEntry[] = [];
+const enqueuedAliases = new Set<string>();
+const activeAliases = new Set<string>();
+const statuses = new Map<string, DocsSourceStatus>();
+
+let server: IPCServer | undefined;
+let lockRefreshTimer: NodeJS.Timeout | undefined;
+let idleExitTimer: NodeJS.Timeout | undefined;
+let statusFlushTimer: NodeJS.Timeout | undefined;
+let maxConcurrent = DEFAULT_MAX_CONCURRENT;
+let idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS;
+const startedAt = Date.now();
+let shuttingDown = false;
+
+function statusFilePath(): string {
+    return path.join(memoryDirectoryRoot(), 'docs-status.json');
+}
+
+function writeStatusFile(): void {
+    try {
+        const snapshot: DocsStatusFile = {
+            coordinatorPid: process.pid,
+            startedAt,
+            updatedAt: Date.now(),
+            sources: Array.from(statuses.values()),
+        };
+        fs.mkdirSync(memoryDirectoryRoot(), { recursive: true });
+        fs.writeFileSync(statusFilePath(), JSON.stringify(snapshot, null, 2));
+    } catch (err) {
+        console.error('docs-coordinator: failed to write status file', err);
+    }
+}
+
+function removeStatusFile(): void {
+    try {
+        if (fs.existsSync(statusFilePath())) fs.unlinkSync(statusFilePath());
+    } catch { /* ignore */ }
+}
+
+function ensureStatus(alias: string, phase: DocsSourcePhase): DocsSourceStatus {
+    let s = statuses.get(alias);
+    if (!s) {
+        s = {
+            alias,
+            phase,
+            pagesDone: 0,
+            pagesTotal: 0,
+            chunksWritten: 0,
+            errors: 0,
+        };
+        statuses.set(alias, s);
+    }
+    return s;
+}
+
+function scheduleIdleExit(): void {
+    if (idleExitTimer) clearTimeout(idleExitTimer);
+    idleExitTimer = setTimeout(() => {
+        if (queue.length === 0 && activeAliases.size === 0) {
+            shutdown(0);
+        }
+    }, idleTimeoutMs);
+}
+
+function cancelIdleExit(): void {
+    if (idleExitTimer) {
+        clearTimeout(idleExitTimer);
+        idleExitTimer = undefined;
+    }
+}
+
+function enqueueSource(req: DocsSourceRequest): 'accepted' | 'duplicate' {
+    if (enqueuedAliases.has(req.alias)) {
+        return 'duplicate';
+    }
+    enqueuedAliases.add(req.alias);
+    queue.push(req);
+    ensureStatus(req.alias, 'queued');
+    cancelIdleExit();
+    pump();
+    return 'accepted';
+}
+
+function pump(): void {
+    while (activeAliases.size < maxConcurrent && queue.length > 0) {
+        const next = queue.shift()!;
+        runSource(next).catch((err) => {
+            console.error(`docs-coordinator: source ${next.alias} crashed`, err);
+            const s = ensureStatus(next.alias, 'error');
+            s.phase = 'error';
+            s.errors += 1;
+            s.lastError = String(err);
+            s.finishedAt = Date.now();
+            activeAliases.delete(next.alias);
+            enqueuedAliases.delete(next.alias);
+            pump();
+            if (queue.length === 0 && activeAliases.size === 0) {
+                scheduleIdleExit();
+            }
+        });
+    }
+}
+
+function workerArgs(req: DocsSourceRequest): string[] {
+    const args = [
+        docsPythonWorkerPath,
+        '--alias', req.alias,
+        '--url', req.url,
+        '--max-depth', String(req.maxDepth ?? 0),
+        '--max-pages', String(req.maxPages ?? 50),
+        '--mode', req.mode ?? 'auto',
+        '--page-timeout-ms', String(req.pageTimeoutMs ?? 20000),
+    ];
+
+    if (req.concurrency !== undefined) {
+        args.push('--concurrency', String(req.concurrency));
+    }
+    for (const p of req.includePatterns ?? []) {
+        args.push('--include', p);
+    }
+    for (const p of req.excludePatterns ?? []) {
+        args.push('--exclude', p);
+    }
+    return args;
+}
+
+async function runSource(req: DocsSourceRequest): Promise<void> {
+    activeAliases.add(req.alias);
+    const status = ensureStatus(req.alias, 'crawling');
+    status.phase = 'crawling';
+    status.startedAt = Date.now();
+    status.errors = 0;
+    status.pagesDone = 0;
+    status.chunksWritten = 0;
+
+    // A re-crawl replaces all rows for this source. Doing the wipe up-front
+    // Only wipe the source up-front when the user explicitly opted out of
+    // incremental updates. Otherwise we rely on per-url upserts in ingestPage
+    // so unchanged pages keep their existing rows.
+    if (req.bypassIncremental) {
+        try {
+            await removeSource(req.alias);
+            dropAliasState(docsState, req.alias);
+        } catch (err) {
+            console.error(`docs-coordinator: removeSource(${req.alias}) failed`, err);
+        }
+    }
+
+    const knownPages = req.bypassIncremental ? {} : knownPagesForAlias(docsState, req.alias);
+    const child = spawn(crawl4aiVenvPython, workerArgs(req), {
+        stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    try {
+        child.stdin.write(JSON.stringify({ knownPages, bypassIncremental: !!req.bypassIncremental }) + '\n');
+        child.stdin.end();
+    } catch (err) {
+        console.error(`docs-coordinator: failed to send stdin payload to ${req.alias} worker`, err);
+    }
+
+    const stderrLines: string[] = [];
+    child.stderr.setEncoding('utf-8');
+    child.stderr.on('data', (chunk: string) => {
+        stderrLines.push(chunk);
+        if (stderrLines.length > 50) stderrLines.shift();
+    });
+
+    const rl = readline.createInterface({ input: child.stdout });
+    rl.on('line', (line) => {
+        handleWorkerLine(req, line).catch((err) => {
+            console.error(`docs-coordinator: ingest error for ${req.alias}`, err);
+            status.errors += 1;
+            status.lastError = String(err);
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        child.on('close', (code, signal) => {
+            const finished = ensureStatus(req.alias, status.phase);
+            finished.finishedAt = Date.now();
+            if (code !== 0 && finished.phase !== 'done') {
+                finished.phase = 'error';
+                finished.errors += 1;
+                finished.lastError = `worker exited with code=${code} signal=${signal}\n${stderrLines.join('').slice(-500)}`;
+            }
+            resolve();
+        });
+        child.on('error', (err) => {
+            const finished = ensureStatus(req.alias, 'error');
+            finished.phase = 'error';
+            finished.errors += 1;
+            finished.lastError = `failed to spawn worker: ${err.message}`;
+            finished.finishedAt = Date.now();
+            resolve();
+        });
+    });
+
+    activeAliases.delete(req.alias);
+    enqueuedAliases.delete(req.alias);
+    writeStatusFile();
+    pump();
+
+    if (queue.length === 0 && activeAliases.size === 0) {
+        scheduleIdleExit();
+    }
+}
+
+async function handleWorkerLine(req: DocsSourceRequest, line: string): Promise<void> {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    let msg: DocsWorkerMessage;
+    try {
+        msg = JSON.parse(trimmed) as DocsWorkerMessage;
+    } catch {
+        console.error(`docs-coordinator: bad JSONL from worker ${req.alias}: ${trimmed.slice(0, 200)}`);
+        return;
+    }
+
+    const status = ensureStatus(req.alias, 'crawling');
+
+    switch (msg.type) {
+        case 'worker-ready':
+            return;
+        case 'worker-progress': {
+            status.pagesDone = msg.pagesDone;
+            status.pagesTotal = Math.max(status.pagesTotal, msg.pagesTotal);
+            status.lastUrl = msg.currentUrl;
+            return;
+        }
+        case 'worker-error': {
+            status.errors += 1;
+            status.lastError = msg.error;
+            if (msg.fatal) {
+                status.phase = 'error';
+            }
+            return;
+        }
+        case 'mode-decided': {
+            status.mode = msg.mode;
+            return;
+        }
+        case 'page-fetched': {
+            status.phase = 'embedding';
+            try {
+                const result = await ingestPage({
+                    alias: req.alias,
+                    url: msg.url,
+                    title: msg.title,
+                    markdown: msg.markdown,
+                    indexedAt: Date.now(),
+                });
+                status.chunksWritten += result.chunksWritten;
+                applyPageFetched(docsState, req.alias, msg.url, {
+                    pageHash: result.pageHash,
+                    chunkCount: result.chunksWritten,
+                    indexedAt: Date.now(),
+                    ...(msg.etag ? { etag: msg.etag } : {}),
+                    ...(msg.lastModified ? { lastModified: msg.lastModified } : {}),
+                });
+            } catch (err) {
+                status.errors += 1;
+                status.lastError = `ingest failed for ${msg.url}: ${err instanceof Error ? err.message : String(err)}`;
+            } finally {
+                status.phase = 'crawling';
+            }
+            return;
+        }
+        case 'page-unchanged': {
+            status.pagesDone += 1;
+            applyPageUnchanged(docsState, req.alias, msg.url, {
+                pageHash: msg.pageHash,
+                indexedAt: Date.now(),
+                ...(msg.etag ? { etag: msg.etag } : {}),
+                ...(msg.lastModified ? { lastModified: msg.lastModified } : {}),
+            });
+            return;
+        }
+        case 'page-skipped': {
+            status.pagesDone += 1;
+            applyPageSkipped(docsState, req.alias, msg.url, Date.now());
+            return;
+        }
+        case 'source-done': {
+            status.phase = 'done';
+            status.finishedAt = Date.now();
+            status.pagesDone = msg.summary.pagesScraped + msg.summary.pagesSkipped;
+            saveDocsState(docsState);
+            return;
+        }
+    }
+}
+
+function handleClientMessage(raw: string): void {
+    const trimmed = raw.trim();
+    if (!trimmed) return;
+
+    let msg: DocsClientMessage;
+    try {
+        msg = JSON.parse(trimmed) as DocsClientMessage;
+    } catch {
+        console.error('docs-coordinator: invalid client message', trimmed.slice(0, 200));
+        return;
+    }
+
+    switch (msg.type) {
+        case 'source-enqueue':
+            enqueueSource(msg);
+            return;
+        case 'shutdown-request':
+            shutdown(0);
+            return;
+    }
+}
+
+function shutdown(code: number): void {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    if (lockRefreshTimer) clearInterval(lockRefreshTimer);
+    if (statusFlushTimer) clearInterval(statusFlushTimer);
+    if (idleExitTimer) clearTimeout(idleExitTimer);
+
+    try { server?.close(); } catch { /* ignore */ }
+
+    deleteLockFile(LockFiles.DocsWriteInProgress).finally(() => {
+        removeStatusFile();
+        process.exit(code);
+    });
+}
+
+async function main(): Promise<void> {
+    if (!fs.existsSync(crawl4aiInstalledMarker)) {
+        console.error('docs-coordinator: Crawl4AI venv not installed. Run `kra ai docs setup` first.');
+        process.exit(2);
+    }
+    if (!fs.existsSync(crawl4aiVenvPython)) {
+        console.error(`docs-coordinator: missing python at ${crawl4aiVenvPython}. Re-run \`kra ai docs setup\`.`);
+        process.exit(2);
+    }
+
+    const settings = await loadSettings();
+    const docsCfg = settings?.ai?.docs;
+    maxConcurrent = Math.max(1, docsCfg?.maxConcurrentSources ?? DEFAULT_MAX_CONCURRENT);
+    idleTimeoutMs = Math.max(5_000, docsCfg?.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS);
+
+    await createLockFile(LockFiles.DocsWriteInProgress);
+    lockRefreshTimer = setInterval(() => {
+        createLockFile(LockFiles.DocsWriteInProgress).catch(() => undefined);
+    }, LOCK_REFRESH_MS);
+    lockRefreshTimer.unref();
+
+    statusFlushTimer = setInterval(() => writeStatusFile(), STATUS_FLUSH_MS);
+    statusFlushTimer.unref();
+    writeStatusFile();
+
+    server = createIPCServer(IPCsockets.DocsCoordinatorSocket);
+    await server.addListener((event) => handleClientMessage(event));
+
+    process.on('SIGINT', () => shutdown(0));
+    process.on('SIGTERM', () => shutdown(0));
+
+    scheduleIdleExit();
+}
+
+main().catch((err) => {
+    console.error('docs-coordinator: fatal', err);
+    shutdown(1);
+});

--- a/src/AI/AIAgent/shared/docs/ingest.ts
+++ b/src/AI/AIAgent/shared/docs/ingest.ts
@@ -1,0 +1,184 @@
+// Markdown ingest pipeline for the docs coordinator.
+//
+// Given a single page (markdown + metadata) coming off a worker's stdout,
+// this module:
+//   1. Splits the markdown via the markdown-aware chunker (heading-aware,
+//      code-block atomic) so chunks carry section context.
+//   2. Embeds each chunk's `contentForEmbedding` (breadcrumb + body) with
+//      the existing BGE-Small encoder.
+//   3. Upserts into the `doc_chunks` LanceDB table (delete-by-url-then-add)
+//      so re-crawling a page replaces stale rows instead of duplicating.
+
+import crypto from 'crypto';
+import { embedMany } from '../memory/embedder';
+import { getDocChunksTable } from '../memory/db';
+import { chunkMarkdown } from './chunker';
+import type { DocChunkRow } from './types';
+
+export interface IngestPageInput {
+    alias: string;
+    url: string;
+    title: string;
+    markdown: string;
+    indexedAt?: number;
+    maxTokens?: number;
+}
+
+export interface IngestPageResult {
+    chunksWritten: number;
+    chunksSkipped: number;
+    chunksDeleted: number;
+    pageHash: string;
+}
+
+interface BuiltDocChunk {
+    row: Omit<DocChunkRow, 'vector'>;
+    contentForEmbedding: string;
+}
+
+export function buildDocChunks(input: IngestPageInput): BuiltDocChunk[] {
+    const indexedAt = input.indexedAt ?? Date.now();
+    const opts: { pageTitle?: string; maxTokens?: number } = {};
+    if (input.title) opts.pageTitle = input.title;
+    if (input.maxTokens !== undefined) opts.maxTokens = input.maxTokens;
+
+    const chunks = chunkMarkdown(input.markdown, opts);
+    const out: BuiltDocChunk[] = [];
+
+    chunks.forEach((chunk, chunkIndex) => {
+        const slice = chunk.content;
+        if (slice.trim().length === 0) return;
+
+        const hash = crypto.createHash('sha1')
+            .update(input.alias)
+            .update('\u0000')
+            .update(input.url)
+            .update('\u0000')
+            .update(chunk.sectionPath)
+            .update('\u0000')
+            .update(String(chunkIndex))
+            .update('\u0000')
+            .update(slice)
+            .digest('hex');
+
+        const id = `${input.alias}:${hashShort(input.url)}:${chunkIndex}:${hash.slice(0, 12)}`;
+
+        out.push({
+            row: {
+                id,
+                sourceAlias: input.alias,
+                url: input.url,
+                pageTitle: input.title,
+                sectionPath: chunk.sectionPath,
+                chunkIndex,
+                tokenCount: chunk.tokenCount,
+                content: slice,
+                contentHash: hash,
+                indexedAt,
+            },
+            contentForEmbedding: chunk.contentForEmbedding,
+        });
+    });
+
+    return out;
+}
+
+export function pageHash(markdown: string): string {
+    return crypto.createHash('sha256').update(markdown, 'utf-8').digest('hex');
+}
+
+/**
+ * Chunk + embed + upsert a single page. Existing rows for the same `url` are
+ * deleted before the new rows are inserted so a re-crawl of the same page
+ * replaces stale chunks.
+ */
+export async function ingestPage(input: IngestPageInput): Promise<IngestPageResult> {
+    const built = buildDocChunks(input);
+
+    const ph = pageHash(input.markdown);
+
+    if (built.length === 0) {
+        await removePage(input.alias, input.url);
+        return { chunksWritten: 0, chunksSkipped: 0, chunksDeleted: 0, pageHash: ph };
+    }
+
+    const vectors = await embedMany(built.map((b) => b.contentForEmbedding));
+    const rows: DocChunkRow[] = built.map((b, i) => ({ ...b.row, vector: vectors[i] }));
+
+    const seedRow = rows[0] ?? null;
+    const { table, justCreated } = await getDocChunksTable(seedRow);
+
+    if (!table) {
+        return { chunksWritten: 0, chunksSkipped: 0, chunksDeleted: 0, pageHash: ph };
+    }
+
+    let chunksDeleted = 0;
+    if (!justCreated) {
+        chunksDeleted = await deleteByUrl(input.alias, input.url);
+    }
+
+    let written = 0;
+    if (rows.length > 0) {
+        if (justCreated) {
+            if (rows.length > 1) {
+                await table.add(rows.slice(1) as unknown as Record<string, unknown>[]);
+            }
+        } else {
+            await table.add(rows as unknown as Record<string, unknown>[]);
+        }
+        written = rows.length;
+    }
+
+    return { chunksWritten: written, chunksSkipped: 0, chunksDeleted, pageHash: ph };
+}
+
+/**
+ * Remove every chunk for a single page. Returns the number deleted.
+ */
+export async function removePage(alias: string, url: string): Promise<number> {
+    return deleteByUrl(alias, url);
+}
+
+/**
+ * Remove every chunk for a whole source. Used when a source is dropped from
+ * settings or when the user explicitly purges via `kra ai docs ...` (future).
+ */
+export async function removeSource(alias: string): Promise<number> {
+    const { table } = await getDocChunksTable(null);
+    if (!table) return 0;
+
+    const before = await safeCount(table);
+    await table.delete(`sourceAlias = '${escapeSql(alias)}'`);
+    const after = await safeCount(table);
+
+    return Math.max(0, before - after);
+}
+
+async function deleteByUrl(alias: string, url: string): Promise<number> {
+    const { table } = await getDocChunksTable(null);
+    if (!table) return 0;
+
+    const before = await safeCount(table);
+    await table.delete(
+        `sourceAlias = '${escapeSql(alias)}' AND url = '${escapeSql(url)}'`,
+    );
+    const after = await safeCount(table);
+
+    return Math.max(0, before - after);
+}
+
+async function safeCount(table: { countRows: () => Promise<number> }): Promise<number> {
+    try {
+        return await table.countRows();
+    } catch {
+        return 0;
+    }
+}
+
+function escapeSql(s: string): string {
+    return s.replace(/'/g, "''");
+}
+
+function hashShort(s: string): string {
+    return crypto.createHash('sha1').update(s).digest('hex').slice(0, 10);
+}

--- a/src/AI/AIAgent/shared/docs/liveProgressScreen.ts
+++ b/src/AI/AIAgent/shared/docs/liveProgressScreen.ts
@@ -1,0 +1,198 @@
+/**
+ * Live progress screen for `kra ai docs`.
+ *
+ * Polls `<repo>/.kra-memory/docs-status.json` every ~500 ms and renders a
+ * blessed table + scrollable event log. Pure UI: no coordinator side
+ * effects beyond the optional `s` keybinding which sends a
+ * `shutdown-request` over IPC.
+ *
+ * Extracted from `commands/manageDocs.ts` to keep the menu file focused
+ * on flow control. Behavior is identical to the previous inline version.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import blessed from 'blessed';
+
+import { memoryDirectoryRoot } from '@/AI/AIAgent/shared/memory/db';
+import { createIPCClient, IPCsockets } from '../../../../../eventSystem/ipc';
+import type { DocsStatusFile, DocsSourceStatus } from './types';
+
+export function statusFilePath(): string {
+    return path.join(memoryDirectoryRoot(), 'docs-status.json');
+}
+
+export function readSnapshot(): DocsStatusFile | null {
+    const file = statusFilePath();
+    if (!fs.existsSync(file)) return null;
+    try {
+        return JSON.parse(fs.readFileSync(file, 'utf8')) as DocsStatusFile;
+    } catch {
+        return null;
+    }
+}
+
+export function coordinatorAlive(): boolean {
+    const snap = readSnapshot();
+    if (!snap) return false;
+    try {
+        process.kill(snap.coordinatorPid, 0);
+
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function indexByAlias(rows: DocsSourceStatus[]): Map<string, DocsSourceStatus> {
+    const m = new Map<string, DocsSourceStatus>();
+    for (const r of rows) m.set(r.alias, r);
+
+    return m;
+}
+
+function tableRow(s: DocsSourceStatus): string[] {
+    const url = s.lastUrl ? (s.lastUrl.length > 60 ? s.lastUrl.slice(0, 57) + '...' : s.lastUrl) : '';
+
+    return [
+        s.alias,
+        s.phase,
+        `${s.pagesDone}/${s.pagesTotal}`,
+        String(s.chunksWritten),
+        String(s.errors),
+        s.mode ?? '',
+        url,
+    ];
+}
+
+function diffLines(prev: Map<string, DocsSourceStatus>, next: DocsSourceStatus[]): string[] {
+    const out: string[] = [];
+    for (const n of next) {
+        const p = prev.get(n.alias);
+        if (!p) {
+            out.push(`[${n.alias}] tracked: phase=${n.phase}`);
+            continue;
+        }
+        if (p.phase !== n.phase) out.push(`[${n.alias}] phase: ${p.phase} \u2192 ${n.phase}`);
+        if (n.pagesDone > p.pagesDone) out.push(`[${n.alias}] pages: ${p.pagesDone} \u2192 ${n.pagesDone}/${n.pagesTotal}`);
+        if (n.chunksWritten > p.chunksWritten) out.push(`[${n.alias}] chunks: +${n.chunksWritten - p.chunksWritten} (total ${n.chunksWritten})`);
+        if (n.errors > p.errors) out.push(`[${n.alias}] error: ${n.lastError ?? '(no message)'}`);
+        if (n.phase === 'done' && p.phase !== 'done') out.push(`[${n.alias}] DONE \u2192 ${n.chunksWritten} chunks, ${n.errors} errors`);
+    }
+
+    return out;
+}
+
+export async function showLiveProgress(): Promise<void> {
+    const screen = blessed.screen({ smartCSR: true, title: 'kra-docs · live' });
+
+    const header = blessed.box({
+        parent: screen,
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: 1,
+        tags: true,
+        content: '{bold}kra-docs · live progress{/bold}  —  q/Esc to close · s to stop coordinator',
+        style: { fg: 'white', bg: 'blue' },
+    });
+
+    const table = blessed.listtable({
+        parent: screen,
+        top: 1,
+        left: 0,
+        width: '100%',
+        height: '60%',
+        keys: false,
+        mouse: false,
+        align: 'left',
+        border: { type: 'line' },
+        style: {
+            header: { fg: 'cyan', bold: true },
+            cell: { fg: 'white' },
+            border: { fg: 'gray' },
+        },
+        data: [['alias', 'phase', 'pages', 'chunks', 'err', 'mode', 'last url']],
+    });
+
+    const log = blessed.log({
+        parent: screen,
+        top: '60%+1',
+        left: 0,
+        width: '100%',
+        bottom: 0,
+        border: { type: 'line' },
+        label: ' events (j/k · PgUp/PgDn · mouse wheel) ',
+        scrollable: true,
+        alwaysScroll: true,
+        scrollback: 5000,
+        keys: true,
+        mouse: true,
+        vi: true,
+        tags: true,
+        scrollbar: { ch: ' ', style: { bg: 'cyan' } },
+        style: { border: { fg: 'gray' } },
+    });
+    log.focus();
+
+    let lastByAlias = new Map<string, DocsSourceStatus>();
+    let lastUpdatedAt = 0;
+
+    const refresh = (): void => {
+        const snap = readSnapshot();
+        if (!snap) {
+            table.setData([
+                ['alias', 'phase', 'pages', 'chunks', 'err', 'mode', 'last url'],
+                ['(no active crawl — docs-status.json missing)', '', '', '', '', '', ''],
+            ]);
+            screen.render();
+
+            return;
+        }
+
+        const rows: string[][] = [['alias', 'phase', 'pages', 'chunks', 'err', 'mode', 'last url']];
+        for (const s of snap.sources) rows.push(tableRow(s));
+        if (snap.sources.length === 0) rows.push(['(no sources tracked yet)', '', '', '', '', '', '']);
+        table.setData(rows);
+
+        if (snap.updatedAt !== lastUpdatedAt) {
+            const deltas = diffLines(lastByAlias, snap.sources);
+            for (const line of deltas) log.add(line);
+            lastUpdatedAt = snap.updatedAt;
+            lastByAlias = indexByAlias(snap.sources);
+        }
+
+        const ageSec = Math.max(0, Math.round((Date.now() - snap.updatedAt) / 1000));
+        let alive = false;
+        try { process.kill(snap.coordinatorPid, 0); alive = true; } catch { /* dead */ }
+        header.setContent(
+            `{bold}kra-docs · live progress{/bold}  —  pid ${snap.coordinatorPid} (${alive ? 'running' : 'exited'}) · updated ${ageSec}s ago  —  q/Esc close · s stop · j/k scroll`,
+        );
+        screen.render();
+    };
+
+    refresh();
+    const tick = setInterval(refresh, 500);
+
+    const closeAndDestroy = (): void => {
+        clearInterval(tick);
+        screen.destroy();
+    };
+
+    screen.key(['q', 'escape', 'C-c'], closeAndDestroy);
+    screen.key(['s'], async (): Promise<void> => {
+        try {
+            const client = createIPCClient(IPCsockets.DocsCoordinatorSocket);
+            await client.emit(JSON.stringify({ type: 'shutdown-request' }));
+            log.add('{yellow-fg}sent shutdown-request{/yellow-fg}');
+            screen.render();
+        } catch (err) {
+            log.add(`{red-fg}stop failed: ${(err as Error).message}{/red-fg}`);
+            screen.render();
+        }
+    });
+
+    await new Promise<void>((resolve) => {
+        screen.on('destroy', () => resolve());
+    });
+}

--- a/src/AI/AIAgent/shared/docs/search.ts
+++ b/src/AI/AIAgent/shared/docs/search.ts
@@ -1,0 +1,147 @@
+/**
+ * Vector search over the doc_chunks table populated by `kra ai docs`.
+ *
+ * Mirrors the shape of `semanticSearch` (memory/search.ts) but tuned for
+ * documentation: it returns the actual chunk content (capped) rather than
+ * just file ranges, since the agent has no other way to pull the markdown
+ * back. Hits are aggregated per page (sourceAlias + url) so the agent gets
+ * one logical entry per page with the best-scoring sections inlined.
+ */
+import { embedOne } from '../memory/embedder';
+import { getDocChunksTable } from '../memory/db';
+import type { DocChunkRow } from './types';
+
+const MIN_SCORE = 0.5;
+const MAX_K = 50;
+const DEFAULT_K = 8;
+const SECTIONS_PER_PAGE = 3;
+const CONTENT_CHAR_BUDGET = 1200;
+
+export interface DocsSearchInput {
+    query: string;
+    k?: number;
+    sourceAlias?: string;
+}
+
+export interface DocsSearchSection {
+    sectionPath: string;
+    chunkIndex: number;
+    score: number;
+    content: string;
+    truncated: boolean;
+    tokenCount: number;
+}
+
+export interface DocsSearchHit {
+    sourceAlias: string;
+    url: string;
+    pageTitle: string;
+    score: number;
+    sections: DocsSearchSection[];
+}
+
+interface RawDocHit {
+    row: DocChunkRow;
+    score: number;
+}
+
+export async function docsSearch(input: DocsSearchInput): Promise<DocsSearchHit[]> {
+    if (typeof input.query !== 'string' || input.query.trim() === '') {
+        throw new Error('docsSearch: query is required and must be non-empty');
+    }
+    const k = clamp(input.k ?? DEFAULT_K, 1, MAX_K);
+
+    const { table } = await getDocChunksTable(null);
+    if (!table) return [];
+
+    const queryVector = await embedOne(input.query);
+
+    const fetchK = Math.min(Math.max(k * 8, 40), 400);
+    const rows = (await table.search(queryVector).limit(fetchK).toArray()) as Array<DocChunkRow & { _distance?: number }>;
+
+    const aliasFilter = input.sourceAlias?.trim();
+
+    const raw: RawDocHit[] = rows
+        .map((row) => ({ row, score: distanceToScore(row._distance) }))
+        .filter((hit) => hit.score >= MIN_SCORE)
+        .filter((hit) => !aliasFilter || hit.row.sourceAlias === aliasFilter);
+
+    const grouped = groupByPage(raw);
+    const topPages = [...grouped.values()]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, k);
+
+    return topPages.map((page) => {
+        const sections = page.sections
+            .sort((a, b) => b.score - a.score)
+            .slice(0, SECTIONS_PER_PAGE)
+            .map((s) => buildSection(s));
+
+        return {
+            sourceAlias: page.sourceAlias,
+            url: page.url,
+            pageTitle: page.pageTitle,
+            score: page.score,
+            sections,
+        } satisfies DocsSearchHit;
+    });
+}
+
+interface PageGroup {
+    sourceAlias: string;
+    url: string;
+    pageTitle: string;
+    score: number;
+    sections: RawDocHit[];
+}
+
+function groupByPage(hits: RawDocHit[]): Map<string, PageGroup> {
+    const groups = new Map<string, PageGroup>();
+    for (const hit of hits) {
+        const key = `${hit.row.sourceAlias}|${hit.row.url}`;
+        const existing = groups.get(key);
+        if (existing) {
+            existing.sections.push(hit);
+            if (hit.score > existing.score) existing.score = hit.score;
+        } else {
+            groups.set(key, {
+                sourceAlias: hit.row.sourceAlias,
+                url: hit.row.url,
+                pageTitle: hit.row.pageTitle,
+                score: hit.score,
+                sections: [hit],
+            });
+        }
+    }
+
+    return groups;
+}
+
+function buildSection(hit: RawDocHit): DocsSearchSection {
+    const content = hit.row.content ?? '';
+    const truncated = content.length > CONTENT_CHAR_BUDGET;
+    const trimmed = truncated ? content.slice(0, CONTENT_CHAR_BUDGET) + '\n…[truncated]' : content;
+
+    return {
+        sectionPath: hit.row.sectionPath,
+        chunkIndex: hit.row.chunkIndex,
+        score: hit.score,
+        content: trimmed,
+        truncated,
+        tokenCount: hit.row.tokenCount,
+    };
+}
+
+function distanceToScore(distance: number | undefined): number {
+    if (typeof distance !== 'number' || Number.isNaN(distance)) return 0;
+    if (distance <= 0) return 1;
+
+    return 1 / (1 + distance);
+}
+
+function clamp(value: number, min: number, max: number): number {
+    if (value < min) return min;
+    if (value > max) return max;
+
+    return value;
+}

--- a/src/AI/AIAgent/shared/docs/state.ts
+++ b/src/AI/AIAgent/shared/docs/state.ts
@@ -1,0 +1,129 @@
+/**
+ * Persistence helpers for incremental docs re-crawl state.
+ *
+ * Stores per-page metadata (etag, last-modified, content hash, last-indexed
+ * timestamp) so the worker can skip pages whose content hasn't changed since
+ * the last successful crawl.
+ *
+ * Lives at `<repo>/.kra-memory/docs-state.json`. Owned exclusively by the
+ * coordinator process — workers receive their slice of `knownPages` over
+ * stdin and never touch the file directly.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { memoryDirectoryRoot } from '../memory/db';
+import type { DocsStateFile, DocsPageState } from './types';
+import { pageStateKey } from './types';
+
+const STATE_VERSION = 1;
+
+export function docsStateFilePath(): string {
+    return path.join(memoryDirectoryRoot(), 'docs-state.json');
+}
+
+export function loadDocsState(): DocsStateFile {
+    const fp = docsStateFilePath();
+    try {
+        if (!fs.existsSync(fp)) {
+            return { version: STATE_VERSION, pages: {} };
+        }
+        const raw = fs.readFileSync(fp, 'utf-8');
+        const parsed = JSON.parse(raw) as DocsStateFile;
+        if (!parsed || typeof parsed !== 'object' || parsed.version !== STATE_VERSION || !parsed.pages) {
+            return { version: STATE_VERSION, pages: {} };
+        }
+        return parsed;
+    } catch (err) {
+        console.error('docs-state: failed to load, starting fresh:', err);
+        return { version: STATE_VERSION, pages: {} };
+    }
+}
+
+export function saveDocsState(state: DocsStateFile): void {
+    try {
+        fs.mkdirSync(memoryDirectoryRoot(), { recursive: true });
+        fs.writeFileSync(docsStateFilePath(), JSON.stringify(state, null, 2));
+    } catch (err) {
+        console.error('docs-state: failed to save:', err);
+    }
+}
+
+export function getPageState(state: DocsStateFile, alias: string, url: string): DocsPageState | undefined {
+    return state.pages[pageStateKey(alias, url)];
+}
+
+export function setPageState(state: DocsStateFile, alias: string, url: string, page: DocsPageState): void {
+    state.pages[pageStateKey(alias, url)] = page;
+}
+
+export function knownPagesForAlias(state: DocsStateFile, alias: string): Record<string, DocsPageState> {
+    const prefix = `${alias}|`;
+    const out: Record<string, DocsPageState> = {};
+    for (const [k, v] of Object.entries(state.pages)) {
+        if (k.startsWith(prefix)) {
+            out[k.slice(prefix.length)] = v;
+        }
+    }
+    return out;
+}
+
+export function dropAliasState(state: DocsStateFile, alias: string): void {
+    const prefix = `${alias}|`;
+    for (const k of Object.keys(state.pages)) {
+        if (k.startsWith(prefix)) {
+            delete state.pages[k];
+        }
+    }
+}
+
+/**
+ * Pure state mutators used by the coordinator's IPC handler. Kept here
+ * so they can be unit-tested in isolation without spinning up the long-lived
+ * coordinator process.
+ */
+export function applyPageFetched(
+    state: DocsStateFile,
+    alias: string,
+    url: string,
+    args: { pageHash: string; chunkCount: number; etag?: string; lastModified?: string; indexedAt: number },
+): void {
+    const ps: DocsPageState = {
+        lastIndexedAt: args.indexedAt,
+        pageHash: args.pageHash,
+        chunkCount: args.chunkCount,
+    };
+    if (args.etag) ps.etag = args.etag;
+    if (args.lastModified) ps.lastModified = args.lastModified;
+    setPageState(state, alias, url, ps);
+}
+
+export function applyPageUnchanged(
+    state: DocsStateFile,
+    alias: string,
+    url: string,
+    args: { pageHash: string; etag?: string; lastModified?: string; indexedAt: number },
+): void {
+    const existing = getPageState(state, alias, url);
+    const ps: DocsPageState = {
+        lastIndexedAt: args.indexedAt,
+        pageHash: args.pageHash,
+        chunkCount: existing?.chunkCount ?? 0,
+    };
+    if (args.etag) ps.etag = args.etag;
+    if (args.lastModified) ps.lastModified = args.lastModified;
+    setPageState(state, alias, url, ps);
+}
+
+export function applyPageSkipped(
+    state: DocsStateFile,
+    alias: string,
+    url: string,
+    indexedAt: number,
+): void {
+    const existing = getPageState(state, alias, url);
+    if (existing) {
+        existing.lastIndexedAt = indexedAt;
+    }
+}

--- a/src/AI/AIAgent/shared/docs/types.ts
+++ b/src/AI/AIAgent/shared/docs/types.ts
@@ -1,0 +1,100 @@
+// IPC and ingest types for the docs coordinator.
+//
+// Wire format on both ends is JSON:
+//   - CLI -> coordinator: a single JSON-encoded `DocsClientMessage` written
+//     via the existing `IPCClient.emit` (one connection per message).
+//   - Worker -> coordinator: JSON Lines over the worker's stdout
+//     (one `DocsWorkerMessage` per line). Workers are spawned as child
+//     processes by the coordinator, so stdout is read directly.
+//   - Coordinator -> CLI status: read from a periodically-written status
+//     file at `<repo>/.kra-memory/docs-status.json`. No reply channel on
+//     the IPC socket itself.
+
+export type DocsSourceRequest = {
+    type: 'source-enqueue',
+    alias: string,
+    url: string,
+    maxDepth?: number,
+    maxPages?: number,
+    includePatterns?: string[],
+    excludePatterns?: string[],
+    bypassIncremental?: boolean,
+    mode?: 'auto' | 'http' | 'browser',
+    concurrency?: number,
+    pageTimeoutMs?: number,
+};
+
+export type DocsClientMessage =
+    | DocsSourceRequest
+    | { type: 'shutdown-request' };
+
+export type DocsWorkerMessage =
+    | { type: 'worker-ready', alias: string, pid: number }
+    | { type: 'mode-decided', alias: string, mode: 'http' | 'browser', reason: string }
+    | { type: 'page-fetched', alias: string, url: string, title: string, markdown: string, links: string[], hash: string, etag?: string, lastModified?: string }
+    | { type: 'page-unchanged', alias: string, url: string, pageHash: string, etag?: string, lastModified?: string }
+    | { type: 'page-skipped', alias: string, url: string, reason: 'sitemap-unchanged' | 'http-not-modified' }
+    | { type: 'worker-progress', alias: string, pagesDone: number, pagesTotal: number, currentUrl: string }
+    | { type: 'worker-error', alias: string, url?: string, error: string, fatal: boolean }
+    | { type: 'source-done', alias: string, summary: { pagesScraped: number, pagesSkipped: number, chunksWritten: number, elapsedMs: number } };
+
+export type DocsSourcePhase =
+    | 'queued'
+    | 'crawling'
+    | 'embedding'
+    | 'done'
+    | 'error';
+
+export type DocsSourceStatus = {
+    alias: string,
+    phase: DocsSourcePhase,
+    pagesDone: number,
+    pagesTotal: number,
+    chunksWritten: number,
+    errors: number,
+    startedAt?: number,
+    finishedAt?: number,
+    lastUrl?: string,
+    lastError?: string,
+    mode?: 'http' | 'browser',
+};
+
+export type DocsStatusFile = {
+    coordinatorPid: number,
+    startedAt: number,
+    updatedAt: number,
+    sources: DocsSourceStatus[],
+};
+
+export type DocChunkRow = {
+    id: string,
+    sourceAlias: string,
+    url: string,
+    pageTitle: string,
+    sectionPath: string,
+    chunkIndex: number,
+    tokenCount: number,
+    content: string,
+    contentHash: string,
+    indexedAt: number,
+    vector: number[],
+};
+
+// Per-page state used to short-circuit re-crawls.
+export type DocsPageState = {
+    etag?: string,
+    lastModified?: string,
+    lastIndexedAt: number,
+    pageHash: string,
+    chunkCount: number,
+};
+
+// Persisted to <repo>/.kra-memory/docs-state.json.
+export type DocsStateFile = {
+    version: 1,
+    pages: Record<string, DocsPageState>,
+};
+
+export function pageStateKey(alias: string, url: string): string {
+    return `${alias}|${url}`;
+}

--- a/src/AI/AIAgent/shared/memory/db.ts
+++ b/src/AI/AIAgent/shared/memory/db.ts
@@ -16,6 +16,7 @@
 import path from 'path';
 import { connect, type Connection, type Table } from '@lancedb/lancedb';
 import type { CodeChunkRow, MemoryRow } from './types';
+import type { DocChunkRow } from '../docs/types';
 
 const MEMORY_FINDINGS_TABLE = 'memory_findings';
 const MEMORY_REVISITS_TABLE = 'memory_revisits';
@@ -24,8 +25,10 @@ let dbCache: Connection | null = null;
 let memoryFindingsTableCache: Table | null = null;
 let memoryRevisitsTableCache: Table | null = null;
 let codeChunksTableCache: Table | null = null;
+let docChunksTableCache: Table | null = null;
 
 const CODE_CHUNKS_TABLE = 'code_chunks';
+const DOC_CHUNKS_TABLE = 'doc_chunks';
 const LEGACY_MEMORY_TABLE = 'memory';
 let legacyDropAttempted = false;
 
@@ -200,6 +203,70 @@ export async function getCodeChunksTable(seedRow: CodeChunkRow | null): Promise<
  */
 export async function countCodeChunks(): Promise<number> {
     const { table } = await getCodeChunksTable(null);
+
+    if (!table) return 0;
+
+    try {
+        return await table.countRows();
+    } catch {
+        return 0;
+    }
+}
+
+export interface GetDocChunksTableResult {
+    table: Table | null;
+    justCreated: boolean;
+}
+
+/**
+ * Returns the doc_chunks table. Mirrors `getCodeChunksTable`: pass a seed
+ * row when about to write so the table can be created on first use; pass
+ * `null` for read-only callers and handle `table === null`. Shares the
+ * module-level `mutex` chain so writes to both tables are serialized
+ * within a single process.
+ */
+export async function getDocChunksTable(seedRow: DocChunkRow | null): Promise<GetDocChunksTableResult> {
+    if (docChunksTableCache) {
+        return { table: docChunksTableCache, justCreated: false };
+    }
+
+    const next = mutex.then(async (): Promise<GetDocChunksTableResult> => {
+        if (docChunksTableCache) {
+            return { table: docChunksTableCache, justCreated: false };
+        }
+
+        const db = await getDb();
+        const tableNames = await db.tableNames();
+
+        if (tableNames.includes(DOC_CHUNKS_TABLE)) {
+            docChunksTableCache = await db.openTable(DOC_CHUNKS_TABLE);
+
+            return { table: docChunksTableCache, justCreated: false };
+        }
+
+        if (!seedRow) {
+            return { table: null, justCreated: false };
+        }
+
+        docChunksTableCache = await db.createTable(
+            DOC_CHUNKS_TABLE,
+            [seedRow as unknown as Record<string, unknown>],
+        );
+
+        return { table: docChunksTableCache, justCreated: true };
+    });
+
+    mutex = next.catch(() => undefined);
+
+    return next;
+}
+
+/**
+ * Total number of doc chunks currently stored. Returns 0 if the table has
+ * never been created.
+ */
+export async function countDocChunks(): Promise<number> {
+    const { table } = await getDocChunksTable(null);
 
     if (!table) return 0;
 

--- a/src/AI/AIAgent/shared/utils/agentSettings.ts
+++ b/src/AI/AIAgent/shared/utils/agentSettings.ts
@@ -52,12 +52,6 @@ function mapServerConfig(server: McpServerSettings): MCPServerConfig {
     return localConfig;
 }
 
-export async function getAgentDefaultModel(): Promise<string | undefined> {
-    const settings = await loadSettings();
-
-    return settings.ai?.agent?.defaultModel;
-}
-
 export async function getConfiguredMcpServers(): Promise<Record<string, MCPServerConfig>> {
     const settings = await loadSettings();
     const configuredServers = settings.ai?.agent?.mcpServers ?? {};

--- a/src/AI/AIAgent/shared/utils/memoryMcpServer.ts
+++ b/src/AI/AIAgent/shared/utils/memoryMcpServer.ts
@@ -12,8 +12,10 @@ import { runStdioMcpServer } from '../../mcp/stdioServer';
 import 'module-alias/register';
 import { editMemory, recall, remember, updateMemory } from '../memory/notes';
 import { semanticSearch } from '../memory/search';
+import { docsSearch } from '../docs/search';
 import { MEMORY_KINDS, MEMORY_LOOKUP_KINDS, MEMORY_STATUSES } from '../memory/types';
-
+import { loadSettings } from '@/utils/common';
+import type { DocsSource } from '@/types/settingsTypes';
 
 const REMEMBER_TOOL = {
     name: 'remember',
@@ -122,15 +124,77 @@ const EDIT_MEMORY_TOOL = {
         required: ['id'],
     },
 };
-const TOOLS = [
-    REMEMBER_TOOL,
-    RECALL_TOOL,
-    UPDATE_MEMORY_TOOL,
-    EDIT_MEMORY_TOOL,
-    SEMANTIC_SEARCH_TOOL,
-];
 
-type ToolName = (typeof TOOLS)[number]['name'];
+const DOCS_SEARCH_TOOL_BASE = {
+    name: 'docs_search',
+    description: [
+        'PREFERRED first-step lookup for any question about an external library, framework, SDK, or service whose docs are listed below.',
+        'Vector search over the indexed documentation corpus populated by `kra ai update-docs` (local LanceDB, no network).',
+        'Returns one entry per matched page (deduped by URL) with the best-scoring sections inlined as markdown,',
+        'so you can read the docs directly in the response without a follow-up fetch.',
+        'Pass `sourceAlias` to scope to a single configured source.',
+        'Always try this BEFORE `web_search` / `web_fetch` when the topic matches one of the available sources listed below \u2014 it is faster, offline, and version-pinned to what the user actually has installed.',
+        'Use `semantic_search` instead for questions about THIS repo\u2019s own code. In case semantic search is denied, use confirm_task_complete to ask the user instead.',
+    ].join(' '),
+};
+
+export function buildDocsSearchTool(sources: DocsSource[]) {
+    const aliasLines = sources
+        .map((s) => {
+            const blurb = s.description?.trim() || s.url;
+            return `  - ${s.alias} \u2014 ${blurb}`;
+        })
+        .join('\n');
+    const aliases = sources.map((s) => s.alias);
+
+    const description = [
+        DOCS_SEARCH_TOOL_BASE.description,
+        '',
+        'Available sources (configured for this repo \u2014 only these aliases are valid for `sourceAlias`):',
+        aliasLines,
+    ].join('\n');
+
+    return {
+        name: DOCS_SEARCH_TOOL_BASE.name,
+        description,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                query: { type: 'string', description: 'Natural-language description of what you are looking for.' },
+                k: { type: 'number', description: 'Max pages returned (default 8, hard cap 50).' },
+                sourceAlias: {
+                    type: 'string',
+                    enum: aliases,
+                    description: 'Optional alias filter. Must be one of the configured aliases listed in this tool\u2019s description.',
+                },
+            },
+            required: ['query'],
+        },
+    };
+}
+export async function buildToolList(): Promise<Array<{ name: string }>> {
+    const tools: Array<{ name: string }> = [
+        REMEMBER_TOOL,
+        RECALL_TOOL,
+        UPDATE_MEMORY_TOOL,
+        EDIT_MEMORY_TOOL,
+        SEMANTIC_SEARCH_TOOL,
+    ];
+
+    try {
+        const settings = await loadSettings();
+        const docsCfg = settings?.ai?.docs;
+        const sources = docsCfg?.enabled ? (docsCfg.sources ?? []) : [];
+        if (sources.length > 0) {
+            tools.push(buildDocsSearchTool(sources));
+        }
+    } catch {
+    }
+
+    return tools;
+}
+
+type ToolName = 'remember' | 'recall' | 'update_memory' | 'edit_memory' | 'semantic_search' | 'docs_search';
 
 async function dispatchTool(name: ToolName, args: Record<string, unknown>): Promise<unknown> {
     switch (name) {
@@ -149,34 +213,48 @@ async function dispatchTool(name: ToolName, args: Record<string, unknown>): Prom
         case 'semantic_search':
             return semanticSearch(args as unknown as Parameters<typeof semanticSearch>[0]);
 
+        case 'docs_search':
+            return docsSearch(args as unknown as Parameters<typeof docsSearch>[0]);
+
         default:
             throw new Error(`Unknown tool: ${name}`);
     }
 }
 
-runStdioMcpServer({
-    serverName: 'kra-memory',
-    tools: TOOLS,
-    handleToolCall: async ({ toolName, params }) => {
-        const callParams = (params ?? {}) as { arguments?: unknown };
-        const rawArgs = callParams.arguments;
-        const args = (typeof rawArgs === 'object' && rawArgs !== null ? rawArgs : {}) as Record<string, unknown>;
-        const result = await dispatchTool(toolName, args);
+async function startServer(): Promise<void> {
+    const TOOLS = await buildToolList();
 
-        return {
-            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-            isError: false,
-        };
-    },
-    onInternalError: (error) => {
-        const message = error instanceof Error ? error.message : String(error);
+    runStdioMcpServer({
+        serverName: 'kra-memory',
+        tools: TOOLS,
+        handleToolCall: async ({ toolName, params }) => {
+            const callParams = (params ?? {}) as { arguments?: unknown };
+            const rawArgs = callParams.arguments;
+            const args = (typeof rawArgs === 'object' && rawArgs !== null ? rawArgs : {}) as Record<string, unknown>;
+            const result = await dispatchTool(toolName as ToolName, args);
 
-        return {
-            kind: 'result',
-            result: {
-                content: [{ type: 'text', text: `Error: ${message}` }],
-                isError: true,
-            },
-        };
-    },
-});
+            return {
+                content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+                isError: false,
+            };
+        },
+        onInternalError: (error) => {
+            const message = error instanceof Error ? error.message : String(error);
+
+            return {
+                kind: 'result',
+                result: {
+                    content: [{ type: 'text', text: `Error: ${message}` }],
+                    isError: true,
+                },
+            };
+        },
+    });
+}
+
+if (require.main === module) {
+    startServer().catch((err) => {
+        console.error('memoryMcpServer failed to start:', err);
+        process.exit(1);
+    });
+}

--- a/src/AI/AIChat/utils/promptModel.ts
+++ b/src/AI/AIChat/utils/promptModel.ts
@@ -20,6 +20,9 @@ import {
     type WebSearchArgs,
     type WebToolResult,
 } from '@/AI/shared/utils/webTools';
+import { loadSettings } from '@/utils/common';
+import { buildDocsSearchTool } from '@/AI/AIAgent/shared/utils/memoryMcpServer';
+import { docsSearch } from '@/AI/AIAgent/shared/docs/search';
 import { updateAgentUi } from '@/AI/AIAgent/shared/utils/agentSessionEvents';
 import { summarizeToolCall, formatToolLine } from '@/AI/AIAgent/shared/utils/agentUi';
 
@@ -35,6 +38,12 @@ const TOOL_AWARENESS_PREAMBLE = [
     'that does NOT execute anything. If you find yourself typing a tool name, stop and emit a real tool call instead.',
     'Lines like `✓ web_search: …` that you may see in earlier turns are passive log markers from the runtime,',
     'not a calling convention you should imitate.',
+].join(' ');
+
+const DOCS_SEARCH_PREAMBLE = [
+    '',
+    'You also have a `docs_search` tool: vector search over documentation pages indexed locally via `kra ai docs`.',
+    'PREFER `docs_search` over `web_search` / `web_fetch` whenever the user’s question matches one of the configured sources listed in the tool’s description — it is faster, offline, and version-pinned to what is installed.',
 ].join(' ');
 
 const CHAT_TOOLS: ChatCompletionTool[] = [
@@ -132,6 +141,21 @@ async function executeToolCall(
         return runWebSearch(args);
     }
 
+    if (toolName === 'docs_search') {
+        if (typeof parsed.query !== 'string') {
+            return { output: 'docs_search missing required argument: query', isError: true };
+        }
+        const docsArgs: { query: string, k?: number, sourceAlias?: string } = { query: parsed.query };
+        if (typeof parsed.k === 'number') docsArgs.k = parsed.k;
+        if (typeof parsed.sourceAlias === 'string') docsArgs.sourceAlias = parsed.sourceAlias;
+        try {
+            const hits = await docsSearch(docsArgs);
+            return { output: JSON.stringify(hits, null, 2), isError: false };
+        } catch (err) {
+            return { output: `docs_search failed: ${(err as Error).message}`, isError: true };
+        }
+    }
+
     return { output: `Unknown tool: ${toolName}`, isError: true };
 }
 
@@ -145,8 +169,31 @@ async function createOpenAIStream(
     toolContext?: ChatToolContext,
 ): Promise<AsyncIterable<string>> {
     const useTools = !!toolContext;
+
+    const chatTools: ChatCompletionTool[] = [...CHAT_TOOLS];
+    let docsPreamble = '';
+    if (useTools) {
+        try {
+            const settings = await loadSettings();
+            const docsCfg = settings?.ai?.docs;
+            const sources = docsCfg?.enabled ? (docsCfg.sources ?? []) : [];
+            if (sources.length > 0) {
+                const docsTool = buildDocsSearchTool(sources);
+                chatTools.push({
+                    type: 'function',
+                    function: {
+                        name: docsTool.name,
+                        description: docsTool.description,
+                        parameters: docsTool.inputSchema as unknown as Record<string, unknown>,
+                    },
+                });
+                docsPreamble = '\n\n' + DOCS_SEARCH_PREAMBLE;
+            }
+        } catch { /* docs settings missing — leave web tools only */ }
+    }
+
     const systemContent = useTools
-        ? `${system ? `${system}\n\n` : ''}${TOOL_AWARENESS_PREAMBLE}`
+        ? `${system ? `${system}\n\n` : ''}${TOOL_AWARENESS_PREAMBLE}${docsPreamble}`
         : system;
     const messages: ChatCompletionMessageParam[] = [
         { role: 'system', content: systemContent },
@@ -162,7 +209,7 @@ async function createOpenAIStream(
                 temperature,
                 stream: true,
                 ...(useTools && !toolsDisabled
-                    ? { tools: CHAT_TOOLS, tool_choice: 'auto' as const }
+                    ? { tools: chatTools, tool_choice: 'auto' as const }
                     : {}),
             });
         } catch (error) {

--- a/src/AI/index.ts
+++ b/src/AI/index.ts
@@ -5,3 +5,5 @@ export * from '@/AI/AIChat/commands/deleteChat';
 export * from '@/AI/AIAgent/commands/showQuota';
 export * from '@/AI/AIAgent/commands/indexCodebase';
 export * from '@/AI/AIAgent/commands/manageMemory';
+export * from '@/AI/AIAgent/commands/manageDocs';
+export * from '@/AI/AIAgent/commands/docsSetup';

--- a/src/AI/shared/data/ai-ascii.ts
+++ b/src/AI/shared/data/ai-ascii.ts
@@ -29,5 +29,7 @@ export const aiAscii = `
         | index       | 🗂️  Index the current codebase for semantic search (writes to per-repo .kra-memory + global registry).                  |
         |-------------|--------------------------------------------------------------------------------------------------------------------------|
         | memory      | 🧰 Manage indexed codebases and long-term memories (findings/revisits) interactively.                                    |
+        |-------------|--------------------------------------------------------------------------------------------------------------------------|
+        | docs        | 📚 Interactive menu for the docs pipeline: install Crawl4AI, list sources, crawl, watch live progress, stop coordinator.    |
         +----------+-----------------------------------------------------------------------------------------------------------------------------+
 `

--- a/src/commandsMaps/aiCommands.ts
+++ b/src/commandsMaps/aiCommands.ts
@@ -10,6 +10,7 @@ export const aiCommands : AiCommands = {
     'quota-agent': ai.showQuota,
     'index': ai.indexCodebase,
     'memory': ai.manageMemory,
+    'docs': ai.manageDocs,
 };
 
 export function handleAiCommandNotExist(commandName: string): void {

--- a/src/commandsMaps/types/commandTypes.ts
+++ b/src/commandsMaps/types/commandTypes.ts
@@ -37,6 +37,7 @@ export type AiCommandName = {
     'quota-agent': Command,
     'index': Command,
     'memory': Command,
+    'docs': Command,
 }
 
 export type SystemCommands = Record<keyof SystemCommandName, Command>;

--- a/src/filePaths.ts
+++ b/src/filePaths.ts
@@ -42,5 +42,10 @@ export const modelCatalogDir = path.join(root, 'model-catalog');
 export const fastembedCacheDir = path.join(root, 'cache', 'fastembed');
 export const quotaCachePath = path.join(root, 'quota-cache.json');
 
+// Crawl4AI venv used by the docs pipeline (created via `kra ai docs` → Setup)
+export const crawl4aiVenvDir = path.join(root, 'crawl4ai-venv');
+export const crawl4aiVenvPython = path.join(crawl4aiVenvDir, 'bin', 'python');
+export const crawl4aiInstalledMarker = path.join(crawl4aiVenvDir, '.installed');
+
 // Re-export for backwards compatibility — actual location is packagePaths.ts
 export { loadSessionWorkerPath } from './packagePaths';

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,7 @@ const main = async (): Promise<void> => {
     }
 
     try {
-        await command();
+        await command(args.slice(2));
     } catch (error) {
         throw error;
     }

--- a/src/packagePaths.ts
+++ b/src/packagePaths.ts
@@ -58,5 +58,12 @@ export const aiLuaDir = path.join(aiFilesDir, 'lua');
 export const autoSaveManagerJsPath = assetPath('dest', 'automationScripts', 'autosave', 'autoSaveManager.js');
 export const autosaveJsPath = assetPath('dest', 'automationScripts', 'autosave', 'autosave.js');
 
+// Compiled docs coordinator entry point
+export const docsCoordinatorJsPath = assetPath('dest', 'src', 'AI', 'AIAgent', 'shared', 'docs', 'coordinator.js');
+
+// Python worker that wraps Crawl4AI (shipped as raw .py)
+export const docsPythonWorkerPath = path.join(automationScriptsDir, 'python', 'kra_docs_worker.py');
+export const docsPythonRequirementsPath = path.join(automationScriptsDir, 'python', 'requirements-lean.txt');
+
 // Default settings template that ships with the package
 export const settingsExamplePath = assetPath('settings.toml.example');

--- a/src/types/settingsTypes.ts
+++ b/src/types/settingsTypes.ts
@@ -47,7 +47,6 @@ export type LspServerSettings = {
 }
 
 type AgentSettings = {
-    defaultModel?: string,
     mcpServers?: Record<string, McpServerSettings>,
     memory?: {
         enabled?: boolean,
@@ -62,6 +61,27 @@ type AgentSettings = {
     },
 }
 
+export type DocsSource = {
+    alias: string,
+    url: string,
+    description?: string,
+    maxDepth?: number,
+    maxPages?: number,
+    includePatterns?: string[],
+    excludePatterns?: string[],
+    mode?: 'auto' | 'http' | 'browser',
+    concurrency?: number,
+    pageTimeoutMs?: number,
+}
+
+export type DocsSettings = {
+    enabled?: boolean,
+    maxConcurrentSources?: number,
+    idleTimeoutMs?: number,
+    cacheRawMarkdown?: boolean,
+    sources?: DocsSource[],
+}
+
 export type Settings = {
     watchCommands: {
         work: WatchOptions,
@@ -69,8 +89,10 @@ export type Settings = {
     },
 
     autosave: Autosave,
+
     ai?: {
         agent?: AgentSettings,
+        docs?: DocsSettings,
     },
     lsp?: Record<string, LspServerSettings>,
 }


### PR DESCRIPTION
new kra ai docs interactive menu spins up a Crawl4AI based crawler that walks configured doc sources (sitemap-first with BFS fallback) chunks and embeds the markdown into a local LanceDB store and exposes a docs_search tool to both the agent via MCP and the chat via OpenAI tool calls

per-source config in `[ai.docs]` (URL, depth, page caps, include/ exclude globstar patterns, timeouts)

coordinator + Python worker pool over IPC, status file polled by a blessed live-progress screen with scrollable event log

incremental crawls via sitemap-lastmod, conditional GET, and content hashing; `--full` bypasses the cache

setup/install of the Crawl4AI venv handled from the menu