### PR TITLE
feat: add executor sub-agent for delegating multi-step work

### DIFF
--- a/__tests__/AI/AIAgent/subAgents/executeTool.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/executeTool.test.ts
@@ -1,0 +1,143 @@
+import { coerceResult, formatExecutionResult } from '@/AI/AIAgent/shared/subAgents/executeTool';
+
+describe('executeTool.coerceResult', () => {
+    it('parses a complete result', () => {
+        const parsed = coerceResult({
+            status: 'completed',
+            summary: 'Did the thing.',
+            events: [
+                { kind: 'edit', detail: 'edited foo.ts', path: 'src/foo.ts', diff: '@@ -1 +1 @@' },
+                { kind: 'read', detail: 'read bar.ts' },
+            ],
+        });
+
+        expect(parsed.status).toBe('completed');
+        expect(parsed.summary).toBe('Did the thing.');
+        expect(parsed.events).toHaveLength(2);
+        expect(parsed.events[0]).toEqual({
+            kind: 'edit',
+            detail: 'edited foo.ts',
+            path: 'src/foo.ts',
+            diff: '@@ -1 +1 @@',
+        });
+        expect(parsed.events[1]).toEqual({ kind: 'read', detail: 'read bar.ts' });
+    });
+
+    it('falls back to a sensible default when status is missing or invalid', () => {
+        const missing = coerceResult({ summary: 'hi', events: [] }).status;
+        const invalid = coerceResult({ status: 'random-junk', summary: 'hi', events: [] }).status;
+
+        expect(['completed', 'partial', 'blocked', 'needs_replan']).toContain(missing);
+        expect(['completed', 'partial', 'blocked', 'needs_replan']).toContain(invalid);
+        expect(missing).toBe(invalid);
+    });
+
+    it('accepts every documented status value', () => {
+        for (const s of ['completed', 'partial', 'blocked', 'needs_replan']) {
+            expect(coerceResult({ status: s, summary: '', events: [] }).status).toBe(s);
+        }
+    });
+
+    it('drops events with missing kind or detail', () => {
+        const parsed = coerceResult({
+            status: 'completed',
+            summary: 's',
+            events: [
+                { kind: 'edit', detail: 'ok' },
+                { kind: 'edit' },
+                { detail: 'ok' },
+                'garbage',
+            ],
+        });
+
+        expect(parsed.events).toHaveLength(1);
+        expect(parsed.events[0]?.kind).toBe('edit');
+    });
+
+    it('falls back to empty events array when events is missing', () => {
+        const parsed = coerceResult({ status: 'partial', summary: 's' });
+
+        expect(parsed.events).toEqual([]);
+    });
+
+    it('captures blockers and replanReason when present', () => {
+        const blocked = coerceResult({
+            status: 'blocked',
+            summary: 's',
+            events: [],
+            blockers: ['cannot read x', 'permission denied y', 42],
+        });
+
+        expect(blocked.blockers).toEqual(['cannot read x', 'permission denied y']);
+
+        const replan = coerceResult({
+            status: 'needs_replan',
+            summary: 's',
+            events: [],
+            replanReason: 'plan step 3 is impossible',
+        });
+
+        expect(replan.replanReason).toBe('plan step 3 is impossible');
+    });
+});
+
+describe('executeTool.formatExecutionResult', () => {
+    it('renders status, summary, and events as readable text', () => {
+        const out = formatExecutionResult({
+            status: 'completed',
+            summary: 'All done.',
+            events: [
+                { kind: 'edit', detail: 'edited foo.ts', path: 'src/foo.ts' },
+                { kind: 'read', detail: 'read bar.ts' },
+            ],
+        });
+
+        expect(out).toContain('completed');
+        expect(out).toContain('All done.');
+        expect(out).toContain('edit src/foo.ts');
+        expect(out).toContain('edited foo.ts');
+        expect(out).toContain('read');
+        expect(out).toContain('read bar.ts');
+    });
+
+    it('truncates inline diffs to 80 lines', () => {
+        const longDiff = Array.from({ length: 200 }, (_, i) => `+ line ${i}`).join('\n');
+        const out = formatExecutionResult({
+            status: 'completed',
+            summary: 's',
+            events: [
+                { kind: 'edit', detail: 'huge', path: 'a.ts', diff: longDiff },
+            ],
+        });
+
+        const renderedDiffLines = out.split('\n').filter((l) => l.includes('+ line '));
+
+        expect(renderedDiffLines.length).toBeLessThanOrEqual(80);
+        expect(renderedDiffLines[0]).toContain('+ line 0');
+    });
+
+    it('renders blockers when status = blocked', () => {
+        const out = formatExecutionResult({
+            status: 'blocked',
+            summary: 's',
+            events: [],
+            blockers: ['needs missing config', 'tsc error in unrelated file'],
+        });
+
+        expect(out).toContain('blocked');
+        expect(out).toContain('needs missing config');
+        expect(out).toContain('tsc error in unrelated file');
+    });
+
+    it('renders replanReason when status = needs_replan', () => {
+        const out = formatExecutionResult({
+            status: 'needs_replan',
+            summary: 's',
+            events: [],
+            replanReason: 'plan does not account for X',
+        });
+
+        expect(out).toContain('needs_replan');
+        expect(out).toContain('plan does not account for X');
+    });
+});

--- a/__tests__/AI/AIAgent/subAgents/investigateTool.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/investigateTool.test.ts
@@ -1,0 +1,122 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { coerceResult, validateEvidence } from '@/AI/AIAgent/shared/subAgents/investigateTool';
+
+describe('investigateTool.coerceResult', () => {
+    it('parses a complete result', () => {
+        const parsed = coerceResult({
+            summary: 'foo handles X',
+            evidence: [
+                {
+                    path: 'src/foo.ts',
+                    lines: '12-20',
+                    excerpt: 'function foo() {}',
+                    why_relevant: 'entry point',
+                },
+            ],
+            confidence: 'high',
+            suggested_next: 'look at bar.ts',
+        });
+
+        expect(parsed.summary).toBe('foo handles X');
+        expect(parsed.evidence).toHaveLength(1);
+        expect(parsed.evidence[0]?.path).toBe('src/foo.ts');
+        expect(parsed.confidence).toBe('high');
+        expect(parsed.suggested_next).toBe('look at bar.ts');
+    });
+
+    it('falls back to a sensible default when confidence is missing or invalid', () => {
+        const missing = coerceResult({ summary: '', evidence: [] }).confidence;
+        const invalid = coerceResult({ summary: '', evidence: [], confidence: 'unknown' }).confidence;
+
+        expect(['high', 'medium', 'low']).toContain(missing);
+        expect(['high', 'medium', 'low']).toContain(invalid);
+        expect(missing).toBe(invalid);
+    });
+
+    it('drops malformed evidence entries', () => {
+        const parsed = coerceResult({
+            summary: '',
+            evidence: [
+                { path: 'a', lines: '1', excerpt: 'x', why_relevant: 'y' },
+                { path: 'a' },
+                'garbage',
+                { path: 'b', lines: '2', excerpt: 'y', why_relevant: 'z' },
+            ],
+        });
+
+        expect(parsed.evidence).toHaveLength(2);
+        expect(parsed.evidence.map((e) => e.path)).toEqual(['a', 'b']);
+    });
+});
+
+describe('investigateTool.validateEvidence', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'investigate-validate-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('keeps evidence whose excerpt matches the file at the stated range', async () => {
+        const file = path.join(tmpDir, 'a.ts');
+        await fs.writeFile(file, ['line one', 'line two', 'line three', 'line four'].join('\n'));
+
+        const validated = await validateEvidence(
+            [{ path: 'a.ts', lines: '2-3', excerpt: 'line two\nline three', why_relevant: 'mid' }],
+            tmpDir,
+        );
+
+        expect(validated[0]?.why_relevant).toBe('mid');
+        expect(validated[0]?.why_relevant.startsWith('[unverified')).toBe(false);
+    });
+
+    it('flags evidence whose excerpt does not match the file', async () => {
+        const file = path.join(tmpDir, 'a.ts');
+        await fs.writeFile(file, ['line one', 'line two'].join('\n'));
+
+        const validated = await validateEvidence(
+            [{ path: 'a.ts', lines: '1-2', excerpt: 'totally different', why_relevant: 'x' }],
+            tmpDir,
+        );
+
+        expect(validated[0]?.why_relevant).toMatch(/^\[unverified: excerpt does not match/);
+    });
+
+    it('flags evidence with a bad line range', async () => {
+        const file = path.join(tmpDir, 'a.ts');
+        await fs.writeFile(file, 'only line\n');
+
+        const validated = await validateEvidence(
+            [{ path: 'a.ts', lines: 'not-a-range', excerpt: 'only line', why_relevant: 'x' }],
+            tmpDir,
+        );
+
+        expect(validated[0]?.why_relevant).toMatch(/^\[unverified: bad line range/);
+    });
+
+    it('flags evidence pointing at a missing file', async () => {
+        const validated = await validateEvidence(
+            [{ path: 'does/not/exist.ts', lines: '1-1', excerpt: 'x', why_relevant: 'x' }],
+            tmpDir,
+        );
+
+        expect(validated[0]?.why_relevant).toMatch(/^\[unverified: file not found/);
+    });
+
+    it('tolerates whitespace-only differences in the excerpt', async () => {
+        const file = path.join(tmpDir, 'a.ts');
+        await fs.writeFile(file, 'foo\nbar\n');
+
+        const validated = await validateEvidence(
+            [{ path: 'a.ts', lines: '1-2', excerpt: '  foo\n  bar  ', why_relevant: 'x' }],
+            tmpDir,
+        );
+
+        expect(validated[0]?.why_relevant).toBe('x');
+    });
+});

--- a/__tests__/AI/AIAgent/subAgents/session.integration.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/session.integration.test.ts
@@ -1,0 +1,255 @@
+import type {
+    AgentClient,
+    AgentSession,
+    AgentSessionOptions,
+    LocalTool,
+} from '@/AI/AIAgent/shared/types/agentTypes';
+import { runSubAgentTask } from '@/AI/AIAgent/shared/subAgents/session';
+
+interface FakeSession extends AgentSession {
+    handlers: Map<string, Array<(e: unknown) => void>>;
+    submitTool: () => LocalTool | undefined;
+    fireIdle: () => void;
+    sentPrompts: string[];
+    disconnectCalls: number;
+}
+
+function makeFakeClient(): { client: AgentClient; lastSession: () => FakeSession | undefined; lastOptions: () => AgentSessionOptions | undefined } {
+    let last: FakeSession | undefined;
+    let lastOpts: AgentSessionOptions | undefined;
+
+    const client: AgentClient = {
+        stop: jest.fn(async () => undefined),
+        createSession: jest.fn(async (options: AgentSessionOptions) => {
+            lastOpts = options;
+            const handlers = new Map<string, Array<(e: unknown) => void>>();
+            const session: Partial<FakeSession> = {
+                handlers,
+                sentPrompts: [],
+                disconnectCalls: 0,
+                on: ((event: string, handler: (e: unknown) => void) => {
+                    if (!handlers.has(event)) handlers.set(event, []);
+                    handlers.get(event)!.push(handler);
+                }) as AgentSession['on'],
+                send: jest.fn(async (opts: { prompt: string }) => {
+                    (session as FakeSession).sentPrompts.push(opts.prompt);
+                }),
+                abort: jest.fn(async () => undefined),
+                disconnect: jest.fn(async () => {
+                    (session as FakeSession).disconnectCalls += 1;
+                }),
+                submitTool: () => options.localTools?.find((t) => t.name === 'submit_result'),
+                fireIdle: () => {
+                    for (const h of handlers.get('session.idle') ?? []) h({});
+                },
+            };
+            last = session as FakeSession;
+
+            return session as AgentSession;
+        }),
+    };
+
+    return { client, lastSession: () => last, lastOptions: () => lastOpts };
+}
+
+describe('runSubAgentTask integration', () => {
+    it('captures the structured result from submit_result and returns', async () => {
+        const { client, lastSession, lastOptions } = makeFakeClient();
+        const onEvent = jest.fn();
+
+        const promise = runSubAgentTask({
+            runtime: { client, model: 'test-model' },
+            mcpServers: {},
+            workingDirectory: '/tmp/wd',
+            systemPrompt: 'sys',
+            taskPrompt: 'task',
+            toolWhitelist: ['read_lines'],
+            resultSchema: { type: 'object' },
+            onEvent,
+        });
+
+        // Let createSession + send resolve.
+        await new Promise((r) => setImmediate(r));
+
+        const session = lastSession()!;
+        const submit = session.submitTool()!;
+
+        expect(submit).toBeDefined();
+        expect(submit.name).toBe('submit_result');
+
+        // Simulate the model calling submit_result.
+        const ack = await submit.handler({ status: 'completed', summary: 's', events: [] });
+
+        expect(ack).toMatch(/Result accepted/);
+
+        const { result, events } = await promise;
+
+        expect(result).toEqual({ status: 'completed', summary: 's', events: [] });
+        expect(events).toEqual([]);
+        expect(session.disconnectCalls).toBe(1);
+        expect(lastOptions()?.systemMessage).toEqual({ mode: 'replace', content: 'sys' });
+        expect(session.sentPrompts).toEqual(['task']);
+    });
+
+    it('races submit_result against session.idle so a stuck model does not stall the orchestrator', async () => {
+        const { client, lastSession } = makeFakeClient();
+
+        const promise = runSubAgentTask({
+            runtime: { client, model: 'test-model' },
+            mcpServers: {},
+            workingDirectory: '/tmp/wd',
+            systemPrompt: 'sys',
+            taskPrompt: 'task',
+            toolWhitelist: [],
+            resultSchema: { type: 'object' },
+        });
+
+        await new Promise((r) => setImmediate(r));
+
+        const session = lastSession()!;
+
+        // Submit the result, but DELIBERATELY never fire session.idle.
+        await session.submitTool()!.handler({ status: 'completed', summary: 'done', events: [] });
+
+        const settled = await Promise.race([
+            promise.then(() => 'settled' as const),
+            new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), 200)),
+        ]);
+
+        expect(settled).toBe('settled');
+
+        const { result } = await promise;
+        expect(result).toEqual({ status: 'completed', summary: 'done', events: [] });
+    });
+
+    it('returns even when the model never submits, once session.idle fires', async () => {
+        const { client, lastSession } = makeFakeClient();
+
+        const promise = runSubAgentTask({
+            runtime: { client, model: 'test-model' },
+            mcpServers: {},
+            workingDirectory: '/tmp/wd',
+            systemPrompt: 'sys',
+            taskPrompt: 'task',
+            toolWhitelist: [],
+            resultSchema: { type: 'object' },
+        });
+
+        await new Promise((r) => setImmediate(r));
+
+        const session = lastSession()!;
+        session.fireIdle();
+
+        const { result, events } = await promise;
+        expect(result).toBeUndefined();
+        expect(events).toEqual([]);
+        expect(session.disconnectCalls).toBe(1);
+    });
+
+    it('passes the tool whitelist as `allowedTools` to the SDK and allows submit_result through onPreToolUse', async () => {
+        const { client, lastOptions, lastSession } = makeFakeClient();
+
+        const promise = runSubAgentTask({
+            runtime: { client, model: 'test-model' },
+            mcpServers: {},
+            workingDirectory: '/tmp/wd',
+            systemPrompt: 'sys',
+            taskPrompt: 'task',
+            toolWhitelist: ['read_lines'],
+            resultSchema: { type: 'object' },
+        });
+
+        await new Promise((r) => setImmediate(r));
+        const opts = lastOptions()!;
+
+        // The provider wrappers handle inventory filtering via `allowedTools`,
+        // so the model never sees non-whitelisted tools. The runtime hook only
+        // needs to short-circuit the synthetic `submit_result` tool and
+        // delegate everything else to the bridge (or allow when no bridge).
+        expect(opts.allowedTools).toEqual(expect.arrayContaining(['read_lines', 'submit_result']));
+
+        const submit = await opts.onPreToolUse({
+            toolName: 'submit_result',
+            toolArgs: {},
+        });
+        expect(submit.permissionDecision).toBe('allow');
+
+        const allowed = await opts.onPreToolUse({
+            toolName: 'read_lines',
+            toolArgs: {},
+        });
+        expect(allowed.permissionDecision).toBe('allow');
+
+        // Submit and let it finish.
+        await lastSession()!.submitTool()!.handler({ status: 'completed', summary: '', events: [] });
+        await promise;
+    });
+
+    it('forwards assistant message deltas and tool events to onEvent', async () => {
+        const { client, lastSession } = makeFakeClient();
+        const onEvent = jest.fn();
+
+        const promise = runSubAgentTask({
+            runtime: { client, model: 'test-model' },
+            mcpServers: {},
+            workingDirectory: '/tmp/wd',
+            systemPrompt: 'sys',
+            taskPrompt: 'task',
+            toolWhitelist: ['read_lines'],
+            resultSchema: { type: 'object' },
+            onEvent,
+        });
+
+        await new Promise((r) => setImmediate(r));
+
+        const session = lastSession()!;
+
+        // Drive synthetic events into the session handlers.
+        session.handlers.get('assistant.message_delta')?.[0]?.({ data: { deltaContent: 'hello' } });
+        session.handlers.get('tool.execution_start')?.[0]?.({ data: { toolName: 'read_lines' } });
+        session.handlers.get('tool.execution_complete')?.[0]?.({ data: { success: true } });
+
+        await session.submitTool()!.handler({ status: 'completed', summary: '', events: [] });
+        const { events } = await promise;
+
+        expect(events).toEqual([
+            { kind: 'message', text: 'hello' },
+            { kind: 'tool_start', toolName: 'read_lines' },
+            { kind: 'tool_complete', success: true },
+        ]);
+        expect(onEvent).toHaveBeenCalledTimes(3);
+    });
+
+    it('passes contextWindow through to createSession only when provided', async () => {
+        const { client, lastOptions, lastSession } = makeFakeClient();
+
+        const p1 = runSubAgentTask({
+            runtime: { client, model: 'm', contextWindow: 100_000 },
+            mcpServers: {},
+            workingDirectory: '/tmp',
+            systemPrompt: 's',
+            taskPrompt: 't',
+            toolWhitelist: [],
+            resultSchema: { type: 'object' },
+            contextWindow: 100_000,
+        });
+        await new Promise((r) => setImmediate(r));
+        expect(lastOptions()?.contextWindow).toBe(100_000);
+        await lastSession()!.submitTool()!.handler({ status: 'completed', summary: '', events: [] });
+        await p1;
+
+        const p2 = runSubAgentTask({
+            runtime: { client, model: 'm' },
+            mcpServers: {},
+            workingDirectory: '/tmp',
+            systemPrompt: 's',
+            taskPrompt: 't',
+            toolWhitelist: [],
+            resultSchema: { type: 'object' },
+        });
+        await new Promise((r) => setImmediate(r));
+        expect(lastOptions()?.contextWindow).toBeUndefined();
+        await lastSession()!.submitTool()!.handler({ status: 'completed', summary: '', events: [] });
+        await p2;
+    });
+});

--- a/__tests__/AI/AIAgent/subAgents/settings.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/settings.test.ts
@@ -1,0 +1,99 @@
+import { mergeExecutor, mergeInvestigator } from '@/AI/AIAgent/shared/subAgents/settings';
+
+describe('mergeExecutor', () => {
+    it('returns defaults when raw is undefined', () => {
+        const merged = mergeExecutor(undefined);
+
+        expect(merged.enabled).toBe(false);
+        expect(merged.useInvestigatorRuntime).toBe(true);
+        expect(merged.allowInterrupt).toBe(true);
+        expect(merged.allowReplanEscape).toBe(true);
+        expect(merged.includeDiffsInLog).toBe(true);
+        expect(merged.maxToolCalls).toBe(60);
+        expect(merged.toolWhitelist).toEqual(expect.arrayContaining(['read_lines', 'edit_lines', 'bash']));
+    });
+
+    it('respects partial overrides and falls back to defaults for the rest', () => {
+        const merged = mergeExecutor({
+            enabled: true,
+            maxToolCalls: 100,
+        });
+
+        expect(merged.enabled).toBe(true);
+        expect(merged.maxToolCalls).toBe(100);
+        expect(merged.useInvestigatorRuntime).toBe(true);
+        expect(merged.allowReplanEscape).toBe(true);
+    });
+
+    it('clamps maxToolCalls into the allowed range', () => {
+        expect(mergeExecutor({ maxToolCalls: 0 }).maxToolCalls).toBe(1);
+        expect(mergeExecutor({ maxToolCalls: 5000 }).maxToolCalls).toBe(500);
+        expect(mergeExecutor({ maxToolCalls: 1.4 }).maxToolCalls).toBe(1);
+        expect(mergeExecutor({ maxToolCalls: NaN as unknown as number }).maxToolCalls).toBe(60);
+    });
+
+    it('ignores non-boolean values for boolean fields', () => {
+        const merged = mergeExecutor({
+            enabled: 'yes' as unknown as boolean,
+            useInvestigatorRuntime: 1 as unknown as boolean,
+        });
+
+        expect(merged.enabled).toBe(false);
+        expect(merged.useInvestigatorRuntime).toBe(true);
+    });
+
+    it('filters non-string entries out of toolWhitelist', () => {
+        const merged = mergeExecutor({
+            toolWhitelist: ['read_lines', 42 as unknown as string, '', 'bash'],
+        });
+
+        expect(merged.toolWhitelist).toEqual(['read_lines', 'bash']);
+    });
+
+    it('falls back to defaults when toolWhitelist is empty after filtering', () => {
+        const merged = mergeExecutor({
+            toolWhitelist: ['', ''],
+        });
+
+        expect(merged.toolWhitelist).toEqual(expect.arrayContaining(['read_lines']));
+    });
+
+    it('handles non-object raw input', () => {
+        const merged = mergeExecutor('garbage' as unknown as undefined);
+
+        expect(merged.enabled).toBe(false);
+        expect(merged.maxToolCalls).toBe(60);
+    });
+});
+
+describe('mergeInvestigator', () => {
+    it('returns defaults when raw is undefined', () => {
+        const merged = mergeInvestigator(undefined);
+
+        expect(merged.enabled).toBe(false);
+        expect(merged.maxEvidenceItems).toBe(8);
+        expect(merged.maxExcerptLines).toBe(20);
+        expect(merged.validateExcerpts).toBe(true);
+        expect(merged.toolWhitelist).toEqual(
+            expect.arrayContaining(['semantic_search', 'read_lines', 'docs_search'])
+        );
+    });
+
+    it('clamps maxEvidenceItems and maxExcerptLines into their allowed ranges', () => {
+        const tooSmall = mergeInvestigator({ maxEvidenceItems: 0, maxExcerptLines: 0 });
+        const tooLarge = mergeInvestigator({ maxEvidenceItems: 9999, maxExcerptLines: 9999 });
+
+        expect(tooSmall.maxEvidenceItems).toBeGreaterThanOrEqual(1);
+        expect(tooSmall.maxExcerptLines).toBeGreaterThanOrEqual(1);
+        expect(tooLarge.maxEvidenceItems).toBeLessThanOrEqual(50);
+        expect(tooLarge.maxExcerptLines).toBeLessThanOrEqual(200);
+    });
+
+    it('respects partial overrides', () => {
+        const merged = mergeInvestigator({ enabled: true, validateExcerpts: false });
+
+        expect(merged.enabled).toBe(true);
+        expect(merged.validateExcerpts).toBe(false);
+        expect(merged.maxEvidenceItems).toBe(8);
+    });
+});

--- a/__tests__/AI/AIAgent/subAgents/singleFlight.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/singleFlight.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Single-flight regression: only one investigation / execution may be running
+ * at a time. Concurrent calls to the tool's `handler` must return the
+ * rejection string immediately without spawning a second sub-agent.
+ */
+const mockRunSubAgentTask = jest.fn();
+
+jest.mock('@/AI/AIAgent/shared/subAgents/session', () => ({
+    runSubAgentTask: (...args: unknown[]) => mockRunSubAgentTask(...args),
+}));
+
+import { createExecuteTool } from '@/AI/AIAgent/shared/subAgents/executeTool';
+import { createInvestigateTool } from '@/AI/AIAgent/shared/subAgents/investigateTool';
+import type { AgentClient } from '@/AI/AIAgent/shared/types/agentTypes';
+import type { ExecutorRuntime, InvestigatorRuntime } from '@/AI/AIAgent/shared/subAgents/types';
+
+const fakeClient = {
+    createSession: jest.fn(),
+    stop: jest.fn(),
+} as unknown as AgentClient;
+
+const executorRuntime: ExecutorRuntime = {
+    client: fakeClient,
+    model: 'm',
+    settings: {
+        enabled: true,
+        useInvestigatorRuntime: true,
+        allowInterrupt: true,
+        allowReplanEscape: true,
+        includeDiffsInLog: true,
+        maxToolCalls: 60,
+        toolWhitelist: ['read_lines'],
+    },
+};
+
+const investigatorRuntime: InvestigatorRuntime = {
+    client: fakeClient,
+    model: 'm',
+    settings: {
+        enabled: true,
+        maxEvidenceItems: 8,
+        maxExcerptLines: 20,
+        validateExcerpts: false,
+        toolWhitelist: ['search'],
+    },
+};
+
+beforeEach(() => {
+    mockRunSubAgentTask.mockReset();
+});
+
+describe('createExecuteTool single-flight', () => {
+    it('rejects a second concurrent execute call', async () => {
+        let resolveFirst!: (value: unknown) => void;
+        mockRunSubAgentTask.mockImplementationOnce(
+            () => new Promise((resolve) => { resolveFirst = resolve; })
+        );
+
+        const tool = createExecuteTool({
+            runtime: executorRuntime,
+            mcpServers: {},
+            workingDirectory: '/tmp/wd',
+        });
+
+        const first = tool.handler({ plan: 'do thing' });
+        // Yield so handler hits the activeRun assignment.
+        await new Promise((r) => setImmediate(r));
+        const second = await tool.handler({ plan: 'do other thing' });
+
+        expect(second).toMatch(/another execution is already running/);
+        expect(mockRunSubAgentTask).toHaveBeenCalledTimes(1);
+
+        resolveFirst({ result: { status: 'completed', summary: 's', events: [] }, events: [] });
+        await first;
+    });
+
+    it('allows a new execute after the previous one completes', async () => {
+        mockRunSubAgentTask
+            .mockResolvedValueOnce({ result: { status: 'completed', summary: 'a', events: [] }, events: [] })
+            .mockResolvedValueOnce({ result: { status: 'completed', summary: 'b', events: [] }, events: [] });
+
+        const tool = createExecuteTool({
+            runtime: executorRuntime,
+            mcpServers: {},
+            workingDirectory: '/tmp/wd',
+        });
+
+        const first = await tool.handler({ plan: 'p1' });
+        const second = await tool.handler({ plan: 'p2' });
+
+        expect(first).toContain('summary: a');
+        expect(second).toContain('summary: b');
+        expect(mockRunSubAgentTask).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports a helpful message when the executor returns no captured result', async () => {
+        mockRunSubAgentTask.mockResolvedValueOnce({
+            result: undefined,
+            events: [
+                { kind: 'tool_start', toolName: 'read_lines' },
+                { kind: 'tool_complete', success: true },
+            ],
+        });
+
+        const tool = createExecuteTool({
+            runtime: executorRuntime,
+            mcpServers: {},
+            workingDirectory: '/tmp/wd',
+        });
+
+        const out = await tool.handler({ plan: 'p' });
+
+        expect(out).toMatch(/did not call submit_result/);
+        expect(out).toContain('event count: 2');
+    });
+});
+
+describe('createInvestigateTool single-flight', () => {
+    it('rejects a second concurrent investigate call', async () => {
+        let resolveFirst!: (value: unknown) => void;
+        mockRunSubAgentTask.mockImplementationOnce(
+            () => new Promise((resolve) => { resolveFirst = resolve; })
+        );
+
+        const tool = createInvestigateTool({
+            runtime: investigatorRuntime,
+            mcpServers: {},
+            workingDirectory: '/tmp/wd',
+        });
+
+        const first = tool.handler({ query: 'q1' });
+        await new Promise((r) => setImmediate(r));
+        const second = await tool.handler({ query: 'q2' });
+
+        expect(second).toMatch(/another investigation is already running/i);
+        expect(mockRunSubAgentTask).toHaveBeenCalledTimes(1);
+
+        resolveFirst({
+            result: { summary: 'done', evidence: [], confidence: 'low' },
+            events: [],
+        });
+        await first;
+    });
+});

--- a/__tests__/AI/AIAgent/subAgents/whitelist.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/whitelist.test.ts
@@ -1,0 +1,69 @@
+import { matchesSubAgentWhitelist } from '@/AI/AIAgent/shared/subAgents/whitelist';
+
+describe('matchesSubAgentWhitelist', () => {
+    const whitelist = [
+        'read_lines',
+        'get_outline',
+        'edit_lines',
+        'lsp_query',
+        'search',
+        'submit_result',
+    ];
+
+    it('matches bare BYOK tool names', () => {
+        expect(matchesSubAgentWhitelist('read_lines', whitelist)).toBe(true);
+        expect(matchesSubAgentWhitelist('lsp_query', whitelist)).toBe(true);
+        expect(matchesSubAgentWhitelist('submit_result', whitelist)).toBe(true);
+    });
+
+    it('matches Copilot dash-prefixed MCP tool names', () => {
+        expect(matchesSubAgentWhitelist('kra-file-context-read_lines', whitelist)).toBe(true);
+        expect(matchesSubAgentWhitelist('kra-memory-search', whitelist)).toBe(true);
+    });
+
+    it('matches Copilot double-underscore-prefixed MCP tool names', () => {
+        expect(matchesSubAgentWhitelist('kra-file-context__read_lines', whitelist)).toBe(true);
+        expect(matchesSubAgentWhitelist('kra-memory__search', whitelist)).toBe(true);
+    });
+
+    it('matches dot-namespaced tool names', () => {
+        expect(matchesSubAgentWhitelist('server.read_lines', whitelist)).toBe(true);
+    });
+
+    it('rejects tools not in the whitelist', () => {
+        expect(matchesSubAgentWhitelist('bash', whitelist)).toBe(false);
+        expect(matchesSubAgentWhitelist('confirm_task_complete', whitelist)).toBe(false);
+        expect(matchesSubAgentWhitelist('kra-bash-bash', whitelist)).toBe(false);
+    });
+
+    it('does NOT match underscore-prefixed lookalikes', () => {
+        // critical: read_lines must not match evil_read_lines etc., because we
+        // do not split on `_` (real tool names already contain underscores).
+        expect(matchesSubAgentWhitelist('evil_read_lines', whitelist)).toBe(false);
+        expect(matchesSubAgentWhitelist('not_search', whitelist)).toBe(false);
+        expect(matchesSubAgentWhitelist('extra_get_outline', whitelist)).toBe(false);
+    });
+
+    it('does not match tools with the whitelist entry as a prefix', () => {
+        expect(matchesSubAgentWhitelist('read_lines_extra', whitelist)).toBe(false);
+        expect(matchesSubAgentWhitelist('search-things', whitelist)).toBe(false);
+    });
+
+    it('handles regex metacharacters in whitelist entries safely', () => {
+        // Even if someone configured a pathological tool name with regex-special
+        // characters, it should be matched literally and not crash.
+        const w = ['weird.tool+name'];
+
+        expect(matchesSubAgentWhitelist('weird.tool+name', w)).toBe(true);
+        expect(matchesSubAgentWhitelist('server-weird.tool+name', w)).toBe(true);
+        expect(matchesSubAgentWhitelist('weirdAtoolBname', w)).toBe(false);
+    });
+
+    it('accepts a Set as whitelist input', () => {
+        const set = new Set(['read_lines']);
+
+        expect(matchesSubAgentWhitelist('read_lines', set)).toBe(true);
+        expect(matchesSubAgentWhitelist('kra-file-context-read_lines', set)).toBe(true);
+        expect(matchesSubAgentWhitelist('bash', set)).toBe(false);
+    });
+});

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -18,7 +18,7 @@ kra ai agent
 |---|---|
 | [`providers.md`](./providers.md) | Provider architecture, Copilot/BYOK behavior, backend add/remove lifecycle, model catalog |
 | [`workflow-and-keymaps.md`](./workflow-and-keymaps.md) | Turn lifecycle, keymaps, tool approval UX, diff editor behavior, session diff history |
-| [`tools-and-mcp.md`](./tools-and-mcp.md) | File-context tools, bash/web tools, MCP configuration, sub-agent tools (`investigate`) |
+| [`tools-and-mcp.md`](./tools-and-mcp.md) | File-context tools, bash/web tools, MCP configuration, sub-agent tools (`investigate`, `execute`) |
 | [`memory-and-indexing.md`](./memory-and-indexing.md) | `kra-memory` store, tools, picker UX, indexing behavior and settings |
 | [`copilot-operations.md`](./copilot-operations.md) | Copilot-only skills and quota monitoring |
 

--- a/docs/agent/tools-and-mcp.md
+++ b/docs/agent/tools-and-mcp.md
@@ -137,9 +137,53 @@ When the orchestrator should skip it:
 - Trivial lookups where the exact file + line range is already known.
 - Cases where it must edit immediately based on context the user just gave.
 
-### Executor (planned, not yet implemented)
+### `execute` (executor sub-agent)
 
-Will consume a structured plan from the orchestrator, run it with a wider
-toolset (reads + edits + bash), and return a typed event log. See
-`settings.toml.example` `[ai.agent.executor]` for the planned configuration
-surface.
+Registered on the orchestrator only when `[ai.agent.executor].enabled = true`.
+Delegates a concrete, multi-step body of work to a smaller model that runs the
+plan end-to-end and returns a curated event log + summary; the raw tool traffic
+(file reads, search results, intermediate edits) never enters the orchestrator's
+context.
+
+| Field | Purpose |
+|---|---|
+| `plan` | Step-by-step plan to execute. Be explicit about what to change and where. |
+| `context` | Optional background the executor should treat as authoritative — prior findings, paths, user constraints. Generous context here saves tool calls on the executor side. |
+| `successCriteria` | Optional checklist the executor uses to decide between `completed` and `partial`. |
+
+Returns a structured envelope with `status` (`completed` / `partial` /
+`blocked` / `needs_replan`), a 2–6 sentence `summary`, a typed `events[]` array
+(with optional `path` and inline `diff` per event), and `blockers[]` /
+`replanReason` when relevant.
+
+Behavior notes:
+
+- Runtime sharing: when `useInvestigatorRuntime = true` (default) and the
+  investigator is also enabled, the executor reuses the investigator's
+  resolved provider + model. Set it to `false` to be prompted for a separate
+  executor model on startup.
+- Only one execution runs at a time; concurrent calls are rejected.
+- `Ctrl-C` (`stop_stream`) aborts the executor and returns control to the
+  orchestrator. The orchestrator sees the partial event log captured so far.
+- Executor tool whitelist (default): `read_lines`, `get_outline`, `edit_lines`,
+  `create_file`, `search`, `lsp_query`, `bash`. `confirm_task_complete` and
+  other end-of-turn tools are forbidden — the orchestrator owns the turn.
+- Hard cap of `maxToolCalls` (default 60) tool calls before the executor is
+  expected to submit — prevents runaway loops on bad plans.
+- Executor output streams into the same chat file under a sub-agent header
+  (⚙️ `[EXECUTOR]`).
+- As soon as the executor calls `submit_result`, control returns to the
+  orchestrator immediately — it does not wait for the model to wind down its
+  trailing acknowledgement.
+
+When the orchestrator should call it:
+
+- Multi-step refactors, feature implementations, or any task whose bulk is
+  mechanical reads + edits rather than reasoning.
+- After `investigate` has produced enough findings to write a concrete plan.
+
+When the orchestrator should skip it:
+
+- One-line trivial edits.
+- Tasks that need orchestrator-grade reasoning at every step.
+

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -39,9 +39,12 @@ gitignoreMemory = true      # documentation-only: whether you keep .kra-memory/ 
 #              a curated synthesis instead of dumping raw file contents.
 [ai.agent.executor]
 enabled = false               # master switch; off by default
+useInvestigatorRuntime = true # if true (and investigator enabled) reuse its provider+model;
+                              # if false you'll be prompted to pick a separate one on startup
 allowInterrupt = true         # Ctrl-C returns control to orchestrator with partial log
 allowReplanEscape = true      # executor may emit needs_replan; orchestrator replans
 includeDiffsInLog = true      # event log carries inline diffs for edits
+maxToolCalls = 60             # hard cap on tool calls before the executor is forced to submit
 # Restrict the toolset the executor is allowed to call (defaults shown):
 # toolWhitelist = ["read_lines", "get_outline", "edit_lines", "create_file",
 #                  "search", "lsp_query", "bash"]

--- a/src/AI/AIAgent/commands/startAgentChat.ts
+++ b/src/AI/AIAgent/commands/startAgentChat.ts
@@ -4,8 +4,11 @@
  * Picker order (matches what the user sees on the screen):
  *   1. Orchestrator provider → (BYOK only) model provider → model
  *      → (Copilot only) reasoning effort
- *   2. For each enabled sub-agent (executor, investigator) the same flow
- *      runs again so each can independently pick BYOK or Copilot.
+ *   2. Investigator (if enabled) → same picker.
+ *   3. Executor (if enabled) → same picker, UNLESS
+ *      `[ai.agent.executor].useInvestigatorRuntime = true` (and the investigator
+ *      is enabled), in which case the executor reuses the investigator's
+ *      resolved client + model and the picker is skipped.
  *
  * Provider-specific concerns are kept tight:
  *   - BYOK orchestrators get the kra-bash + kra-web MCP servers attached.
@@ -46,17 +49,6 @@ export async function startAgentChat(): Promise<void> {
         orchestrator = await pickAgentRuntime('orchestrator');
         allClients.push(orchestrator.client);
 
-        if (subAgentSettings.executor.enabled) {
-            const picked = await pickAgentRuntime('executor');
-            allClients.push(picked.client);
-            executor = {
-                client: picked.client,
-                model: picked.model,
-                ...(picked.contextWindow !== undefined ? { contextWindow: picked.contextWindow } : {}),
-                settings: subAgentSettings.executor,
-            };
-        }
-
         if (subAgentSettings.investigator.enabled) {
             const picked = await pickAgentRuntime('investigator');
             allClients.push(picked.client);
@@ -66,6 +58,29 @@ export async function startAgentChat(): Promise<void> {
                 ...(picked.contextWindow !== undefined ? { contextWindow: picked.contextWindow } : {}),
                 settings: subAgentSettings.investigator,
             };
+        }
+
+        if (subAgentSettings.executor.enabled) {
+            // If `useInvestigatorRuntime` is on AND we have an investigator,
+            // skip the picker and reuse the investigator's resolved client +
+            // model so the user only goes through the picker once.
+            if (subAgentSettings.executor.useInvestigatorRuntime && investigator) {
+                executor = {
+                    client: investigator.client,
+                    model: investigator.model,
+                    ...(investigator.contextWindow !== undefined ? { contextWindow: investigator.contextWindow } : {}),
+                    settings: subAgentSettings.executor,
+                };
+            } else {
+                const picked = await pickAgentRuntime('executor');
+                allClients.push(picked.client);
+                executor = {
+                    client: picked.client,
+                    model: picked.model,
+                    ...(picked.contextWindow !== undefined ? { contextWindow: picked.contextWindow } : {}),
+                    settings: subAgentSettings.executor,
+                };
+            }
         }
 
         await conversation.converseAgent({

--- a/src/AI/AIAgent/providers/byok/byokSession.ts
+++ b/src/AI/AIAgent/providers/byok/byokSession.ts
@@ -38,6 +38,7 @@ import { TURN_REMINDER } from '@/AI/AIAgent/shared/main/turnReminder';
 import { buildMcpClientPool, type McpClientPool } from '@/AI/AIAgent/providers/byok/mcpClientPool';
 import { createExecutableToolBridge, disconnectPool } from '@/AI/AIAgent/mcp/executableToolBridge';
 import { compactMessages, estimateTokens, isContextLengthError } from '@/AI/AIAgent/providers/byok/byokCompactor';
+import { getFileContextsTaggedBlock } from '@/AI/shared/conversation';
 
 const DEFAULT_SYSTEM_PROMPT = [
     'You are an autonomous coding agent operating inside a proposal workspace.',
@@ -112,6 +113,7 @@ export class OpenAICompatibleSession implements AgentSession {
         this.mcp = await buildMcpClientPool({
             servers: mergedServers,
             ...(this.opts.excludedTools ? { excludedTools: this.opts.excludedTools } : {}),
+            ...(this.opts.allowedTools ? { allowedTools: this.opts.allowedTools } : {}),
             workingDirectory: this.opts.workingDirectory,
         });
 
@@ -193,9 +195,14 @@ export class OpenAICompatibleSession implements AgentSession {
         this.compactedThisTurn = false;
         this.abortController = new AbortController();
 
+        const taggedFiles = await getFileContextsTaggedBlock();
+        const userContent = taggedFiles
+            ? `${options.prompt}\n\n${taggedFiles}\n\n${TURN_REMINDER}`
+            : `${options.prompt}\n\n${TURN_REMINDER}`;
+
         this.messages.push({
             role: 'user',
-            content: `${options.prompt}\n\n${TURN_REMINDER}`,
+            content: userContent,
         });
 
         try {

--- a/src/AI/AIAgent/providers/byok/mcpClientPool.ts
+++ b/src/AI/AIAgent/providers/byok/mcpClientPool.ts
@@ -16,6 +16,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
+import { matchesSubAgentWhitelist } from '@/AI/AIAgent/shared/subAgents/whitelist';
 
 export interface RegisteredTool {
     server: string;
@@ -38,6 +39,14 @@ export interface McpClientPool {
 interface BuildPoolOptions {
     servers: Record<string, MCPServerConfig>;
     excludedTools?: string[];
+    /**
+     * Positive filter applied AFTER `excludedTools`. When set, only tools
+     * whose namespaced name (`<server>__<tool>`) matches an entry — using
+     * the same trailing-segment matcher as the sub-agent whitelist — are
+     * registered. Used by sub-agent sessions to keep the model's tool
+     * inventory tightly scoped.
+     */
+    allowedTools?: string[];
     workingDirectory: string;
 }
 
@@ -52,6 +61,7 @@ export async function buildMcpClientPool(options: BuildPoolOptions): Promise<Mcp
     const tools = new Map<string, RegisteredTool>();
     const clients: Client[] = [];
     const excluded = new Set(options.excludedTools ?? []);
+    const allowedSet = options.allowedTools ? new Set(options.allowedTools) : null;
 
     for (const [serverName, config] of Object.entries(options.servers)) {
         if (config.type !== 'local' && config.type !== 'stdio') {
@@ -100,6 +110,10 @@ export async function buildMcpClientPool(options: BuildPoolOptions): Promise<Mcp
             }
 
             const namespaced = namespacedToolName(serverName, tool.name);
+
+            if (allowedSet && !matchesSubAgentWhitelist(namespaced, allowedSet)) {
+                continue;
+            }
 
             tools.set(namespaced, {
                 server: serverName,

--- a/src/AI/AIAgent/providers/copilot/copilotClient.ts
+++ b/src/AI/AIAgent/providers/copilot/copilotClient.ts
@@ -10,11 +10,50 @@ import { TURN_REMINDER } from '@/AI/AIAgent/shared/main/turnReminder';
 import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
 import { createExecutableToolBridge, disconnectPool } from '@/AI/AIAgent/mcp/executableToolBridge';
 import { buildMcpClientPool, type McpClientPool } from '@/AI/AIAgent/providers/byok/mcpClientPool';
+import { matchesSubAgentWhitelist } from '@/AI/AIAgent/shared/subAgents/whitelist';
 
 export interface CopilotClientWrapperOptions {
     githubToken?: string;
     useLoggedInUser?: boolean;
     reasoningEffort?: ReasoningEffort;
+}
+
+async function decideCopilotExcludedTools(
+    options: AgentSessionOptions
+): Promise<string[]> {
+    const baseExcluded = options.excludedTools ?? [];
+
+    if (!options.allowedTools) {
+        return baseExcluded;
+    }
+
+    const allowedSet = new Set(options.allowedTools);
+    const merged = new Set<string>(baseExcluded);
+
+    let probePool: McpClientPool | undefined;
+    try {
+        probePool = await buildMcpClientPool({
+            servers: options.mcpServers,
+            workingDirectory: options.workingDirectory,
+        });
+
+        for (const tool of probePool.tools.values()) {
+            if (matchesSubAgentWhitelist(tool.namespacedName, allowedSet)) {
+                continue;
+            }
+            // Copilot's excludedTools accepts the bare MCP tool name.
+            merged.add(tool.originalName);
+        }
+    } catch {
+        // If we can't enumerate, fall back to the caller-supplied excludes
+        // only — the runtime denylist (if any) will still gate execution.
+    } finally {
+        if (probePool) {
+            await probePool.disconnect();
+        }
+    }
+
+    return Array.from(merged);
 }
 
 export class CopilotClientWrapper implements AgentClient {
@@ -56,7 +95,14 @@ export class CopilotClientWrapper implements AgentClient {
         const isSubAgent = options.isSubAgent === true;
         const skillsDir = path.join(__dirname, '..', '..', '..', '..', 'skills');
 
-        const onPermissionRequest = () => ({ kind: 'approved' as const });
+        const onPermissionRequest = (): { kind: 'approved' } => ({ kind: 'approved' as const });
+
+        // When the caller asked for a positive tool inventory filter, translate
+        // it into Copilot's `excludedTools` knob. Copilot accepts bare MCP tool
+        // names there, so we enumerate the configured MCP servers, drop the
+        // ones our whitelist matches, and merge the rest with whatever
+        // `excludedTools` the caller already supplied.
+        const mergedExcluded = await decideCopilotExcludedTools(options);
 
         const sdkSession = await this.inner.createSession({
             clientName: 'copilot-cli',
@@ -67,7 +113,7 @@ export class CopilotClientWrapper implements AgentClient {
             enableConfigDiscovery: !isSubAgent,
             ...(isSubAgent ? {} : { skillDirectories: [skillsDir] }),
             mcpServers: options.mcpServers,
-            ...(options.excludedTools ? { excludedTools: options.excludedTools } : {}),
+            ...(mergedExcluded.length > 0 ? { excludedTools: mergedExcluded } : {}),
             ...(options.localTools && options.localTools.length > 0 ? { tools: options.localTools } : {}),
             onPermissionRequest,
             infiniteSessions: {

--- a/src/AI/AIAgent/shared/main/agentConversation.ts
+++ b/src/AI/AIAgent/shared/main/agentConversation.ts
@@ -13,6 +13,7 @@ import type {
     LocalTool,
 } from '@/AI/AIAgent/shared/types/agentTypes';
 import { createInvestigateTool } from '@/AI/AIAgent/shared/subAgents/investigateTool';
+import { createExecuteTool } from '@/AI/AIAgent/shared/subAgents/executeTool';
 
 import { handleAgentUserInput, handlePreToolUse } from '@/AI/AIAgent/shared/utils/agentToolHook';
 import { runStartupIndexingFlow } from '@/AI/AIAgent/shared/main/agentIndexingFlow';
@@ -133,6 +134,27 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
                 },
                 agentLabel: 'INVESTIGATOR',
                 headerEmoji: '🔍',
+                parentOnPreToolUse: orchestratorOnPreToolUse,
+                parentOnPostToolUse: orchestratorOnPostToolUse,
+            },
+        }));
+    }
+
+    if (options.executor) {
+        orchestratorLocalTools.push(createExecuteTool({
+            runtime: options.executor,
+            mcpServers: mergedMcpServers,
+            workingDirectory: cwd,
+            chatBridge: {
+                getParentState: () => {
+                    if (!stateRef.current) {
+                        throw new Error('Executor invoked before orchestrator state was ready');
+                    }
+
+                    return stateRef.current;
+                },
+                agentLabel: 'EXECUTOR',
+                headerEmoji: '⚙️',
                 parentOnPreToolUse: orchestratorOnPreToolUse,
                 parentOnPostToolUse: orchestratorOnPostToolUse,
             },

--- a/src/AI/AIAgent/shared/main/agentPromptActions.ts
+++ b/src/AI/AIAgent/shared/main/agentPromptActions.ts
@@ -1,11 +1,9 @@
-import * as fs from 'fs/promises';
-import type { AgentConversationState, MessageOptions } from '@/AI/AIAgent/shared/types/agentTypes';
+import type { AgentConversationState } from '@/AI/AIAgent/shared/types/agentTypes';
 import { formatSubmittedAgentPrompt } from '@/AI/AIAgent/shared/utils/agentUi';
 import {
     formatAssistantHeader,
     materializeUserDraft,
 } from '@/AI/shared/utils/conversationUtils/chatHeaders';
-import type { FileContext } from '@/AI/shared/types/aiTypes';
 import {
     clearAgentPrompt,
     focusAgentPrompt,
@@ -30,58 +28,6 @@ export function getErrorMessage(error: unknown): string {
     return 'Unknown error';
 }
 
-
-async function createSelectionAttachment(
-    context: FileContext,
-    displayName: string
-): Promise<{
-    type: 'selection',
-    filePath: string,
-    displayName: string,
-    selection: {
-        start: { line: number, character: number },
-        end: { line: number, character: number },
-    },
-    text: string,
-}> {
-    const content = await fs.readFile(context.filePath, 'utf8');
-    const allLines = content.split('\n');
-    const startLine = context.startLine ?? 1;
-    const endLine = context.endLine ?? startLine;
-    const selectedText = allLines.slice(startLine - 1, endLine).join('\n');
-
-    return {
-        type: 'selection',
-        filePath: context.filePath,
-        displayName,
-        selection: {
-            start: { line: startLine - 1, character: 0 },
-            end: { line: endLine - 1, character: allLines[endLine - 1]?.length ?? 0 },
-        },
-        text: selectedText,
-    };
-}
-
-async function buildAttachments(): Promise<NonNullable<MessageOptions['attachments']>> {
-    const attachments: NonNullable<MessageOptions['attachments']> = [];
-
-    for (const context of fileContext.fileContexts) {
-        const displayName = context.filePath.split('/').pop() ?? context.filePath;
-
-        if (!context.isPartial) {
-            attachments.push({
-                type: 'file',
-                path: context.filePath,
-                displayName,
-            });
-            continue;
-        }
-
-        attachments.push(await createSelectionAttachment(context, displayName));
-    }
-
-    return attachments;
-}
 
 async function handleSubmit(state: AgentConversationState): Promise<void> {
     if (state.isStreaming) {
@@ -110,11 +56,11 @@ async function handleSubmit(state: AgentConversationState): Promise<void> {
     await refreshAgentLayout(state.nvim);
     await focusAgentPrompt(state.nvim);
 
-    const attachments = await buildAttachments();
+    const taggedFiles = await fileContext.getFileContextsTaggedBlock();
+    const finalPrompt = taggedFiles ? `${prompt}\n\n${taggedFiles}` : prompt;
 
     await state.session.send({
-        prompt,
-        attachments,
+        prompt: finalPrompt,
         mode: 'immediate',
     });
 }

--- a/src/AI/AIAgent/shared/subAgents/executeTool.ts
+++ b/src/AI/AIAgent/shared/subAgents/executeTool.ts
@@ -1,0 +1,375 @@
+/**
+ * `execute` LocalTool — registered on the orchestrator session when the
+ * executor sub-agent is enabled.
+ *
+ * The orchestrator hands a concrete plan to the executor (a smaller, cheaper
+ * model) which carries it out using a wider toolset that includes write/edit
+ * tools. The executor returns a typed event log + summary instead of streaming
+ * the raw tool traffic back through the orchestrator's expensive context.
+ *
+ * Like `investigate`, every executor tool call flows through the orchestrator's
+ * approval modal (tagged `[EXECUTOR]`), so the user retains full control.
+ *
+ * Phases not yet wired here (per plan.md):
+ *   - Phase 4: real-time streaming controls (/orch, /exec) and Ctrl-C interrupt
+ *     beyond the existing `stop_stream` abort.
+ *   - Phase 5: `needs_replan` escape hatch — the result schema reserves a
+ *     `'needs_replan'` status value but the orchestrator side doesn't yet
+ *     react to it specially. For now it is surfaced as a regular tool result.
+ */
+
+import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
+import type { LocalTool } from '@/AI/AIAgent/shared/types/agentTypes';
+import type { ExecutorRuntime } from '@/AI/AIAgent/shared/subAgents/types';
+import { runSubAgentTask, type SubAgentChatBridge, type SubAgentEvent } from '@/AI/AIAgent/shared/subAgents/session';
+
+export interface CreateExecuteToolOptions {
+    runtime: ExecutorRuntime;
+    mcpServers: Record<string, MCPServerConfig>;
+    workingDirectory: string;
+    chatBridge?: SubAgentChatBridge;
+}
+
+interface ExecuteArgs {
+    plan: string;
+    context?: string;
+    successCriteria?: string;
+}
+
+export interface ExecutionEvent {
+    kind:
+        | 'step_start'
+        | 'step_done'
+        | 'read'
+        | 'edit'
+        | 'create'
+        | 'search'
+        | 'run'
+        | 'discovery'
+        | 'decision'
+        | 'blocked'
+        | 'note';
+    detail: string;
+    path?: string;
+    diff?: string;
+}
+
+export interface ExecutionResult {
+    status: 'completed' | 'partial' | 'blocked' | 'needs_replan';
+    summary: string;
+    events: ExecutionEvent[];
+    blockers?: string[];
+    replanReason?: string;
+}
+
+const EXECUTE_PARAMETERS: Record<string, unknown> = {
+    type: 'object',
+    properties: {
+        plan: {
+            type: 'string',
+            description: [
+                'The concrete plan for the executor to carry out. Be specific:',
+                'list the steps in order, name the files/symbols to touch, and state',
+                'the intended outcome of each step. The executor only sees what you',
+                'put here plus `context` — it has no access to your conversation.',
+            ].join(' '),
+        },
+        context: {
+            type: 'string',
+            description: [
+                'Optional supporting context: relevant findings from prior',
+                '`investigate` calls, exact line ranges, the user\'s constraints,',
+                'symbol names, or anything else that would shortcut the executor\'s',
+                'work. Be generous — every byte you put here saves a tool call.',
+            ].join(' '),
+        },
+        successCriteria: {
+            type: 'string',
+            description: [
+                'Optional explicit criteria for what counts as "done". The executor',
+                'will only mark `status: completed` if these are met; otherwise it',
+                'returns `partial` or `blocked` with a reason.',
+            ].join(' '),
+        },
+    },
+    required: ['plan'],
+    additionalProperties: false,
+};
+
+export function createExecuteTool(opts: CreateExecuteToolOptions): LocalTool {
+    const { runtime, mcpServers, workingDirectory } = opts;
+    const { settings } = runtime;
+
+    let activeRun: Promise<string> | null = null;
+
+    return {
+        name: 'execute',
+        serverLabel: 'kra-subagent',
+        description: [
+            'PREFERRED execution tool. Use `execute` to delegate any concrete,',
+            'multi-step body of work — edits across several files, a refactor, a',
+            'new feature implementation — to a smaller, cheaper executor model.',
+            'The executor runs the work end-to-end and returns ONLY a curated event',
+            'log + summary; the raw tool traffic (file reads, search results,',
+            'intermediate edits) never enters your context. That keeps your',
+            'expensive context lean and dramatically cuts the token cost of any',
+            'task whose bulk is mechanical reads + edits rather than reasoning.',
+            'Workflow: think the plan through (optionally call `investigate` first),',
+            'then call `execute` with a step-by-step `plan`. Pass any prior findings,',
+            'paths, or user constraints in `context` — the executor only sees what',
+            'you give it, so be generous; every byte saves a tool call on its side.',
+            'Skip `execute` only for one-line trivial edits or for tasks that',
+            'genuinely need orchestrator-grade reasoning at every step.',
+            'Only ONE execution can run at a time. Wait for the in-flight execution',
+            'to return before issuing another.',
+        ].join(' '),
+        parameters: EXECUTE_PARAMETERS,
+        handler: async (rawArgs) => {
+            if (activeRun) {
+                return [
+                    'execute: another execution is already running. Only one executor',
+                    'is allowed at a time so the user retains full control. Wait for it',
+                    'to finish and then issue your next execute call.',
+                ].join(' ');
+            }
+
+            const args = rawArgs as unknown as ExecuteArgs;
+            const run = (async (): Promise<string> => {
+                const systemPrompt = buildExecutorSystemPrompt(settings);
+                const taskPrompt = buildExecutorTaskPrompt(args);
+
+                const { result, events } = await runSubAgentTask({
+                    runtime,
+                    mcpServers,
+                    workingDirectory,
+                    systemPrompt,
+                    taskPrompt,
+                    toolWhitelist: settings.toolWhitelist,
+                    resultSchema: buildResultSchema(),
+                    ...(runtime.contextWindow !== undefined ? { contextWindow: runtime.contextWindow } : {}),
+                    ...(opts.chatBridge ? { chatBridge: opts.chatBridge } : {}),
+                });
+
+                if (!result) {
+                    return [
+                        'Executor did not call submit_result. It may have hit a tool-call',
+                        'limit, refused the task, or been aborted by the user.',
+                        `Captured event count: ${events.length}.`,
+                        events.length > 0 ? `Last events: ${summariseRawEvents(events.slice(-5))}` : '',
+                    ].filter(Boolean).join(' ');
+                }
+
+                const parsed = coerceResult(result);
+
+                return formatExecutionResult(parsed);
+            })();
+
+            activeRun = run;
+
+            try {
+                return await run;
+            } finally {
+                activeRun = null;
+            }
+        },
+    };
+}
+
+function buildExecutorSystemPrompt(settings: ExecutorRuntime['settings']): string {
+    return [
+        'You are an executor sub-agent. Your job is to carry out a concrete plan',
+        'handed to you by an orchestrator. You are NOT the planner — do not',
+        're-scope the work, do not ask for permission, just execute.',
+        '',
+        'Workflow:',
+        '  1. Read the `plan` carefully. If `context` is provided, treat it as',
+        '     authoritative background you should rely on instead of re-discovering.',
+        '  2. For each step, use the smallest tool sequence that gets it done.',
+        '     Prefer get_outline + targeted read_lines over reading whole files.',
+        '  3. When you make an edit, it lands in a proposal workspace — the user',
+        '     will review the diff before it touches the real repo, so be precise',
+        '     but do not be timid.',
+        '  4. After each meaningful action (edit, create, run), record a short',
+        '     event in your eventual `submit_result` payload. Reads/searches that',
+        '     directly inform an edit can be summarised in one `read` event.',
+        '  5. When all steps are done OR you hit a blocker, call `submit_result`',
+        '     exactly once with the appropriate `status`:',
+        '       - `completed`   = every step done, success criteria met',
+        '       - `partial`     = some steps done, others skipped (explain why)',
+        '       - `blocked`     = a step cannot proceed (explain why in `blockers`)',
+        `       - \`needs_replan\` = the plan itself is wrong${settings.allowReplanEscape
+            ? ' (set `replanReason`)'
+            : ' — DISABLED in settings, do not use'}`,
+        '  6. Do NOT call any tool after `submit_result`. Output a brief',
+        '     acknowledgement and stop.',
+        '  7. NEVER call `confirm_task_complete` or any other end-of-turn tool.',
+        '     The orchestrator owns the turn.',
+        '',
+        'Quality bar:',
+        '  - Make MINIMAL, SURGICAL edits. Do not reformat untouched code.',
+        '  - Every event\'s `detail` is a single human-readable sentence.',
+        '  - If you read a file you do not edit, mention it as a `read` event so',
+        '    the orchestrator knows what informed your decisions.',
+        `  - Hard cap: ${settings.maxToolCalls} tool calls. Submit before you hit it.`,
+    ].join('\n');
+}
+
+function buildExecutorTaskPrompt(args: ExecuteArgs): string {
+    const lines = ['Plan to execute:', '', args.plan];
+
+    if (args.successCriteria) {
+        lines.push('', 'Success criteria:', args.successCriteria);
+    }
+
+    if (args.context) {
+        lines.push('', 'Context from the orchestrator:', args.context);
+    }
+
+    lines.push('', 'Execute the plan, then call submit_result with your typed event log + summary.');
+
+    return lines.join('\n');
+}
+
+function buildResultSchema(): Record<string, unknown> {
+    return {
+        type: 'object',
+        properties: {
+            status: {
+                type: 'string',
+                enum: ['completed', 'partial', 'blocked', 'needs_replan'],
+                description: 'Outcome of the execution. See system prompt for the meaning of each value.',
+            },
+            summary: {
+                type: 'string',
+                description: '2–6 sentences describing what was done, what changed, and any caveats.',
+            },
+            events: {
+                type: 'array',
+                items: {
+                    type: 'object',
+                    properties: {
+                        kind: {
+                            type: 'string',
+                            enum: [
+                                'step_start', 'step_done', 'read', 'edit', 'create',
+                                'search', 'run', 'discovery', 'decision', 'blocked', 'note',
+                            ],
+                        },
+                        detail: {
+                            type: 'string',
+                            description: 'One-sentence human-readable description of the event.',
+                        },
+                        path: {
+                            type: 'string',
+                            description: 'Repository-relative file path, when the event refers to a file.',
+                        },
+                        diff: {
+                            type: 'string',
+                            description: 'Optional inline unified diff for edit/create events.',
+                        },
+                    },
+                    required: ['kind', 'detail'],
+                    additionalProperties: false,
+                },
+            },
+            blockers: {
+                type: 'array',
+                items: { type: 'string' },
+                description: 'Required when status = blocked: list the things preventing completion.',
+            },
+            replanReason: {
+                type: 'string',
+                description: 'Required when status = needs_replan: why the plan itself is wrong.',
+            },
+        },
+        required: ['status', 'summary', 'events'],
+        additionalProperties: false,
+    };
+}
+
+export function coerceResult(raw: Record<string, unknown>): ExecutionResult {
+    const status = (
+        raw['status'] === 'completed'
+        || raw['status'] === 'partial'
+        || raw['status'] === 'blocked'
+        || raw['status'] === 'needs_replan'
+    ) ? raw['status'] : 'partial';
+
+    const summary = typeof raw['summary'] === 'string' ? raw['summary'] : '';
+
+    const events: ExecutionEvent[] = Array.isArray(raw['events'])
+        ? (raw['events'] as unknown[]).flatMap((e) => {
+            if (typeof e !== 'object' || e === null) return [];
+            const obj = e as Record<string, unknown>;
+            const kind = typeof obj['kind'] === 'string' ? obj['kind'] : '';
+            const detail = typeof obj['detail'] === 'string' ? obj['detail'] : '';
+
+            if (!kind || !detail) return [];
+
+            const ev: ExecutionEvent = { kind: kind as ExecutionEvent['kind'], detail };
+
+            if (typeof obj['path'] === 'string') ev.path = obj['path'];
+            if (typeof obj['diff'] === 'string') ev.diff = obj['diff'];
+
+            return [ev];
+        })
+        : [];
+
+    const result: ExecutionResult = { status, summary, events };
+
+    if (Array.isArray(raw['blockers'])) {
+        const blockers = (raw['blockers'] as unknown[]).filter((b): b is string => typeof b === 'string');
+
+        if (blockers.length > 0) result.blockers = blockers;
+    }
+
+    if (typeof raw['replanReason'] === 'string') {
+        result.replanReason = raw['replanReason'];
+    }
+
+    return result;
+}
+
+export function formatExecutionResult(r: ExecutionResult): string {
+    const lines: string[] = [
+        `status: ${r.status}`,
+        `summary: ${r.summary}`,
+        '',
+        `events (${r.events.length}):`,
+    ];
+
+    for (const ev of r.events) {
+        const head = ev.path ? `${ev.kind} ${ev.path}` : ev.kind;
+        lines.push(`  - [${head}] ${ev.detail}`);
+
+        if (ev.diff) {
+            const diffLines = ev.diff.split('\n').slice(0, 80).map((l) => `      ${l}`);
+            lines.push(...diffLines);
+        }
+    }
+
+    if (r.blockers && r.blockers.length > 0) {
+        lines.push('', 'blockers:');
+
+        for (const b of r.blockers) {
+            lines.push(`  - ${b}`);
+        }
+    }
+
+    if (r.replanReason) {
+        lines.push('', `replanReason: ${r.replanReason}`);
+    }
+
+    return lines.join('\n');
+}
+
+function summariseRawEvents(events: SubAgentEvent[]): string {
+    return events
+        .map((e) => {
+            if (e.kind === 'tool_start' && e.toolName) return `tool_start:${e.toolName}`;
+            if (e.kind === 'tool_complete') return `tool_complete:${e.success ? 'ok' : 'fail'}`;
+
+            return e.kind;
+        })
+        .join(', ');
+}

--- a/src/AI/AIAgent/shared/subAgents/investigateTool.ts
+++ b/src/AI/AIAgent/shared/subAgents/investigateTool.ts
@@ -32,14 +32,14 @@ export interface CreateInvestigateToolOptions {
     chatBridge?: SubAgentChatBridge;
 }
 
-interface EvidenceItem {
+export interface EvidenceItem {
     path: string;
     lines: string;
     excerpt: string;
     why_relevant: string;
 }
 
-interface InvestigationResult {
+export interface InvestigationResult {
     summary: string;
     evidence: EvidenceItem[];
     confidence: 'high' | 'medium' | 'low';
@@ -186,9 +186,6 @@ function buildInvestigatorSystemPrompt(settings: InvestigatorRuntime['settings']
         '  - Every excerpt MUST be copied verbatim from the file at the stated line range.',
         '  - Set `confidence` honestly. If you could not find what was asked, say so.',
         '  - Prefer fewer, high-signal excerpts over many shallow ones.',
-        '',
-        `Allowed tools: ${settings.toolWhitelist.join(', ')}, submit_result.`,
-        'Any other tool call will be denied.',
     ].join('\n');
 }
 
@@ -258,7 +255,7 @@ function buildResultSchema(maxEvidenceItems: number): Record<string, unknown> {
     };
 }
 
-function coerceResult(raw: Record<string, unknown>): InvestigationResult {
+export function coerceResult(raw: Record<string, unknown>): InvestigationResult {
     const summary = typeof raw['summary'] === 'string' ? raw['summary'] : '';
     const confidence =
         raw['confidence'] === 'high' || raw['confidence'] === 'medium' || raw['confidence'] === 'low'
@@ -317,7 +314,7 @@ function normaliseForCompare(s: string): string {
     return s.replace(/\s+/g, ' ').trim();
 }
 
-async function validateEvidence(
+export async function validateEvidence(
     evidence: EvidenceItem[],
     workingDirectory: string
 ): Promise<EvidenceItem[]> {

--- a/src/AI/AIAgent/shared/subAgents/session.ts
+++ b/src/AI/AIAgent/shared/subAgents/session.ts
@@ -102,6 +102,10 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
     };
 
     let captured: Record<string, unknown> | undefined;
+    let resolveSubmitted: (() => void) | undefined;
+    const submitted = new Promise<void>((resolve) => {
+        resolveSubmitted = resolve;
+    });
 
     const submitTool: LocalTool = {
         name: 'submit_result',
@@ -112,47 +116,16 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
         serverLabel: 'kra-subagent',
         handler: async (args) => {
             captured = args;
+            resolveSubmitted?.();
 
             return 'Result accepted. End your turn now without calling any more tools.';
         },
     };
 
-    const whitelist = new Set([...opts.toolWhitelist, 'submit_result']);
     const bridge = opts.chatBridge;
 
-    const matchesWhitelist = (toolName: string): boolean => {
-        if (whitelist.has(toolName)) {
-            return true;
-        }
-
-        // Different providers prefix MCP tools differently:
-        //   BYOK   → bare `originalName` (e.g. `read_lines`)
-        //   Copilot → `<server>__<tool>` or `<server>-<tool>` (e.g. `kra-memory-search`)
-        // Match if any whitelist entry appears as a trailing segment delimited
-        // by `__`, `-` or `.`. We deliberately do NOT split on `_` because
-        // many tool names (read_lines, lsp_query, …) contain underscores.
-        for (const allowed of whitelist) {
-            const re = new RegExp(`(^|[\\-.]|__)${allowed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
-
-            if (re.test(toolName)) {
-                return true;
-            }
-        }
-
-        return false;
-    };
-
     const onPreToolUse = async (input: AgentPreToolUseHookInput): Promise<AgentPreToolUseHookOutput> => {
-        if (!matchesWhitelist(input.toolName)) {
-            return {
-                permissionDecision: 'deny',
-                permissionDecisionReason:
-                    `Tool '${input.toolName}' is not in this sub-agent's whitelist. ` +
-                    `Allowed tools: ${[...whitelist].join(', ')}.`,
-            };
-        }
-
-        // submit_result is synthetic — don't bother the user for approval.
+        // submit_result is a synthetic local tool — always allow it.
         if (input.toolName === 'submit_result') {
             return { permissionDecision: 'allow' };
         }
@@ -184,6 +157,10 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
         return;
     };
 
+    // The provider wrappers honour `allowedTools` by filtering the MCP/built-in
+    // tool inventory advertised to the model BEFORE the turn starts. We still
+    // pass the static `excludedTools` list so the SDK's own built-in editors
+    // (which we replace with our MCP-served versions) never appear.
     const session: AgentSession = await opts.runtime.client.createSession({
         model: opts.runtime.model,
         workingDirectory: opts.workingDirectory,
@@ -196,6 +173,7 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
             'grep', 'glob', 'create', 'apply_patch',
             'bash', 'shell', 'run_in_terminal', 'execute',
         ],
+        allowedTools: [...opts.toolWhitelist, 'submit_result'],
         onPreToolUse,
         onPostToolUse,
     });
@@ -238,12 +216,17 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
         // via the `session.idle` event. We wait for idle in both cases so the
         // sub-agent reliably finishes (and submit_result fires) before we
         // disconnect.
+        // We ALSO race against `submitted` (resolved synchronously by the
+        // submit_result handler): some models keep emitting text or denied
+        // tool calls after submitting, which delays or never fires `idle`.
+        // Once we have a captured result there is nothing useful left for the
+        // model to do, so we hand control back to the orchestrator immediately.
         const idle = new Promise<void>((resolve) => {
             session.on('session.idle', () => resolve());
         });
 
         await session.send({ prompt: opts.taskPrompt });
-        await idle;
+        await Promise.race([idle, submitted]);
     } finally {
         if (bridge && parentState) {
             await appendToChat(

--- a/src/AI/AIAgent/shared/subAgents/settings.ts
+++ b/src/AI/AIAgent/shared/subAgents/settings.ts
@@ -40,9 +40,11 @@ const DEFAULT_INVESTIGATOR_TOOLS = [
 
 const EXECUTOR_DEFAULTS: ExecutorSettings = {
     enabled: false,
+    useInvestigatorRuntime: true,
     allowInterrupt: true,
     allowReplanEscape: true,
     includeDiffsInLog: true,
+    maxToolCalls: 60,
     toolWhitelist: DEFAULT_EXECUTOR_TOOLS,
 };
 
@@ -56,9 +58,11 @@ const INVESTIGATOR_DEFAULTS: InvestigatorSettings = {
 
 interface RawExecutor {
     enabled?: boolean;
+    useInvestigatorRuntime?: boolean;
     allowInterrupt?: boolean;
     allowReplanEscape?: boolean;
     includeDiffsInLog?: boolean;
+    maxToolCalls?: number;
     toolWhitelist?: string[];
 }
 
@@ -95,11 +99,14 @@ export async function loadSubAgentSettings(): Promise<SubAgentSettings> {
     };
 }
 
-function mergeExecutor(raw: RawExecutor | undefined): ExecutorSettings {
+export function mergeExecutor(raw: RawExecutor | undefined): ExecutorSettings {
     if (!raw || typeof raw !== 'object') return { ...EXECUTOR_DEFAULTS };
 
     return {
         enabled: typeof raw.enabled === 'boolean' ? raw.enabled : EXECUTOR_DEFAULTS.enabled,
+        useInvestigatorRuntime: typeof raw.useInvestigatorRuntime === 'boolean'
+            ? raw.useInvestigatorRuntime
+            : EXECUTOR_DEFAULTS.useInvestigatorRuntime,
         allowInterrupt: typeof raw.allowInterrupt === 'boolean'
             ? raw.allowInterrupt
             : EXECUTOR_DEFAULTS.allowInterrupt,
@@ -109,11 +116,12 @@ function mergeExecutor(raw: RawExecutor | undefined): ExecutorSettings {
         includeDiffsInLog: typeof raw.includeDiffsInLog === 'boolean'
             ? raw.includeDiffsInLog
             : EXECUTOR_DEFAULTS.includeDiffsInLog,
+        maxToolCalls: clampInt(raw.maxToolCalls, 1, 500, EXECUTOR_DEFAULTS.maxToolCalls),
         toolWhitelist: normaliseStringList(raw.toolWhitelist, EXECUTOR_DEFAULTS.toolWhitelist),
     };
 }
 
-function mergeInvestigator(raw: RawInvestigator | undefined): InvestigatorSettings {
+export function mergeInvestigator(raw: RawInvestigator | undefined): InvestigatorSettings {
     if (!raw || typeof raw !== 'object') return { ...INVESTIGATOR_DEFAULTS };
 
     return {

--- a/src/AI/AIAgent/shared/subAgents/types.ts
+++ b/src/AI/AIAgent/shared/subAgents/types.ts
@@ -14,9 +14,18 @@ import type { AgentClient } from '@/AI/AIAgent/shared/types/agentTypes';
 
 export interface ExecutorSettings {
     enabled: boolean;
+    /**
+     * If true AND the investigator is also enabled, the executor reuses the
+     * investigator's resolved runtime (client + model) instead of prompting the
+     * user to pick a separate provider/model on startup. Saves a picker step
+     * when the user wants both sub-agents to run on the same cheap model.
+     */
+    useInvestigatorRuntime: boolean;
     allowInterrupt: boolean;
     allowReplanEscape: boolean;
     includeDiffsInLog: boolean;
+    /** Hard cap on tool calls before the executor is forced to submit. */
+    maxToolCalls: number;
     toolWhitelist: string[];
 }
 

--- a/src/AI/AIAgent/shared/subAgents/whitelist.ts
+++ b/src/AI/AIAgent/shared/subAgents/whitelist.ts
@@ -1,0 +1,37 @@
+/**
+ * Whitelist matcher for sub-agent tool calls.
+ *
+ * Sub-agents run with a restricted toolset. Different providers surface MCP
+ * tool names with different prefixes:
+ *   BYOK    → bare `originalName`              (e.g. `read_lines`)
+ *   Copilot → `<server>__<tool>` or `<server>-<tool>` (e.g. `kra-memory-search`,
+ *             `kra-file-context__search`)
+ *
+ * Match if any whitelist entry appears as a trailing segment delimited by
+ * `__`, `-`, or `.`. We deliberately do NOT split on `_` because many real
+ * tool names (`read_lines`, `lsp_query`, …) contain underscores.
+ *
+ * Exported separately from `session.ts` so the regex behaviour is unit-testable
+ * without having to spin up a sub-agent session.
+ */
+export function matchesSubAgentWhitelist(toolName: string, whitelist: Iterable<string>): boolean {
+    const allowed = new Set(whitelist);
+
+    if (allowed.has(toolName)) {
+        return true;
+    }
+
+    for (const entry of allowed) {
+        const re = new RegExp(`(^|[\\-.]|__)${escapeRegExp(entry)}$`);
+
+        if (re.test(toolName)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function escapeRegExp(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/AI/AIAgent/shared/types/agentTypes.ts
+++ b/src/AI/AIAgent/shared/types/agentTypes.ts
@@ -108,6 +108,15 @@ export interface AgentSessionOptions {
     additionalMcpServers?: Record<string, MCPServerConfig>;
     excludedTools?: string[];
     /**
+     * If set, restricts the tool inventory advertised to the model to the
+     * given names. Tools are matched by trailing segment delimiter (`-`,
+     * `__`, `.`) so bare names like `read_lines` match namespaced MCP tools
+     * like `kra-file-context__read_lines`. Provider wrappers translate this
+     * into whatever positive- or inverse-exclusion machinery they have.
+     * Sub-agents use this to scope what the small model can even see.
+     */
+    allowedTools?: string[];
+    /**
      * In-process tools registered alongside MCP tools. Useful for sub-agent
      * dispatch tools (e.g. `investigate`) where the handler must run in the
      * same Node process as the orchestrator session. They flow through the

--- a/src/AI/shared/utils/conversationUtils/fileContexts.ts
+++ b/src/AI/shared/utils/conversationUtils/fileContexts.ts
@@ -142,6 +142,42 @@ export async function getFileContextsForPrompt(): Promise<string> {
 }
 
 /**
+ * Generate a metadata-only `<tagged_files>` block describing the loaded file
+ * contexts (path + line count for full files, path + line range for partial
+ * selections). The model is expected to read the actual contents on demand
+ * via its file-reading tools. Mirrors the format the Copilot Agent SDK
+ * surfaces for attachments.
+**/
+export async function getFileContextsTaggedBlock(): Promise<string> {
+    if (fileContexts.length === 0) return '';
+
+    const lines: string[] = [];
+
+    for (const context of fileContexts) {
+        if (context.isPartial) {
+            const start = context.startLine;
+            const end = context.endLine;
+            const range = typeof start === 'number' && typeof end === 'number'
+                ? (start === end ? `line ${start}` : `lines ${start}-${end}`)
+                : 'partial selection';
+            lines.push(`* ${context.filePath} (${range})`);
+            continue;
+        }
+
+        try {
+            const content = await fs.readFile(context.filePath, 'utf-8');
+            const count = content.length === 0 ? 0 : content.split('\n').length;
+            lines.push(`* ${context.filePath} (${count} lines)`);
+        } catch (error) {
+            console.error(`Error loading context for ${context.filePath}:`, error);
+            lines.push(`* ${context.filePath}`);
+        }
+    }
+
+    return `<tagged_files>\n${lines.join('\n')}\n</tagged_files>`;
+}
+
+/**
  * Display current file contexts in command line
 **/
 export async function showFileContexts(nvim: NeovimClient): Promise<void> {


### PR DESCRIPTION
opt-in executor sub-agent that the orchestrator can delegate concrete, multi-step work to via a new `execute` tool the executor runs the plan end-to-end with its own restricted toolset (reads, edits, search, lsp, bash) and returns only a curated event log plus summary, so the raw tool traffic never enters the orchestrator's context. On any task whose bulk is mechanical reads and edits this keeps the expensive context lean and cuts token cost sharply

the executor runs the plan end-to-end with its own restricted toolset (reads, edits, search, lsp, bash) and returns only a curated event log plus summary, so the raw tool traffic never enters the orchestrator's context, on any task whose bulk is mechanical reads and edits this keeps the expensive context lean and cuts token cost sharply