### PR TITLE
feat: BYOK model capabilities, dynamic params, text-based tool calls,…

### DIFF
--- a/__tests__/AI/shared/modelsDevCatalog.test.ts
+++ b/__tests__/AI/shared/modelsDevCatalog.test.ts
@@ -1,0 +1,109 @@
+import {
+    formatCapabilitiesSummary,
+} from '@/AI/shared/data/modelsDevCatalog';
+
+describe('modelsDevCatalog', () => {
+    describe('formatCapabilitiesSummary', () => {
+        it('produces a non-empty summary with reasoning capabilities', () => {
+            const info = {
+                id: 'test-model',
+                name: 'Test Model',
+                provider: 'test',
+                providerName: 'Test Provider',
+                capabilities: {
+                    reasoning: true,
+                    reasoningField: 'reasoning_content' as const,
+                    toolCall: true,
+                    temperature: true,
+                    structuredOutput: false,
+                    attachment: true,
+                    inputModalities: ['text', 'image'],
+                    outputModalities: ['text'],
+                    openWeights: true,
+                },
+                contextWindow: 128000,
+                maxOutputTokens: 16384,
+            };
+            const summary = formatCapabilitiesSummary(info);
+            expect(summary).toContain('Test Model');
+            expect(summary).toContain('128k');
+            expect(summary).toContain('Reasoning');
+            expect(summary).toContain('reasoning_content');
+            expect(summary).toContain('Tool calling');
+            expect(summary).toContain('Open weights');
+        });
+
+        it('shows context window as ? when zero', () => {
+            const info = {
+                id: 'test',
+                name: 'Test',
+                provider: 'test',
+                providerName: 'Test',
+                capabilities: {
+                    reasoning: false,
+                    toolCall: false,
+                    temperature: true,
+                    structuredOutput: false,
+                    attachment: false,
+                    inputModalities: ['text'],
+                    outputModalities: ['text'],
+                },
+                contextWindow: 0,
+            };
+            const summary = formatCapabilitiesSummary(info);
+            expect(summary).toContain('?');
+        });
+
+        it('shows pricing with cached and reasoning breakdown', () => {
+            const info = {
+                id: 'test',
+                name: 'Test',
+                provider: 'test',
+                providerName: 'Test',
+                capabilities: {
+                    reasoning: true,
+                    toolCall: true,
+                    temperature: true,
+                    structuredOutput: true,
+                    attachment: false,
+                    inputModalities: ['text'],
+                    outputModalities: ['text'],
+                },
+                pricing: {
+                    inputPerM: 1.50,
+                    outputPerM: 6.00,
+                    cachedInputPerM: 0.30,
+                    reasoningPerM: 10.00,
+                },
+                contextWindow: 128000,
+            };
+            const summary = formatCapabilitiesSummary(info);
+            expect(summary).toContain('$1.50');
+            expect(summary).toContain('$6.00');
+            expect(summary).toContain('cached $0.30');
+            expect(summary).toContain('reasoning $10.00');
+        });
+
+        it('shows reasoning_details as reasoning field for Gemini-style models', () => {
+            const info = {
+                id: 'gemini-3-flash',
+                name: 'Gemini 3 Flash',
+                provider: 'google',
+                providerName: 'Google',
+                capabilities: {
+                    reasoning: true,
+                    reasoningField: 'reasoning_details' as const,
+                    toolCall: true,
+                    temperature: true,
+                    structuredOutput: true,
+                    attachment: true,
+                    inputModalities: ['text', 'image'],
+                    outputModalities: ['text'],
+                },
+                contextWindow: 1000000,
+            };
+            const summary = formatCapabilitiesSummary(info);
+            expect(summary).toContain('reasoning_details');
+        });
+    });
+});

--- a/src/AI/AIAgent/commands/memory/sections/docsSources.ts
+++ b/src/AI/AIAgent/commands/memory/sections/docsSources.ts
@@ -1,7 +1,7 @@
 import blessed from 'blessed';
 import { loadSettings } from '@/utils/common';
 import { getDocChunksTable } from '@/AI/AIAgent/shared/memory/db';
-import { docsCoordinatorJsPath } from '@/packagePaths';
+import { docsCoordinatorJsPath, docsLiveProgressJsPath } from '@/packagePaths';
 import { crawl4aiVenvDir } from '@/filePaths';
 import { createIPCClient, IPCsockets } from '../../../../../../eventSystem/ipc';
 import {
@@ -12,6 +12,7 @@ import {
     coordinatorAlive,
     readSnapshot,
 } from '@/AI/AIAgent/shared/docs/liveProgressScreen';
+import { runInherit } from '@/UI/dashboard/screen';
 import type { DocsSettings, DocsSource } from '@/types/settingsTypes';
 import type { DocsSourceRequest } from '@/AI/AIAgent/shared/docs/types';
 import {
@@ -404,8 +405,19 @@ export function mountDocsSourcesSection(opts: {
             }
             else if (item.key === 'crawl-all') await crawlAllAction();
             else if (item.key === 'progress') {
-                await updateLivePane();
-                flash('live progress pane refreshed');
+                const liveActive = (await coordinatorAlive()) || (await readSnapshot()) !== null;
+                if (liveActive) {
+                    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+                    try {
+                        await runInherit(process.execPath, [docsLiveProgressJsPath], screen);
+                    } finally {
+                        pollTimer = setInterval(() => { void updateLivePane(); }, 500);
+                    }
+                    await updateLivePane();
+                } else {
+                    await updateLivePane();
+                    flash('no active crawl yet — start one with "Re-index all sources"');
+                }
             }
             else if (item.key === 'stop') await stopCoordinatorAction();
 

--- a/src/AI/AIAgent/commands/startAgentChat.ts
+++ b/src/AI/AIAgent/commands/startAgentChat.ts
@@ -88,6 +88,10 @@ export async function startAgentChat(): Promise<void> {
             client: orchestrator.client,
             model: orchestrator.model,
             ...(orchestrator.contextWindow !== undefined ? { contextWindow: orchestrator.contextWindow } : {}),
+            ...(orchestrator.capabilities ? { modelCapabilities: orchestrator.capabilities } : {}),
+            ...(orchestrator.reasoningEffort ? { reasoningEffort: orchestrator.reasoningEffort } : {}),
+            ...(orchestrator.temperature != null ? { temperature: orchestrator.temperature } : {}),
+            ...(orchestrator.dynamicParams ? { dynamicParams: orchestrator.dynamicParams } : {}),
             ...(orchestrator.kind === 'byok'
                 ? { additionalMcpServers: buildByokExtraMcpServers() }
                 : {}),

--- a/src/AI/AIAgent/commands/subAgentProviderPicker.ts
+++ b/src/AI/AIAgent/commands/subAgentProviderPicker.ts
@@ -20,15 +20,22 @@ import {
 } from '@/AI/shared/data/providers';
 import {
     type ModelInfo as ByokModelInfo,
+    type ModelCapabilities,
+    type ParamDescriptor,
     formatModelInfoForPicker,
     getModelCatalog,
 } from '@/AI/shared/data/modelCatalog';
+import {
+    getModelsDevCatalog,
+    lookupModelCapabilities,
+    formatCapabilitiesSummary,
+    type ModelsDevModelInfo,
+} from '@/AI/shared/data/modelsDevCatalog';
 import { OpenAICompatibleClient } from '@/AI/AIAgent/providers/byok/byokClient';
 import { CopilotClientWrapper } from '@/AI/AIAgent/providers/copilot/copilotClient';
 import { getGithubToken } from '@/AI/AIAgent/shared/utils/agentSettings';
 import { type ModelInfo as CopilotModelInfo } from '@github/copilot-sdk';
 import type { AgentClient, ReasoningEffort } from '@/AI/AIAgent/shared/types/agentTypes';
-
 const PROVIDER_KIND_BYOK = 'BYOK (OpenAI-compatible)';
 const PROVIDER_KIND_COPILOT = 'GitHub Copilot';
 
@@ -40,6 +47,19 @@ export interface AgentRuntimePick {
     client: AgentClient;
     model: string;
     contextWindow?: number;
+    /** Dynamic capabilities fetched from models.dev for the selected model. */
+    capabilities?: ModelCapabilities;
+    /** Reasoning effort for BYOK models that support it. */
+    reasoningEffort?: 'low' | 'medium' | 'high';
+    /** Temperature override for BYOK sessions. */
+    temperature?: number;
+    /**
+     * Generic per-(provider, model) optional params resolved by the picker.
+     * Threaded through to `AgentSessionOptions.dynamicParams` so the BYOK
+     * session's `OPTIONAL_PARAMS` registry / dynamic spec generator can pick
+     * them up without each new param needing a typed field on this pick.
+     */
+    dynamicParams?: Record<string, unknown>;
 }
 
 async function pickByokRuntime(role: AgentRole): Promise<AgentRuntimePick> {
@@ -53,24 +73,148 @@ async function pickByokRuntime(role: AgentRole): Promise<AgentRuntimePick> {
         throw new Error(`No models returned for provider '${provider}'.`);
     }
 
+    let devModels: Map<string, ModelsDevModelInfo> = new Map();
+    try {
+        // First try provider-specific catalog, then supplement with global lookup
+        const catalog = await getModelsDevCatalog(provider);
+        devModels = new Map(catalog.map((m) => [m.id, m]));
+
+        // For models not found in the provider catalog, try a global search
+        // (e.g. open-code models like "minimax-m2.7" exist under "opencode" in models.dev)
+        for (const m of models) {
+            if (!devModels.has(m.id)) {
+                try {
+                    const globalMatch = await lookupModelCapabilities(m.id);
+                    if (globalMatch) {
+                        devModels.set(m.id, globalMatch);
+                    }
+                } catch { /* non-fatal per-model */ }
+            }
+        }
+    } catch { /* non-fatal — models.dev may be unreachable */ }
+
     const sorted = [...models].sort((a, b) => a.label.localeCompare(b.label));
     const labelToModel = new Map<string, ByokModelInfo>();
     for (const m of sorted) {
         labelToModel.set(formatModelInfoForPicker(m), m);
     }
 
+    // Build a details callback that shows capabilities from models.dev
+    const detailsCallback = (item: string, _index: number): string => {
+        const model = labelToModel.get(item);
+        if (!model) return '';
+        const devInfo = devModels.get(model.id);
+        if (devInfo) {
+            return formatCapabilitiesSummary(devInfo);
+        }
+        // Fallback: show basic info from our catalog
+        const lines: string[] = [];
+        lines.push(`{bold}{cyan-fg}${model.label}{/cyan-fg}{/bold}`);
+        lines.push('');
+        if (model.contextWindow > 0) {
+            lines.push(`{bold}Context window:{/}  ${Math.round(model.contextWindow / 1000).toLocaleString()}k tokens`);
+        }
+        if (model.pricing) {
+            lines.push(`{bold}Pricing:{/}  $${model.pricing.inputPerM.toFixed(2)}/$${model.pricing.outputPerM.toFixed(2)} per 1M tokens`);
+            if (model.pricing.cachedInputPerM != null) {
+                lines.push(`  cached $${model.pricing.cachedInputPerM.toFixed(2)}`);
+            }
+        }
+
+        return lines.join('\n');
+    };
+
     const selectedLabel = await ui.searchSelectAndReturnFromArray({
         itemsArray: [...labelToModel.keys()],
         prompt: `Select a ${role} ${provider} model`,
+        details: detailsCallback,
+        detailsUseTags: true,
     });
     const picked = labelToModel.get(selectedLabel);
     if (!picked) {
         throw new Error(`Model selection '${selectedLabel}' could not be resolved.`);
     }
 
+    // Resolve capabilities for the selected model. Preference order:
+    //   1. Provider-native capabilities from the live `/v1/models` response
+    //      (e.g. crof reports `reasoning_effort: true` per model). This is
+    //      most accurate for custom-named models models.dev doesn't track.
+    //   2. models.dev lookup for the canonical id.
+    //   3. undefined — the legacy fallback at the bottom of this fn runs.
+    const capabilities: ModelCapabilities | undefined =
+        picked.capabilities ?? devModels.get(picked.id)?.capabilities;
+    // Optional settings driven by `ModelCapabilities.supportedParams` (Phase
+    // 3). The picker iterates the descriptor map and dispatches the right UI
+    // for each param `type`. Values are stored both in `dynamicParams` and,
+    // for legacy fields the rest of the codebase still reads directly
+    // (`reasoningEffort` / `temperature`), in dedicated typed slots.
+    let reasoningEffort: 'low' | 'medium' | 'high' | undefined;
+    let temperature: number | undefined;
+    const dynamicParams: Record<string, unknown> = {};
+
+    const supportedParams = capabilities?.supportedParams;
+    // Provider allowlist: only DeepInfra and crof reliably accept the OpenAI
+    // enum form (`reasoning_effort: 'low'|'medium'|'high'`). Every other BYOK
+    // proxy gets the boolean form (`reasoning_effort: true`) which they either
+    // accept directly or translate into the upstream vendor's thinking control.
+    // The picker UX follows: literal mode shows enum, boolean mode shows yes/no.
+    const literalReasoningEffortProviders: ReadonlySet<string> = new Set(['deepinfra', 'copf']);
+    const reasoningEffortMode: 'literal' | 'boolean' =
+        literalReasoningEffortProviders.has(provider) ? 'literal' : 'boolean';
+    const effectiveSupportedParams: Record<string, ParamDescriptor> | undefined = supportedParams
+        ? Object.fromEntries(
+            Object.entries(supportedParams).map(([key, desc]) => {
+                if (key !== 'reasoning_effort') return [key, desc];
+
+                return [key, { ...desc, sendAs: desc.sendAs ?? reasoningEffortMode }];
+            }),
+        )
+        : undefined;
+
+    if (effectiveSupportedParams && Object.keys(effectiveSupportedParams).length > 0) {
+        for (const [key, desc] of Object.entries(effectiveSupportedParams)) {
+            if (desc.canSend === false) continue;
+            const value = await renderDynamicParamPicker(key, desc);
+            if (value === undefined) continue;
+            dynamicParams[key] = value;
+            if (key === 'reasoning_effort' && typeof value === 'string') {
+                reasoningEffort = value as 'low' | 'medium' | 'high';
+            } else if (key === 'temperature') {
+                temperature = value as number;
+            }
+        }
+    } else {
+        // Legacy fallback when models.dev capabilities (and thus
+        // `supportedParams`) are unavailable. Mirrors values into
+        // `dynamicParams` for parity with the descriptor-driven path.
+        if (capabilities?.reasoning) {
+            if (reasoningEffortMode === 'literal') {
+                reasoningEffort = await pickByokReasoningEffort();
+                if (reasoningEffort != null) {
+                    dynamicParams['reasoning_effort'] = reasoningEffort;
+                }
+            } else {
+                const enable = await ui.searchSelectAndReturnFromArray({
+                    itemsArray: ['default', 'enable'],
+                    prompt: 'Reasoning effort: enable thinking? (Esc / default = off)',
+                }).catch(() => undefined);
+                if (enable === 'enable') {
+                    dynamicParams['reasoning_effort'] = true;
+                }
+            }
+        }
+        if (capabilities?.temperature !== false) {
+            temperature = await pickByokTemperature();
+            if (temperature != null) {
+                dynamicParams['temperature'] = temperature;
+            }
+        }
+    }
+
     const client = new OpenAICompatibleClient({
         baseURL: getProviderBaseURL(provider),
         apiKey: getProviderApiKey(provider),
+        provider,
     });
 
     return {
@@ -78,7 +222,121 @@ async function pickByokRuntime(role: AgentRole): Promise<AgentRuntimePick> {
         client,
         model: picked.id,
         ...(picked.contextWindow > 0 ? { contextWindow: picked.contextWindow } : {}),
+        ...(capabilities ? { capabilities } : {}),
+        ...(reasoningEffort ? { reasoningEffort } : {}),
+        ...(temperature != null ? { temperature } : {}),
+        ...(Object.keys(dynamicParams).length > 0 ? { dynamicParams } : {}),
     };
+}
+
+/**
+ * Generic descriptor-driven picker used by `pickByokRuntime`. Dispatches the
+ * right UI control based on `desc.type` and returns either a typed value or
+ * `undefined` (Esc / skip / 'default'). Values are returned in their native
+ * shape so they can be passed straight into the OpenAI Chat Completions
+ * request body.
+ */
+async function renderDynamicParamPicker(
+    key: string,
+    desc: ParamDescriptor,
+): Promise<unknown | undefined> {
+    const labelWithDefault = desc.defaultValue != null
+        ? `${desc.label} (default: ${String(desc.defaultValue)})`
+        : desc.label;
+    const prompt = `Select ${labelWithDefault} — Esc for default`;
+
+    if (key === 'reasoning_effort' && desc.sendAs !== 'literal') {
+        // Boolean wire shape — most BYOK proxies (opencode, openrouter, oxlo, …)
+        // accept `reasoning_effort: true` and translate to the upstream
+        // vendor's thinking control. Don't mislead the user with low/med/high
+        // since the value is coerced to true at request build time anyway.
+        const selected = await ui.searchSelectAndReturnFromArray({
+            itemsArray: ['default', 'enable'],
+            prompt: `${desc.label}: enable thinking? (Esc / default = off)`,
+        }).catch(() => undefined);
+        if (!selected || selected === 'default') return undefined;
+
+        return true;
+    }
+
+    if (desc.type === 'enum') {
+        const items = [...(desc.enumValues ?? [])];
+        if (items.length === 0) return undefined;
+        const selected = await ui.searchSelectAndReturnFromArray({
+            itemsArray: items,
+            prompt,
+        }).catch(() => undefined);
+
+        return selected ?? undefined;
+    }
+
+    if (desc.type === 'number') {
+        const items = ['default', ...buildNumberSteps(desc)];
+        const selected = await ui.searchSelectAndReturnFromArray({
+            itemsArray: items,
+            prompt,
+        }).catch(() => undefined);
+        if (!selected || selected === 'default') return undefined;
+        const parsed = parseFloat(selected);
+
+        return Number.isFinite(parsed) ? parsed : undefined;
+    }
+
+    if (desc.type === 'boolean') {
+        const selected = await ui.searchSelectAndReturnFromArray({
+            itemsArray: ['default', 'true', 'false'],
+            prompt,
+        }).catch(() => undefined);
+        if (!selected || selected === 'default') return undefined;
+
+        return selected === 'true';
+    }
+
+    // type === 'string' or future extension — not currently used by any
+    // descriptor, but keep a safe fallback so adding one later doesn't crash.
+    void key;
+
+    return undefined;
+}
+
+/**
+ * Build a discrete value list for a numeric descriptor (default 21 steps
+ * across the [min, max] range, snapped to `step` precision).
+ */
+function buildNumberSteps(desc: ParamDescriptor): string[] {
+    if (desc.min == null || desc.max == null) return [];
+    const step = desc.step ?? (desc.max - desc.min) / 20;
+    if (step <= 0) return [];
+    const out: string[] = [];
+    const decimals = step < 1 ? Math.max(0, -Math.floor(Math.log10(step))) : 0;
+    for (let v = desc.min; v <= desc.max + 1e-9; v += step) {
+        out.push(v.toFixed(decimals));
+    }
+
+    return out;
+}
+
+async function pickByokReasoningEffort(): Promise<'low' | 'medium' | 'high' | undefined> {
+    const itemsArray = ['low', 'medium', 'high'];
+    const selected = await ui.searchSelectAndReturnFromArray({
+        itemsArray,
+        prompt: 'Select reasoning effort level (or Esc to skip)',
+    }).catch(() => undefined);
+
+    if (!selected) return undefined;
+
+    return selected as 'low' | 'medium' | 'high';
+}
+
+async function pickByokTemperature(): Promise<number | undefined> {
+    const selected = await ui.searchSelectAndReturnFromArray({
+        itemsArray: ['default', '0', '0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1.0', '1.5', '2.0'],
+        prompt: 'Select temperature (or Esc for default)',
+    }).catch(() => undefined);
+
+    if (!selected || selected === 'default') return undefined;
+
+    return parseFloat(selected);
 }
 
 async function pickCopilotReasoningEffort(model: CopilotModelInfo): Promise<ReasoningEffort | undefined> {

--- a/src/AI/AIAgent/providers/byok/byokClient.ts
+++ b/src/AI/AIAgent/providers/byok/byokClient.ts
@@ -11,16 +11,20 @@ import { OpenAICompatibleSession } from '@/AI/AIAgent/providers/byok/byokSession
 export interface OpenAICompatibleClientOptions {
     baseURL: string;
     apiKey: string;
+    /** Provider key (e.g. 'openrouter', 'deepseek') used to scope persisted overrides. */
+    provider?: string;
 }
 
 export class OpenAICompatibleClient implements AgentClient {
     private readonly baseURL: string;
     private readonly apiKey: string;
+    private readonly provider: string | undefined;
     private sessions: OpenAICompatibleSession[] = [];
 
     public constructor(options: OpenAICompatibleClientOptions) {
         this.baseURL = options.baseURL;
         this.apiKey = options.apiKey;
+        this.provider = options.provider;
     }
 
     public createSession: AgentClient['createSession'] = async (
@@ -30,6 +34,7 @@ export class OpenAICompatibleClient implements AgentClient {
             sessionOptions: options,
             baseURL: this.baseURL,
             apiKey: this.apiKey,
+            ...(this.provider ? { provider: this.provider } : {}),
         });
 
         await session.init();

--- a/src/AI/AIAgent/providers/byok/byokOverrides.ts
+++ b/src/AI/AIAgent/providers/byok/byokOverrides.ts
@@ -1,0 +1,98 @@
+/**
+ * Persisted (provider, model) overrides for BYOK quirks we discover at runtime.
+ *
+ * Stored under `${KRA_HOME}/byok-overrides/<provider>.json`. Today we cache:
+ *  - `strippedParams`: OpenAI param keys the provider rejected with HTTP 400,
+ *    seeded into the next session so we skip the round-trip.
+ *  - `streamingMode`: `'non-streaming'` when we've detected the provider
+ *    silently buffers its upstream response into one SSE frame.
+ *  - `inlineReasoningTags`: `true` when the model writes its chain-of-thought
+ *    inline as `<think>…</think>` inside `delta.content` instead of using the
+ *    structured `reasoning_content` / `reasoning_details` fields.
+ *
+ * Reads are sync (fast, called once in the session constructor); writes are
+ * async, debounced via a per-file promise chain, and best-effort (failures
+ * are swallowed because losing one cache update is non-fatal).
+ */
+
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import path from 'path';
+import { kraHome } from '@/filePaths';
+
+export interface ModelOverrides {
+    strippedParams?: string[];
+    streamingMode?: 'streaming' | 'non-streaming';
+    inlineReasoningTags?: boolean;
+    updatedAt?: string;
+}
+
+function overridesDir(): string {
+    return path.join(kraHome(), 'byok-overrides');
+}
+
+function slug(value: string): string {
+    return value.replace(/[^a-zA-Z0-9._-]+/g, '_');
+}
+
+function overridesPath(provider: string): string {
+    return path.join(overridesDir(), `${slug(provider)}.json`);
+}
+
+export function loadOverridesSync(provider: string | undefined): Record<string, ModelOverrides> {
+    if (!provider) return {};
+    try {
+        const raw = fs.readFileSync(overridesPath(provider), 'utf8');
+        const parsed = JSON.parse(raw) as unknown;
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed as Record<string, ModelOverrides>;
+        }
+    } catch {
+        // No cache yet, malformed JSON, or unreadable file — treat as empty.
+    }
+    return {};
+}
+
+export function getModelOverride(provider: string | undefined, model: string): ModelOverrides {
+    const map = loadOverridesSync(provider);
+    return map[model] ?? {};
+}
+
+const writeQueue = new Map<string, Promise<void>>();
+
+export async function recordOverride(
+    provider: string | undefined,
+    model: string,
+    patch: Partial<ModelOverrides>,
+): Promise<void> {
+    if (!provider) return;
+
+    const file = overridesPath(provider);
+    const prior = writeQueue.get(file) ?? Promise.resolve();
+    const next = prior.then(async () => {
+        const current = loadOverridesSync(provider);
+        const existing = current[model] ?? {};
+        const merged: ModelOverrides = {
+            ...existing,
+            ...patch,
+            updatedAt: new Date().toISOString(),
+        };
+
+        if (patch.strippedParams) {
+            const union = new Set<string>([
+                ...(existing.strippedParams ?? []),
+                ...patch.strippedParams,
+            ]);
+            merged.strippedParams = [...union];
+        }
+
+        current[model] = merged;
+        await fsp.mkdir(overridesDir(), { recursive: true });
+        await fsp.writeFile(file, JSON.stringify(current, null, 2), 'utf8');
+    }).catch(() => {
+        // Non-critical — losing one cache update doesn't break the session.
+    });
+
+    writeQueue.set(file, next);
+    return next;
+}

--- a/src/AI/AIAgent/providers/byok/byokSession.ts
+++ b/src/AI/AIAgent/providers/byok/byokSession.ts
@@ -21,6 +21,7 @@
 
 import OpenAI from 'openai';
 import type {
+    ChatCompletion,
     ChatCompletionChunk,
     ChatCompletionMessageParam,
     ChatCompletionMessageToolCall,
@@ -34,23 +35,25 @@ import {
     type AgentSessionOptions,
     type LocalTool,
 } from '@/AI/AIAgent/shared/types/agentTypes';
-import { TURN_REMINDER } from '@/AI/AIAgent/shared/main/turnReminder';
 import { buildMcpClientPool, type McpClientPool } from '@/AI/AIAgent/providers/byok/mcpClientPool';
 import { createExecutableToolBridge, disconnectPool } from '@/AI/AIAgent/mcp/executableToolBridge';
 import { compactMessages, estimateTokens, isContextLengthError } from '@/AI/AIAgent/providers/byok/byokCompactor';
 import { getFileContextsTaggedBlock } from '@/AI/shared/conversation';
+import { getModelOverride, recordOverride } from '@/AI/AIAgent/providers/byok/byokOverrides';
 
 const DEFAULT_SYSTEM_PROMPT = [
-    'You are an autonomous coding agent operating inside a proposal workspace.',
+    'You are a coding agent.',
     'You may freely read, edit, and create files; the user reviews the resulting',
     'git diff at the end. Use the available tools — do not just describe what you',
-    'would do. Always finish by calling confirm_task_complete.',
+    'would do.',
 ].join(' ');
 
 export interface OpenAICompatibleSessionOptions {
     sessionOptions: AgentSessionOptions;
     baseURL: string;
     apiKey: string;
+    /** Provider key (e.g. 'openrouter', 'deepseek') used to scope persisted overrides. */
+    provider?: string;
 }
 
 interface InternalToolCall {
@@ -59,9 +62,343 @@ interface InternalToolCall {
     args: string;
 }
 
+// ─── Text-based tool call extraction ─────────────────────────────────────────
+//
+// Some providers emit tool calls as special tokens in the content field instead
+// of structured `tool_calls` deltas.  We detect these patterns and convert them
+// into proper InternalToolCall objects.
+//
+// Pattern: <|tool_call_begin|>call_id<|tool_call_argument_begin|>{json}<|tool_call_end|>
+// May be wrapped in <|tool_calls_section_begin|>...<|tool_calls_section_end|>
+
+const TOOL_CALL_BEGIN = /<\|tool_call_begin\|>/g;
+const TOOL_CALL_ARGUMENT_BEGIN = '<|tool_call_argument_begin|>';
+const TOOL_CALL_END = '<|tool_call_end|>';
+
+/**
+ * Extract the function name from a Kimi-style tool call ID.
+ * IDs follow the format `functions.tool_name:idx` (e.g. `functions.kra-file-context:search:0`).
+ * The tool name itself may contain colons (namespaced MCP tools).
+ */
+function extractNameFromCallId(callId: string): string | undefined {
+    // Match `functions.{anything}:{digits}` — the tool name is everything
+    // between "functions." and the last ":{digits}".
+    const match = callId.match(/^functions\.(.+):(\d+)$/);
+    if (match) return match[1];
+
+    return undefined;
+}
+
+/**
+ * Resolve a tool name extracted from model output to the registered name.
+ *
+ * Models may output tool names in different formats:
+ *   - `kra-file-context:search`  (colon-separated, as seen in system prompts)
+ *   - `kra_file_context__search`  (double-underscore, the actual registered name)
+ *
+ * This function tries an exact match first, then falls back to normalising
+ * hyphens to underscores and colons to double underscores.
+ */
+function resolveToolName(name: string, knownTools: ChatCompletionTool[]): string | undefined {
+    // Exact match
+    if (knownTools.some((t) => t.function.name === name)) return name;
+
+    // Normalise: replace hyphens with underscores, colons with double underscores
+    const normalised = name.replace(/-/g, '_').replace(/:/g, '__');
+    if (knownTools.some((t) => t.function.name === normalised)) return normalised;
+
+    return undefined;
+}
+
+/**
+ * Extract tool calls from special-token patterns in the assistant content.
+ * Handles both raw tokens and HTML-encoded variants (&lt;|…|&gt;).
+ */
+function extractTextToolCalls(rawText: string): InternalToolCall[] {
+    // Normalise HTML-encoded tokens
+    const text = rawText
+        .replace(/&lt;\|/g, '<|')
+        .replace(/\|&gt;/g, '|>');
+    const calls: InternalToolCall[] = [];
+    TOOL_CALL_BEGIN.lastIndex = 0;
+
+    let match: RegExpExecArray | null;
+    while ((match = TOOL_CALL_BEGIN.exec(text)) !== null) {
+        const startIdx = match.index + match[0].length;
+
+        const argBeginIdx = text.indexOf(TOOL_CALL_ARGUMENT_BEGIN, startIdx);
+        if (argBeginIdx === -1) break;
+
+        const callId = text.slice(startIdx, argBeginIdx).trim();
+
+        const endIdx = text.indexOf(TOOL_CALL_END, argBeginIdx);
+        if (endIdx === -1) break;
+
+        const argsStr = text.slice(
+            argBeginIdx + TOOL_CALL_ARGUMENT_BEGIN.length,
+            endIdx
+        ).trim();
+
+        let name = '';
+        let args = '';
+        try {
+            const parsed = JSON.parse(argsStr);
+            if (typeof parsed === 'object' && parsed !== null) {
+                if (typeof parsed.name === 'string') {
+                    name = parsed.name;
+                    args = typeof parsed.arguments === 'string'
+                        ? parsed.arguments
+                        : JSON.stringify(parsed.arguments ?? {});
+                } else {
+                    args = JSON.stringify(parsed);
+                }
+            }
+        } catch {
+            args = argsStr;
+        }
+
+        // Fallback: extract name from the call ID (e.g. functions.kra-file-context:search:0)
+        if (!name) {
+            name = extractNameFromCallId(callId) ?? '';
+        }
+
+        if (name || args) {
+            calls.push({
+                id: callId || `call_${Date.now()}_${calls.length}`,
+                name: name || '(unknown)',
+                args: args || '{}',
+            });
+        }
+    }
+
+    return calls;
+}
+
+/**
+ * Strip special-token tool call patterns from the assistant content.
+ * Also strips section wrappers and handles HTML-encoded variants.
+ */
+function stripTextToolCalls(rawText: string): string {
+    let text = rawText
+        .replace(/&lt;\|/g, '<|')
+        .replace(/\|&gt;/g, '|>');
+    // Remove section wrappers first
+    text = text.replace(/<\|tool_calls_section_begin\|>[\s\S]*?<\|tool_calls_section_end\|>/g, '');
+    // Remove individual tool call blocks
+    text = text.replace(/<\|tool_call_begin\|>[\s\S]*?<\|tool_call_end\|>/g, '');
+    text = text.replace(/\n{3,}/g, '\n\n').trim();
+
+    return text;
+}
+
+/**
+ * When a provider claims to support tools but the model writes tool calls as
+ * plain text (no special tokens, no structured deltas), we try to match known
+ * tool names followed by JSON arguments in the content.
+ *
+ * Pattern: tool_name{"key": "value"} or tool_name\n{...}
+ * The tool name must exactly match one of the provided tool definitions.
+ */
+function extractPlainTextToolCalls(
+    text: string,
+    knownTools: ChatCompletionTool[],
+): InternalToolCall[] {
+    if (knownTools.length === 0) return [];
+
+    const calls: InternalToolCall[] = [];
+    // Build a regex that matches any known tool name followed by JSON-like args
+    const toolNames = knownTools.map((t) => t.function.name);
+    // Escape special regex chars in tool names (e.g. dots, colons)
+    const escapedNames = toolNames.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const pattern = new RegExp(
+        `(?<=^|\\s|\\n)(${escapedNames.join('|')})\\s*(\\{[\\s\\S]*?\\})`,
+        'g'
+    );
+
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+        const name = match[1];
+        const argsStr = match[2];
+
+        // Validate that argsStr is valid JSON
+        let args = '{}';
+        try {
+            const parsed = JSON.parse(argsStr);
+            args = typeof parsed === 'object' && parsed !== null
+                ? JSON.stringify(parsed)
+                : argsStr;
+        } catch {
+            // Not valid JSON — skip this match
+            continue;
+        }
+
+        calls.push({
+            id: `call_${Date.now()}_${calls.length}`,
+            name,
+            args,
+        });
+    }
+
+    return calls;
+}
+
+/**
+ * Strip plain-text tool calls from the assistant content so they don't appear
+ * as regular text in the chat.
+ */
+function stripPlainTextToolCalls(
+    text: string,
+    knownTools: ChatCompletionTool[],
+): string {
+    if (knownTools.length === 0) return text;
+    const toolNames = knownTools.map((t) => t.function.name);
+    const escapedNames = toolNames.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const pattern = new RegExp(
+        `(?<=^|\\s|\\n)(${escapedNames.join('|')})\\s*(\\{[\\s\\S]*?\\})`,
+        'g'
+    );
+    let result = text.replace(pattern, '');
+    result = result.replace(/\n{3,}/g, '\n\n').trim();
+
+    return result;
+}
+
 type EventListener<K extends keyof AgentSessionEventMap> = (
     e: AgentSessionEventMap[K]
 ) => void;
+
+// ─── Optional-parameter registry ─────────────────────────────────────────────
+//
+// Different OpenAI-compatible providers accept different subsets of optional
+// chat-completion parameters.  Rather than hardcode three booleans + brittle
+// keyword matching on 400 error messages, we describe each managed param as a
+// `ParamSpec` in priority order (least-critical first).  When the provider
+// rejects the request with 400, we strip the lowest-priority active param and
+// retry — without trying to parse the error message at all.
+//
+// Phase 2 added the `dynamicParams` slot on AgentSessionOptions; Phase 3
+// will generate descriptors from `ModelCapabilities.supportedParams`.
+
+const MAX_STRIP_ITERATIONS = 16;
+
+interface ParamContext {
+    opts: AgentSessionOptions;
+    openaiTools: ChatCompletionTool[];
+    messages: ChatCompletionMessageParam[];
+    stripped: ReadonlySet<string>;
+}
+
+interface ParamSpec {
+    /** OpenAI API request body key. */
+    key: string;
+    /** Pull the value from session options / runtime context. */
+    extract: (ctx: ParamContext) => unknown;
+    /** Whether this param should currently be sent. */
+    isActive: (ctx: ParamContext) => boolean;
+    /** Other keys to strip together with this one (e.g. `tool_choice` with `tools`). */
+    companions?: readonly string[];
+    /** Returns a reason string to refuse auto-stripping; `undefined` to allow. */
+    refuseStripReason?: (ctx: ParamContext) => string | undefined;
+}
+
+function hasAssistantToolCallsInHistory(messages: ChatCompletionMessageParam[]): boolean {
+    return messages.some((m) => {
+        if (m.role !== 'assistant') return false;
+        const calls = (m as { tool_calls?: unknown[] }).tool_calls;
+
+        return Array.isArray(calls) && calls.length > 0;
+    });
+}
+
+const OPTIONAL_PARAMS: readonly ParamSpec[] = [
+    {
+        key: 'reasoning_effort',
+        extract: (ctx) =>
+            ctx.opts.dynamicParams?.['reasoning_effort']
+            ?? ctx.opts.reasoningEffort,
+        isActive: (ctx) =>
+            !ctx.stripped.has('reasoning_effort')
+            && (ctx.opts.dynamicParams?.['reasoning_effort'] != null
+                || ctx.opts.reasoningEffort != null),
+    },
+    {
+        key: 'temperature',
+        extract: (ctx) =>
+            ctx.opts.dynamicParams?.['temperature']
+            ?? ctx.opts.temperature,
+        isActive: (ctx) =>
+            !ctx.stripped.has('temperature')
+            && ctx.opts.modelCapabilities?.temperature !== false
+            && (ctx.opts.dynamicParams?.['temperature'] != null
+                || ctx.opts.temperature != null),
+    },
+    {
+        // Decoupled from `tools` so providers that accept the schema but reject
+        // `tool_choice: 'auto'` can recover without losing tool calling.
+        key: 'tool_choice',
+        extract: () => 'auto' as const,
+        isActive: (ctx) =>
+            !ctx.stripped.has('tool_choice')
+            && !ctx.stripped.has('tools')
+            && ctx.openaiTools.length > 0,
+    },
+    {
+        key: 'tools',
+        extract: (ctx) => ctx.openaiTools,
+        isActive: (ctx) =>
+            !ctx.stripped.has('tools')
+            && ctx.openaiTools.length > 0,
+        companions: ['tool_choice'],
+        refuseStripReason: (ctx) =>
+            hasAssistantToolCallsInHistory(ctx.messages)
+                ? 'tools have already been used this turn — auto-stripping mid-conversation would invalidate prior tool_call messages; switch to a model that supports tools'
+                : undefined,
+    },
+];
+
+/**
+ * Convert a non-streaming `ChatCompletion` response into a single-chunk async
+ * iterable shaped like `Stream<ChatCompletionChunk>`. Used when the cached
+ * provider override says streaming is buffered, so we save the SSE round-trip
+ * while keeping the rest of `streamOnePass` (delta accumulation, tool-call
+ * extraction, sniffer) untouched.
+ */
+function synthesizeStreamFromCompletion(completion: ChatCompletion): Stream<ChatCompletionChunk> {
+    const choice = completion.choices[0];
+    const msg = choice.message;
+    const chunk: ChatCompletionChunk = {
+        id: completion.id,
+        object: 'chat.completion.chunk',
+        created: completion.created,
+        model: completion.model,
+        choices: [
+            {
+                index: 0,
+                delta: {
+                    role: 'assistant',
+                    content: typeof msg.content === 'string' ? msg.content : null,
+                    ...(msg.tool_calls
+                        ? {
+                            tool_calls: msg.tool_calls.map((tc, i) => ({
+                                index: i,
+                                id: tc.id,
+                                type: 'function' as const,
+                                function: { name: tc.function.name, arguments: tc.function.arguments },
+                            })),
+                        }
+                        : {}),
+                },
+                finish_reason: choice.finish_reason ?? 'stop',
+            },
+        ],
+    };
+
+    async function* gen(): AsyncGenerator<ChatCompletionChunk> {
+        yield chunk;
+    }
+
+    return gen() as unknown as Stream<ChatCompletionChunk>;
+}
 
 export class OpenAICompatibleSession implements AgentSession {
     private readonly openai: OpenAI;
@@ -72,12 +409,36 @@ export class OpenAICompatibleSession implements AgentSession {
     private listeners: { [K in keyof AgentSessionEventMap]?: EventListener<K>[] } = {};
     private abortController: AbortController | undefined;
     private compactedThisTurn = false;
+    /** OpenAI param keys we have been forced to drop after a 400 retry. */
+    private strippedParams = new Set<string>();
+    /** Hard cap on how many strip-and-retry iterations we'll perform per turn. */
+    private stripIterations = 0;
     private readonly executableToolBridge = createExecutableToolBridge(() => this.mcp);
     private localTools: Map<string, LocalTool> = new Map();
+    /** Provider key used to scope persisted overrides; undefined disables persistence. */
+    private readonly provider: string | undefined;
+    /** True when this model writes reasoning inline as <think>…</think> in delta.content. */
+    private inlineReasoningTags = false;
+    /** Sniffer state: are we currently inside a <think>…</think> block? */
+    private insideThinkBlock = false;
+    /** Sniffer state: leftover text that may be the start of a tag spanning chunks. */
+    private inlineThinkBuffer = '';
+    /** Cached `streamingMode` override from disk (`'non-streaming'` => provider buffers SSE). */
+    private readonly cachedStreamingMode: 'streaming' | 'non-streaming' | undefined;
 
     public constructor(opts: OpenAICompatibleSessionOptions) {
         this.opts = opts.sessionOptions;
         this.openai = new OpenAI({ apiKey: opts.apiKey, baseURL: opts.baseURL });
+        this.provider = opts.provider;
+
+        const override = getModelOverride(this.provider, this.opts.model);
+        for (const key of override.strippedParams ?? []) {
+            this.strippedParams.add(key);
+        }
+        if (override.inlineReasoningTags) {
+            this.inlineReasoningTags = true;
+        }
+        this.cachedStreamingMode = override.streamingMode;
     }
 
     public on: AgentSession['on'] = (event, handler) => {
@@ -191,14 +552,131 @@ export class OpenAICompatibleSession implements AgentSession {
         });
     }
 
+    private buildParamContext(): ParamContext {
+        return {
+            opts: this.opts,
+            openaiTools: this.openaiTools,
+            messages: this.messages,
+            stripped: this.strippedParams,
+        };
+    }
+
+    /**
+     * Produce the full ordered ParamSpec list for this session: static
+     * `OPTIONAL_PARAMS` (highest strip-priority last, like `tools`) plus an
+     * auto-generated spec for each `dynamicParams` key not already covered
+     * by a static spec. Auto-generated specs are placed first so they get
+     * stripped before any well-known param the user explicitly cares about.
+     */
+    private effectiveParamSpecs(): readonly ParamSpec[] {
+        const dyn = this.opts.dynamicParams;
+        if (!dyn) return OPTIONAL_PARAMS;
+        const knownKeys = new Set(OPTIONAL_PARAMS.map((s) => s.key));
+        const extras: ParamSpec[] = [];
+        for (const key of Object.keys(dyn)) {
+            if (knownKeys.has(key)) continue;
+            if (dyn[key] == null) continue;
+            extras.push({
+                key,
+                extract: (ctx) => ctx.opts.dynamicParams?.[key],
+                isActive: (ctx) =>
+                    !ctx.stripped.has(key)
+                    && ctx.opts.dynamicParams?.[key] != null,
+            });
+        }
+        if (extras.length === 0) return OPTIONAL_PARAMS;
+
+        return [...extras, ...OPTIONAL_PARAMS];
+    }
+
+    /**
+     * Inline-reasoning sniffer. Some models (open-source distillations, certain
+     * proxies) emit chain-of-thought as `<think>…</think>` tags inside
+     * `delta.content` instead of using the structured `reasoning_content` /
+     * `reasoning_details` fields. This helper splits each chunk into reasoning
+     * vs. message portions, emits the appropriate events, and returns the
+     * message-only text so the caller can append it to `assistantText`.
+     *
+     * The state machine handles tags that span chunk boundaries by holding the
+     * suspicious tail in `inlineThinkBuffer` until the next call.
+     */
+    private emitContentWithSniffer(text: string): string {
+        const buf = this.inlineThinkBuffer + text;
+        this.inlineThinkBuffer = '';
+
+        let messageOut = '';
+        let i = 0;
+        while (i < buf.length) {
+            if (this.insideThinkBlock) {
+                const closeIdx = buf.indexOf('</think>', i);
+                if (closeIdx === -1) {
+                    // Possible partial '</think' at the tail — keep up to 7 chars buffered.
+                    const keep = Math.min(7, buf.length - i);
+                    const safeEnd = buf.length - keep;
+                    if (safeEnd > i) {
+                        const reasoning = buf.slice(i, safeEnd);
+                        if (reasoning.length > 0) {
+                            this.emit('assistant.reasoning_delta', { data: { deltaContent: reasoning } });
+                        }
+                    }
+                    this.inlineThinkBuffer = buf.slice(safeEnd);
+
+                    return messageOut;
+                }
+                if (closeIdx > i) {
+                    this.emit('assistant.reasoning_delta', { data: { deltaContent: buf.slice(i, closeIdx) } });
+                }
+                this.insideThinkBlock = false;
+                i = closeIdx + '</think>'.length;
+            } else {
+                const openIdx = buf.indexOf('<think>', i);
+                if (openIdx === -1) {
+                    // Possible partial '<think' at the tail — keep up to 6 chars buffered.
+                    const keep = Math.min(6, buf.length - i);
+                    const safeEnd = buf.length - keep;
+                    if (safeEnd > i) {
+                        messageOut += buf.slice(i, safeEnd);
+                    }
+                    this.inlineThinkBuffer = buf.slice(safeEnd);
+
+                    return messageOut;
+                }
+                if (openIdx > i) {
+                    messageOut += buf.slice(i, openIdx);
+                }
+                this.insideThinkBlock = true;
+                i = openIdx + '<think>'.length;
+                if (!this.inlineReasoningTags) {
+                    this.inlineReasoningTags = true;
+                    void recordOverride(this.provider, this.opts.model, { inlineReasoningTags: true });
+                }
+            }
+        }
+        if (messageOut.length > 0) {
+            this.emit('assistant.message_delta', { data: { deltaContent: messageOut } });
+        }
+
+        return messageOut;
+    }
+
     public send: AgentSession['send'] = async (options: AgentSendOptions) => {
         this.compactedThisTurn = false;
         this.abortController = new AbortController();
 
-        const taggedFiles = await getFileContextsTaggedBlock();
-        const userContent = taggedFiles
-            ? `${options.prompt}\n\n${taggedFiles}\n\n${TURN_REMINDER}`
-            : `${options.prompt}\n\n${TURN_REMINDER}`;
+        // Sub-agents (investigator / executor) receive their own system prompt and
+        // should not be polluted with the user's open-file context — that is an
+        // orchestrator-only concern.
+        const isSubAgent = this.opts.isSubAgent === true;
+        let userContent: string;
+
+        if (isSubAgent) {
+            userContent = options.prompt;
+        } else {
+            const taggedFiles = await getFileContextsTaggedBlock();
+            userContent = taggedFiles
+                ? `${options.prompt}\n\n${taggedFiles}`
+                : options.prompt;
+        }
 
         this.messages.push({
             role: 'user',
@@ -230,21 +708,55 @@ export class OpenAICompatibleSession implements AgentSession {
         }
     }
 
+    /**
+     * Extract tool calls that some models emit as text in the content field
+     * instead of structured `tool_calls` deltas.
+     *
+     * Supported patterns:
+     *   <|tool_call_begin|>call_id<|tool_call_argument_begin|>{json}<|tool_call_end|>
+     *   May be wrapped in <|tool_calls_section_begin|>...<|tool_calls_section_end|>  (Kimi K2)
+     */
     private async streamOnePass(): Promise<InternalToolCall[]> {
         await this.maybeProactiveCompact();
 
         let stream: Stream<ChatCompletionChunk>;
 
         try {
-            stream = await this.openai.chat.completions.create(
-                {
-                    model: this.opts.model,
-                    messages: this.messages,
-                    stream: true,
-                    ...(this.openaiTools.length > 0 ? { tools: this.openaiTools } : {}),
-                },
-                { signal: this.abortController?.signal }
-            );
+            const useNonStreaming = this.cachedStreamingMode === 'non-streaming';
+            const createParams: Record<string, unknown> = {
+                model: this.opts.model,
+                messages: this.messages,
+                stream: !useNonStreaming,
+            };
+
+            if (useNonStreaming && process.env.KRA_BYOK_DEBUG === '1') {
+                process.stderr.write(
+                    `[byok] cached streamingMode='non-streaming' for ${this.opts.model}: ` +
+                    `requesting stream:false and synthesizing one chunk.\n`
+                );
+            }
+
+
+            const paramCtx = this.buildParamContext();
+            const effectiveSpecs = this.effectiveParamSpecs();
+            for (const spec of effectiveSpecs) {
+                if (spec.isActive(paramCtx)) {
+                    createParams[spec.key] = spec.extract(paramCtx);
+                }
+            }
+
+            if (useNonStreaming) {
+                const completion = await this.openai.chat.completions.create(
+                    createParams as unknown as Parameters<typeof this.openai.chat.completions.create>[0],
+                    { signal: this.abortController?.signal }
+                ) as ChatCompletion;
+                stream = synthesizeStreamFromCompletion(completion);
+            } else {
+                stream = await this.openai.chat.completions.create(
+                    createParams as unknown as Parameters<typeof this.openai.chat.completions.create>[0],
+                    { signal: this.abortController?.signal }
+                ) as Stream<ChatCompletionChunk>;
+            }
         } catch (error) {
             if (!this.compactedThisTurn && isContextLengthError(error)) {
                 this.compactedThisTurn = true;
@@ -257,6 +769,68 @@ export class OpenAICompatibleSession implements AgentSession {
                 return this.streamOnePass();
             }
 
+            // Provide clearer error messages for common provider failures.
+            if (error instanceof Error) {
+                const status = (error as unknown as { status?: number }).status;
+                if (status === 502 || status === 503) {
+                    throw new Error(
+                        `Provider returned ${status} (service unavailable). ` +
+                        `The model may be overloaded or temporarily down. ` +
+                        `Original: ${error.message}`
+                    );
+                }
+                if (status === 400) {
+                    // Generalised retry: find the lowest-priority active optional
+                    // param, strip it (plus any companions), retry.  No error-
+                    // message parsing — purely registry-driven.
+                    if (this.stripIterations >= MAX_STRIP_ITERATIONS) {
+                        throw new Error(
+                            `Provider returned 400 (bad request) after ${this.stripIterations} ` +
+                            `param-stripping retries. Original: ${error.message}`
+                        );
+                    }
+
+                    const ctx = this.buildParamContext();
+                    const next = this.effectiveParamSpecs().find((spec) => spec.isActive(ctx));
+
+                    if (next) {
+                        const refusal = next.refuseStripReason?.(ctx);
+                        if (refusal) {
+                            throw new Error(
+                                `Provider returned 400, but auto-strip of '${next.key}' refused: ` +
+                                `${refusal}. Original: ${error.message}`
+                            );
+                        }
+
+                        this.strippedParams.add(next.key);
+                        for (const companion of next.companions ?? []) {
+                            this.strippedParams.add(companion);
+                        }
+                        this.stripIterations++;
+
+                        this.emit('session.param_stripped', {
+                            data: {
+                                param: next.key,
+                                companions: [...(next.companions ?? [])],
+                                reason: error.message,
+                            },
+                        });
+
+                        void recordOverride(this.provider, this.opts.model, {
+                            strippedParams: [next.key, ...(next.companions ?? [])],
+                        });
+
+
+                        return this.streamOnePass();
+                    }
+
+                    throw new Error(
+                        `Provider returned 400 (bad request). All non-essential parameters ` +
+                        `already stripped. Original: ${error.message}`
+                    );
+                }
+            }
+
             throw error;
         }
 
@@ -264,33 +838,131 @@ export class OpenAICompatibleSession implements AgentSession {
         let assistantText = '';
         const debug = process.env.KRA_BYOK_DEBUG === '1';
         let chunkCount = 0;
+        const streamStartedAt = Date.now();
+        let firstChunkAt: number | undefined;
+        let lastChunkAt: number | undefined;
+
+        // Some providers reuse the same index for multiple parallel tool calls,
+        // causing them to merge into one (e.g. "web_fetchweb_fetchweb_fetch").
+        // Track the next synthetic index to assign when we detect a collision.
+        let syntheticIndexCounter = 0;
+        const idToIndex = new Map<string, number>();
 
         for await (const chunk of stream) {
             chunkCount += 1;
-            const delta = chunk.choices[0].delta;
+            if (firstChunkAt === undefined) {
+                firstChunkAt = Date.now();
+            }
+            lastChunkAt = Date.now();
+
+
+            // Some OpenAI-compatible providers send chunks with empty choices
+            // (e.g. usage-only chunks). Guard against undefined choice / delta.
+            const choice = chunk.choices[0];
+            if (!choice) {
+                continue;
+            }
+            const delta = choice.delta;
+            if (!delta) {
+                continue;
+            }
 
             if (debug) {
                 process.stderr.write(
-                    `[byok] chunk #${chunkCount} content=${JSON.stringify(delta.content ?? null)} tool_calls=${delta.tool_calls?.length ?? 0} finish=${chunk.choices[0].finish_reason ?? ''}\n`
+                    `[byok] chunk #${chunkCount} content=${JSON.stringify(delta.content ?? null)} tool_calls=${delta.tool_calls?.length ?? 0} finish=${choice.finish_reason ?? ''}\n`
                 );
+                if (delta.tool_calls) {
+                    for (const tc of delta.tool_calls) {
+                        process.stderr.write(
+                            `[byok]   tc: index=${tc.index} id=${JSON.stringify(tc.id ?? null)} name=${JSON.stringify(tc.function?.name ?? null)} args_len=${tc.function?.arguments?.length ?? 0}\n`
+                        );
+                    }
+                }
             }
 
-            const reasoning =
-                (delta as unknown as { reasoning_content?: string }).reasoning_content ??
-                (delta as unknown as { reasoning?: string }).reasoning;
+            // Detect reasoning content based on the model's known interleaved field.
+            // DeepSeek models use `reasoning_content`, some Google models use
+            // `reasoning_details`, and others use the raw `reasoning` field.
+            // The capability data from models.dev tells us which field to watch.
+            const reasoningField = this.opts.modelCapabilities?.reasoningField;
+            let reasoning: string | undefined;
+            if (reasoningField === 'reasoning_content') {
+                reasoning = (delta as unknown as { reasoning_content?: string }).reasoning_content;
+            } else if (reasoningField === 'reasoning_details') {
+                // reasoning_details is a structured object; extract text from it
+                const details = (delta as unknown as { reasoning_details?: Array<{ type: string; text?: string }> }).reasoning_details;
+                if (details) {
+                    reasoning = details
+                        .filter((d) => d.type === 'reasoning' && typeof d.text === 'string')
+                        .map((d) => d.text!)
+                        .join('');
+                }
+            } else {
+                // Legacy fallback: try reasoning_content then reasoning
+                reasoning =
+                    (delta as unknown as { reasoning_content?: string }).reasoning_content ??
+                    (delta as unknown as { reasoning?: string }).reasoning;
+            }
 
             if (typeof reasoning === 'string' && reasoning.length > 0) {
                 this.emit('assistant.reasoning_delta', { data: { deltaContent: reasoning } });
             }
-
             if (typeof delta.content === 'string' && delta.content.length > 0) {
-                assistantText += delta.content;
-                this.emit('assistant.message_delta', { data: { deltaContent: delta.content } });
+                const useSniffer = !reasoningField
+                    && (this.inlineReasoningTags
+                        || this.insideThinkBlock
+                        || this.inlineThinkBuffer.length > 0
+                        || delta.content.includes('<think'));
+                if (useSniffer) {
+                    assistantText += this.emitContentWithSniffer(delta.content);
+                } else {
+                    assistantText += delta.content;
+                    this.emit('assistant.message_delta', { data: { deltaContent: delta.content } });
+                }
             }
+
 
             if (delta.tool_calls) {
                 for (const tc of delta.tool_calls) {
-                    const existing = accumulatedToolCalls.get(tc.index) ?? {
+                    // Determine the effective index for this tool call.
+                    // Well-behaved providers assign unique `index` values to each
+                    // parallel tool call (0, 1, 2, …). Some providers reuse
+                    // index 0 for all tool calls, causing them to merge into one
+                    // (e.g. name becomes "web_fetchweb_fetchweb_fetch").
+                    //
+                    // When a delta carries `tc.id` (the start of a new tool call),
+                    // we check if that id is already tracked. If not, and the
+                    // provider-given index is already occupied by a *different*
+                    // id, we assign a synthetic index to keep them separate.
+                    let effectiveIndex: number;
+
+                    if (tc.id) {
+                        // This is the start of a new tool call (or a duplicate id).
+                        const knownIndex = idToIndex.get(tc.id);
+                        if (knownIndex !== undefined) {
+                            // We've seen this id before — continue accumulating
+                            // into the same slot.
+                            effectiveIndex = knownIndex;
+                        } else {
+                            // New id. Check if the provider-given index is
+                            // already taken by a different tool call.
+                            const existing = accumulatedToolCalls.get(tc.index);
+                            if (existing?.id && existing.id !== tc.id) {
+                                // Index collision — assign a synthetic index.
+                                effectiveIndex = 1000 + syntheticIndexCounter++;
+                            } else {
+                                effectiveIndex = tc.index;
+                            }
+                            idToIndex.set(tc.id, effectiveIndex);
+                        }
+                    } else {
+                        // Continuation chunk (no id) — use the index mapping
+                        // we established when the id first appeared.
+                        const knownIndex = idToIndex.get(accumulatedToolCalls.get(tc.index)?.id ?? '');
+                        effectiveIndex = knownIndex ?? tc.index;
+                    }
+
+                    const existing = accumulatedToolCalls.get(effectiveIndex) ?? {
                         id: '',
                         name: '',
                         args: '',
@@ -298,7 +970,7 @@ export class OpenAICompatibleSession implements AgentSession {
                     if (tc.id) existing.id = tc.id;
                     if (tc.function?.name) existing.name += tc.function.name;
                     if (tc.function?.arguments) existing.args += tc.function.arguments;
-                    accumulatedToolCalls.set(tc.index, existing);
+                    accumulatedToolCalls.set(effectiveIndex, existing);
                 }
             }
         }
@@ -307,12 +979,55 @@ export class OpenAICompatibleSession implements AgentSession {
             process.stderr.write(
                 `[byok] stream done: chunks=${chunkCount} text_len=${assistantText.length} tool_calls=${accumulatedToolCalls.size}\n`
             );
+
+            for (const [idx, tc] of accumulatedToolCalls.entries()) {
+                process.stderr.write(
+                    `[byok]   tool_call[${idx}]: id=${JSON.stringify(tc.id)} name=${JSON.stringify(tc.name)} args_len=${tc.args.length}\n`
+                );
+            }
         }
 
 
         const toolCalls = Array.from(accumulatedToolCalls.values()).filter(
             (tc) => tc.id && tc.name
         );
+
+        // Some providers emit tool calls as special tokens in the content field
+        // instead of structured `tool_calls` deltas. Try to extract them.
+        if (toolCalls.length === 0 && assistantText.length > 0) {
+            const extracted = extractTextToolCalls(assistantText);
+            if (extracted.length > 0) {
+                if (debug) {
+                    process.stderr.write(
+                        `[byok] extracted ${extracted.length} text-based tool calls from content\n`
+                    );
+                }
+                // Resolve extracted names to registered tool names (e.g.
+                // `kra-file-context:search` → `kra_file_context__search`)
+                for (const tc of extracted) {
+                    const resolved = resolveToolName(tc.name, this.openaiTools);
+                    if (resolved) tc.name = resolved;
+                }
+                toolCalls.push(...extracted);
+                assistantText = stripTextToolCalls(assistantText);
+            }
+        }
+
+        // Fallback: when the provider strips <|…|> tokens entirely but the model
+        // still writes tool calls as plain text (e.g. `tool_name{"key": "val"}`).
+        // Match known tool names followed by JSON arguments.
+        if (toolCalls.length === 0 && assistantText.length > 0 && this.openaiTools.length > 0) {
+            const plainExtracted = extractPlainTextToolCalls(assistantText, this.openaiTools);
+            if (plainExtracted.length > 0) {
+                if (debug) {
+                    process.stderr.write(
+                        `[byok] extracted ${plainExtracted.length} plain-text tool calls from content\n`
+                    );
+                }
+                toolCalls.push(...plainExtracted);
+                assistantText = stripPlainTextToolCalls(assistantText, this.openaiTools);
+            }
+        }
 
         const assistantMessage: ChatCompletionMessageParam = {
             role: 'assistant',
@@ -327,6 +1042,32 @@ export class OpenAICompatibleSession implements AgentSession {
                 }
                 : {}),
         };
+
+        // Buffered-proxy detection: a long delay before the first chunk AND all
+        // chunks arriving within a small burst window means the upstream provider
+        // almost certainly buffered the full completion server-side and emitted it
+        // as a tight cluster of SSE frames (rather than streaming in real time).
+        // We persist the override + emit an event so a UI can warn and so future
+        // sessions can switch to the non-streaming code path immediately.
+        const ttfbMs = (firstChunkAt ?? Date.now()) - streamStartedAt;
+        const burstMs = (lastChunkAt ?? firstChunkAt ?? streamStartedAt) - (firstChunkAt ?? streamStartedAt);
+        const looksBuffered = ttfbMs >= 5000 && burstMs < 500;
+        if (looksBuffered && this.cachedStreamingMode !== 'non-streaming') {
+            this.emit('session.streaming_behavior_detected', {
+                data: {
+                    mode: 'non-streaming',
+                    ttfbMs,
+                    chunkCount,
+                    inlineReasoningTags: this.inlineReasoningTags,
+                },
+            });
+            void recordOverride(this.provider, this.opts.model, { streamingMode: 'non-streaming' });
+            process.stderr.write(
+                `[byok] detected buffered streaming for ${this.opts.model} ` +
+                `(ttfb=${ttfbMs}ms, burst=${burstMs}ms, chunks=${chunkCount}); ` +
+                `subsequent sessions will use non-streaming requests.\n`
+            );
+        }
 
         this.messages.push(assistantMessage);
 
@@ -403,7 +1144,25 @@ export class OpenAICompatibleSession implements AgentSession {
             return;
         }
 
-        const tool = this.mcp?.tools.get(call.name);
+        // Resolve tool name: exact match → colon→double-underscore → suffix match
+        // e.g. `kra-file-context:search` → `kra-file-context__search`
+        // e.g. `recall` → `kra-memory__recall`
+        let tool = this.mcp?.tools.get(call.name);
+        if (!tool && call.name) {
+            const colonNorm = call.name.replace(/:/g, '__');
+            tool = this.mcp?.tools.get(colonNorm);
+            if (tool) { call.name = colonNorm; }
+            else {
+                // Short name suffix match: `recall` → `kra-memory__recall`
+                for (const [key, entry] of this.mcp?.tools ?? []) {
+                    if (key.endsWith('__' + call.name)) {
+                        call.name = key;
+                        tool = entry;
+                        break;
+                    }
+                }
+            }
+        }
 
         if (!tool) {
             this.emitToolStart(call, '(unknown)', '(unknown tool)');

--- a/src/AI/AIAgent/shared/docs/coordinator.ts
+++ b/src/AI/AIAgent/shared/docs/coordinator.ts
@@ -87,7 +87,14 @@ async function writeStatusFile(): Promise<void> {
             sources: Array.from(statuses.values()),
         };
         await fs.promises.mkdir(kraDocsRoot, { recursive: true });
-        await fs.promises.writeFile(statusFilePath(), JSON.stringify(snapshot, null, 2));
+        // Atomic write: write to a temp file in the same dir, then rename.
+        // Without this, concurrent readers (dashboard / live progress UI) can
+        // catch the file mid-write and JSON.parse throws — making the UI
+        // briefly think there's no active crawl.
+        const finalPath = statusFilePath();
+        const tmpPath = `${finalPath}.${process.pid}.tmp`;
+        await fs.promises.writeFile(tmpPath, JSON.stringify(snapshot, null, 2));
+        await fs.promises.rename(tmpPath, finalPath);
     } catch (err) {
         console.error('docs-coordinator: failed to write status file', err);
     }

--- a/src/AI/AIAgent/shared/docs/liveProgressCli.ts
+++ b/src/AI/AIAgent/shared/docs/liveProgressCli.ts
@@ -1,0 +1,22 @@
+/**
+ * Standalone CLI entrypoint that runs the multi-pane live crawl progress
+ * screen. Spawned by the `kra memory` docs section via `runInherit` so the
+ * blessed screen owns the tty cleanly (two blessed screens cannot share the
+ * same tty inside a single process — attempting that freezes the terminal).
+ */
+
+import 'module-alias/register';
+
+import { showLiveProgress } from './liveProgressScreen';
+
+async function main(): Promise<void> {
+    try {
+        await showLiveProgress();
+    } catch (err) {
+        process.stderr.write(`live progress failed: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exit(1);
+    }
+    process.exit(0);
+}
+
+void main();

--- a/src/AI/AIAgent/shared/docs/liveProgressScreen.ts
+++ b/src/AI/AIAgent/shared/docs/liveProgressScreen.ts
@@ -24,12 +24,33 @@ export function statusFilePath(): string {
     return kraDocsStatusPath;
 }
 
+// Last successful read, cached per-process. Used to absorb sporadic read
+// failures (transient parse errors, race with file rotation) so the UI
+// doesn't flap between "active" and "no active crawl" every poll tick.
+let lastGoodSnapshot: { snap: DocsStatusFile; at: number } | null = null;
+const LAST_GOOD_TTL_MS = 5000;
+
 export async function readSnapshot(): Promise<DocsStatusFile | null> {
     const file = statusFilePath();
     try {
-        return JSON.parse(fs.readFileSync(file, 'utf8')) as DocsStatusFile;
+        const snap = JSON.parse(fs.readFileSync(file, 'utf8')) as DocsStatusFile;
+        lastGoodSnapshot = { snap, at: Date.now() };
+
+        return snap;
     } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+        const code = (err as NodeJS.ErrnoException).code;
+        // ENOENT means the coordinator has stopped and removed the file —
+        // that's a real "no crawl" signal, don't paper over it.
+        if (code === 'ENOENT') {
+            lastGoodSnapshot = null;
+
+            return null;
+        }
+        // Any other error (transient parse failure, EAGAIN, …) — fall back
+        // to the last good snapshot if it's still fresh, else null.
+        if (lastGoodSnapshot && Date.now() - lastGoodSnapshot.at < LAST_GOOD_TTL_MS) {
+            return lastGoodSnapshot.snap;
+        }
 
         return null;
     }
@@ -275,6 +296,8 @@ export async function showLiveProgress(): Promise<void> {
         },
     });
     attachFocusCycleKeys(screen, ring);
+    ring.focusAt(0);
+    ring.renderFooter();
 
     const tick = setInterval(() => { void refresh(); }, 500);
     screen.key(['q', 'escape', 'C-c'], () => {

--- a/src/AI/AIAgent/shared/main/agentConversation.ts
+++ b/src/AI/AIAgent/shared/main/agentConversation.ts
@@ -166,12 +166,15 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
         model: options.model,
         workingDirectory: cwd,
         mcpServers: mergedMcpServers,
-        excludedTools: ['str_replace_editor', 'write_file', 'read_file', 'edit', 'view', 'grep', 'glob', 'create', 'apply_patch', 'report_intent'],
+        excludedTools: ['str_replace_editor', 'write_file', 'read_file', 'edit', 'view', 'grep', 'glob', 'create', 'apply_patch', 'report_intent', ...(options.provider === 'byok' ? ['confirm_task_complete'] : [])],
         ...(orchestratorLocalTools.length > 0 ? { localTools: orchestratorLocalTools } : {}),
         ...(options.contextWindow !== undefined ? { contextWindow: options.contextWindow } : {}),
+        ...(options.modelCapabilities ? { modelCapabilities: options.modelCapabilities } : {}),
+        ...(options.reasoningEffort ? { reasoningEffort: options.reasoningEffort } : {}),
+        ...(options.temperature != null ? { temperature: options.temperature } : {}),
+        ...(options.dynamicParams ? { dynamicParams: options.dynamicParams } : {}),
         onPreToolUse: orchestratorOnPreToolUse,
         onPostToolUse: orchestratorOnPostToolUse,
-
         onUserInputRequest: async (request) => handleAgentUserInput(
             nvimClient,
             request.question as string,

--- a/src/AI/AIAgent/shared/main/agentPromptActions.ts
+++ b/src/AI/AIAgent/shared/main/agentPromptActions.ts
@@ -70,24 +70,24 @@ async function handleSubmit(state: AgentConversationState): Promise<void> {
 export async function setupEventHandlers(state: AgentConversationState): Promise<void> {
     state.nvim.on('notification', (method: string, args: unknown[]) => {
         void (async (): Promise<void> => {
-        if (method !== 'prompt_action') {
-            return;
-        }
-
-        const action = typeof args[0] === 'string' ? args[0] : '';
-
-        try {
-            if (action === 'submit_pressed') {
-                await handleSubmit(state);
-            } else {
-                await dispatchPromptAction(state, action, args);
+            if (method !== 'prompt_action') {
+                return;
             }
-        } catch (error) {
-            await updateAgentUi(state.nvim, 'show_error', [
-                `Action failed: ${action}`,
-                getErrorMessage(error),
-            ]);
-        }
+
+            const action = typeof args[0] === 'string' ? args[0] : '';
+
+            try {
+                if (action === 'submit_pressed') {
+                    await handleSubmit(state);
+                } else {
+                    await dispatchPromptAction(state, action, args);
+                }
+            } catch (error) {
+                await updateAgentUi(state.nvim, 'show_error', [
+                    `Action failed: ${action}`,
+                    getErrorMessage(error),
+                ]);
+            }
         })();
     });
 }

--- a/src/AI/AIAgent/shared/memory/registry.ts
+++ b/src/AI/AIAgent/shared/memory/registry.ts
@@ -113,15 +113,15 @@ export async function upsertRegistryEntry(
     patch: Partial<RegistryEntry> & { alias?: string; rootPath?: string },
 ): Promise<RegistryEntry> {
     const reg = await loadRegistry();
-    const existing = reg.repos[id];
+    const existing: RegistryEntry | undefined = reg.repos[id];
 
     const next: RegistryEntry = {
-        alias: patch.alias ?? existing.alias ?? id,
-        rootPath: patch.rootPath ?? existing.rootPath ?? '',
-        repoKey: patch.repoKey ?? existing.repoKey ?? computeRepoKey(id),
-        lastIndexedCommit: patch.lastIndexedCommit ?? existing.lastIndexedCommit ?? '',
-        lastIndexedAt: patch.lastIndexedAt ?? existing.lastIndexedAt ?? 0,
-        chunksCount: patch.chunksCount ?? existing.chunksCount ?? 0,
+        alias: patch.alias ?? existing?.alias ?? id,
+        rootPath: patch.rootPath ?? existing?.rootPath ?? '',
+        repoKey: patch.repoKey ?? existing?.repoKey ?? computeRepoKey(id),
+        lastIndexedCommit: patch.lastIndexedCommit ?? existing?.lastIndexedCommit ?? '',
+        lastIndexedAt: patch.lastIndexedAt ?? existing?.lastIndexedAt ?? 0,
+        chunksCount: patch.chunksCount ?? existing?.chunksCount ?? 0,
     };
 
     reg.repos[id] = next;

--- a/src/AI/AIAgent/shared/subAgents/session.ts
+++ b/src/AI/AIAgent/shared/subAgents/session.ts
@@ -176,8 +176,8 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
         allowedTools: [...opts.toolWhitelist, 'submit_result'],
         onPreToolUse,
         onPostToolUse,
+        isSubAgent: true,
     });
-
     // Always capture into the local event log for the caller's audit trail.
     session.on('assistant.message_delta', (e) => {
         emit({ kind: 'message', text: e.data.deltaContent });

--- a/src/AI/AIAgent/shared/types/agentTypes.ts
+++ b/src/AI/AIAgent/shared/types/agentTypes.ts
@@ -67,7 +67,40 @@ export type AgentSessionEventMap = {
     'tool.execution_complete': ToolExecutionCompleteEvent;
     'session.idle': void;
     'assistant.usage': AssistantUsageEvent;
+    'session.param_stripped': ParamStrippedEvent;
+    'session.streaming_behavior_detected': StreamingBehaviorDetectedEvent;
 };
+
+export interface ParamStrippedEvent {
+    data: {
+        /** Primary OpenAI API parameter key that was dropped (e.g. 'temperature'). */
+        param: string;
+        /** Companion keys dropped together with `param` (e.g. ['tool_choice'] when stripping 'tools'). */
+        companions: string[];
+        /** Provider error message that triggered the strip. */
+        reason: string;
+    };
+}
+
+export interface StreamingBehaviorDetectedEvent {
+    data: {
+        /**
+         * `'non-streaming'` when the provider silently buffered the entire
+         * upstream response into a single SSE frame. `'streaming'` is reserved
+         * for future re-detection if a provider regains streaming.
+         */
+        mode: 'streaming' | 'non-streaming';
+        /** Milliseconds between request send and the first content/tool chunk. */
+        ttfbMs: number;
+        /** Total number of chunks observed across the response. */
+        chunkCount: number;
+        /**
+         * `true` when the model emitted reasoning inline as `<think>…</think>`
+         * tags inside `delta.content` instead of using a structured field.
+         */
+        inlineReasoningTags: boolean;
+    };
+}
 
 // ─── Provider-neutral session/client interfaces ──────────────────────────────
 
@@ -125,6 +158,33 @@ export interface AgentSessionOptions {
     localTools?: LocalTool[];
     systemMessage?: { mode?: 'append' | 'replace'; content: string };
     contextWindow?: number;
+    /**
+     * Model capabilities fetched from models.dev. The BYOK session uses
+     * this to know which streaming delta fields to watch for reasoning
+     * content, whether to advertise tool calls, etc.
+     */
+    modelCapabilities?: import('@/AI/shared/data/modelCatalog').ModelCapabilities;
+    /**
+     * Reasoning effort level (BYOK only, for models that support it).
+     * Maps to the `reasoning_effort` parameter in OpenAI-compatible APIs.
+     */
+    reasoningEffort?: 'low' | 'medium' | 'high';
+    /**
+     * Temperature override for BYOK sessions. When the model supports it,
+     * this is passed directly to the chat completion API.
+     */
+    temperature?: number;
+    /**
+     * Generic per-(provider, model) optional parameters resolved by the picker
+     * (Phase 2 of the BYOK parameter overhaul). Keyed by the OpenAI Chat
+     * Completions API parameter name (e.g. `top_p`, `frequency_penalty`,
+     * `parallel_tool_calls`). The BYOK session's `OPTIONAL_PARAMS` registry
+     * checks this map first and falls back to the typed `reasoningEffort` /
+     * `temperature` fields above for backward compatibility. Values are
+     * passed through verbatim, so the picker is responsible for producing
+     * API-shaped values.
+     */
+    dynamicParams?: Record<string, unknown>;
     onPreToolUse: (input: AgentPreToolUseHookInput) => Promise<AgentPreToolUseHookOutput>;
     onPostToolUse: (input: AgentPostToolUseHookInput) => Promise<AgentPostToolUseHookOutput | void>;
     onUserInputRequest?: (request: AgentUserInputRequest) => Promise<AgentUserInputResponse>;
@@ -158,6 +218,19 @@ export interface AgentConversationOptions {
     provider: string;
     additionalMcpServers?: Record<string, MCPServerConfig>;
     contextWindow?: number;
+    /** Model capabilities from models.dev. Passed through to the BYOK session. */
+    modelCapabilities?: import('@/AI/shared/data/modelCatalog').ModelCapabilities;
+    /** Reasoning effort for BYOK models. Maps to `reasoning_effort` in the API. */
+    reasoningEffort?: 'low' | 'medium' | 'high';
+    /** Temperature override for BYOK sessions. */
+    /** Temperature override for BYOK sessions. */
+    temperature?: number;
+    /**
+     * Generic optional params resolved by the picker. See the matching field
+     * on `AgentSessionOptions` for the full contract. Threaded straight
+     * through to the session.
+     */
+    dynamicParams?: Record<string, unknown>;
     executor?: import('@/AI/AIAgent/shared/subAgents/types').ExecutorRuntime;
     investigator?: import('@/AI/AIAgent/shared/subAgents/types').InvestigatorRuntime;
 }

--- a/src/AI/AIChat/data/keys.ts
+++ b/src/AI/AIChat/data/keys.ts
@@ -71,3 +71,23 @@ export function getOpenCodeKey(): string {
 
     return apiKey;
 }
+
+export function getOxloKey(): string {
+    const apiKey = process.env.OXLO_API;
+
+    if (!apiKey) {
+        throw new Error('OXLO_API environment variable is not set');
+    }
+
+    return apiKey;
+}
+
+export function getCrofKey(): string {
+    const apiKey = process.env.COPF_API;
+
+    if (!apiKey) {
+        throw new Error('COPF_API_KEY environment variable is not set');
+    }
+
+    return apiKey;
+}

--- a/src/AI/AIChat/main/conversation.ts
+++ b/src/AI/AIChat/main/conversation.ts
@@ -308,7 +308,7 @@ function parseChatHistory(historyString: string): ChatHistory[] {
     let currentTextLines: string[] = [];
     let currentTimestamp = '';
 
-    const flushMessage = () => {
+    const flushMessage = (): void => {
         if (currentRole !== null && currentTextLines.length > 0) {
             const messageText = currentTextLines.join("\n").trim();
             if (messageText) {

--- a/src/AI/AIChat/utils/aiUtils.ts
+++ b/src/AI/AIChat/utils/aiUtils.ts
@@ -2,8 +2,8 @@ import * as ui from '@/UI/generalUI';
 import { ChatModelDetails } from '@/AI/shared/types/aiTypes';
 import { SUPPORTED_PROVIDERS } from '@/AI/shared/data/providers';
 import { getModelCatalog, formatModelInfoForPicker, type ModelInfo } from '@/AI/shared/data/modelCatalog';
+import { getModelsDevCatalog, formatCapabilitiesSummary, type ModelsDevModelInfo } from '@/AI/shared/data/modelsDevCatalog';
 import { menuChain } from '@/UI/menuChain';
-
 export async function promptUserForTemperature(model: string): Promise<number> {
     const maxTemp = model.startsWith('gemini') ? 20 : 10;
     const optionsArray: string[] = [];
@@ -45,6 +45,13 @@ export async function pickProviderAndModel(): Promise<ChatModelDetails> {
                 throw new Error(`No models returned for provider '${provider}'.`);
             }
 
+            // Fetch capabilities from models.dev for the details panel
+            let devModels: Map<string, ModelsDevModelInfo> = new Map();
+            try {
+                const catalog = await getModelsDevCatalog(provider);
+                devModels = new Map(catalog.map((m) => [m.id, m]));
+            } catch { /* non-fatal */ }
+
             const sorted = [...models].sort((a, b) => a.label.localeCompare(b.label));
             const labelToModel = new Map<string, ModelInfo>();
 
@@ -52,15 +59,48 @@ export async function pickProviderAndModel(): Promise<ChatModelDetails> {
                 labelToModel.set(formatModelInfoForPicker(m), m);
             }
 
+            // Build a details callback that shows capabilities from models.dev
+            const detailsCallback = (item: string, _index: number): string => {
+                const model = labelToModel.get(item);
+                if (!model) return '';
+                const devInfo = devModels.get(model.id);
+                if (devInfo) {
+                    return formatCapabilitiesSummary(devInfo);
+                }
+                // Fallback: show basic info from our catalog
+                const lines: string[] = [];
+                lines.push(`{bold}{cyan-fg}${model.label}{/cyan-fg}{/bold}`);
+                lines.push('');
+                if (model.contextWindow > 0) {
+                    lines.push(`{bold}Context window:{/}  ${Math.round(model.contextWindow / 1000).toLocaleString()}k tokens`);
+                }
+                if (model.pricing) {
+                    lines.push(`{bold}Pricing:{/}  $${model.pricing.inputPerM.toFixed(2)}/$${model.pricing.outputPerM.toFixed(2)} per 1M tokens`);
+                    if (model.pricing.cachedInputPerM != null) {
+                        lines.push(`  cached $${model.pricing.cachedInputPerM.toFixed(2)}`);
+                    }
+                }
+
+                return lines.join('\n');
+            };
+
             const selectedLabel = await ui.searchSelectAndReturnFromArray({
                 itemsArray: [...labelToModel.keys()],
                 prompt: `Select a ${provider} model`,
+                details: detailsCallback,
+                detailsUseTags: true,
             });
 
             const picked = labelToModel.get(selectedLabel);
 
             if (!picked) {
                 throw new Error(`Model selection '${selectedLabel}' could not be resolved.`);
+            }
+
+            // Enrich the model with capabilities from models.dev
+            const devInfo = devModels.get(picked.id);
+            if (devInfo) {
+                picked.capabilities = devInfo.capabilities;
             }
 
             return picked;

--- a/src/AI/AIChat/utils/promptModel.ts
+++ b/src/AI/AIChat/utils/promptModel.ts
@@ -28,6 +28,56 @@ import { summarizeToolCall, formatToolLine } from '@/AI/AIAgent/shared/utils/age
 
 const MAX_TOOL_ITERATIONS = 8;
 
+/**
+ * Extract tool calls from text-based patterns that some providers/models
+ * emit in the content field instead of structured `tool_calls` deltas.
+ *
+ * Pattern: <|tool_call_begin|>call_id<|tool_call_argument_begin|>{json}<|tool_call_end|>
+ */
+function extractChatTextToolCalls(text: string): Array<{ id: string; name: string; args: string }> {
+    const calls: Array<{ id: string; name: string; args: string }> = [];
+    const beginRe = /<\|tool_call_begin\|>/g;
+    let match: RegExpExecArray | null;
+    while ((match = beginRe.exec(text)) !== null) {
+        const startIdx = match.index + match[0].length;
+        const argBeginIdx = text.indexOf('<|tool_call_argument_begin|>', startIdx);
+        if (argBeginIdx === -1) break;
+        const callId = text.slice(startIdx, argBeginIdx).trim();
+        const endIdx = text.indexOf('<|tool_call_end|>', argBeginIdx);
+        if (endIdx === -1) break;
+        const argsStr = text.slice(
+            argBeginIdx + '<|tool_call_argument_begin|>'.length,
+            endIdx
+        ).trim();
+        let name = '';
+        let args = '';
+        try {
+            const parsed = JSON.parse(argsStr);
+            if (typeof parsed === 'object' && parsed !== null) {
+                if (typeof parsed.name === 'string') {
+                    name = parsed.name;
+                    args = typeof parsed.arguments === 'string'
+                        ? parsed.arguments
+                        : JSON.stringify(parsed.arguments ?? {});
+                } else {
+                    args = JSON.stringify(parsed);
+                }
+            }
+        } catch {
+            args = argsStr;
+        }
+        if (name || args) {
+            calls.push({
+                id: callId || `call_${Date.now()}_${calls.length}`,
+                name: name || '(unknown)',
+                args: args || '{}',
+            });
+        }
+    }
+
+    return calls;
+}
+
 const TOOL_AWARENESS_PREAMBLE = [
     'You have access to web tools: `web_search` (DuckDuckGo) and `web_fetch` (retrieve a URL as text).',
     'Use them whenever the user asks about current events, specific URLs, library documentation,',
@@ -87,10 +137,32 @@ export async function promptModel(
     return createOpenAIStream(openai, model, system, messages, temperature, controller, toolContext);
 }
 
-function looksLikeToolsUnsupported(error: unknown): boolean {
-    const message = error instanceof Error ? error.message : String(error ?? '');
+/**
+ * Inspect a 400 error message to guess which request parameter the provider
+ * rejected.  Returns a set of parameter names that look suspicious.
+ *
+ * Many OpenAI-compatible providers return vague 400 errors with no detail
+ * about *which* parameter was unsupported, so we fall back to keyword
+ * heuristics.  When the message is unhelpful we return *all* optional
+ * parameters so the caller can strip them one-by-one.
+ */
+function guessUnsupportedParams(error: unknown): Set<string> {
+    const msg = error instanceof Error ? error.message.toLowerCase() : String(error ?? '').toLowerCase();
+    const result = new Set<string>();
 
-    return /tool|function[_ ]?call|not[_ ]?support/i.test(message);
+    if (/reasoning_effort|reasoning/.test(msg)) result.add('reasoning_effort');
+    if (/temperature/.test(msg)) result.add('temperature');
+    if (/tool|function[_ ]?call|not[_ ]?support/.test(msg)) result.add('tools');
+
+    // If the message is completely unhelpful, assume all optional params
+    // could be the culprit so we try stripping them one-by-one.
+    if (result.size === 0) {
+        result.add('reasoning_effort');
+        result.add('temperature');
+        result.add('tools');
+    }
+
+    return result;
 }
 
 interface ToolCallAccumulator {
@@ -201,34 +273,56 @@ async function createOpenAIStream(
         ...initialMessages,
     ];
     let toolsDisabled = false;
+    let temperatureDisabled = false;
 
     async function openStream(): Promise<AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>> {
         try {
             return await openai.chat.completions.create({
                 messages,
                 model: llmModel,
-                temperature,
+                ...(!temperatureDisabled ? { temperature } : {}),
                 stream: true,
                 ...(useTools && !toolsDisabled
                     ? { tools: chatTools, tool_choice: 'auto' as const }
                     : {}),
             });
         } catch (error) {
-            if (useTools && !toolsDisabled && looksLikeToolsUnsupported(error)) {
-                toolsDisabled = true;
+            // Progressive retry: strip the most likely offending parameter
+            // and retry.  Many OpenAI-compatible providers reject parameters
+            // they don't support with a 400, but give vague error messages.
+            if (error instanceof Error) {
+                const status = (error as unknown as { status?: number }).status;
+                if (status === 400) {
+                    const suspected = guessUnsupportedParams(error);
 
-                return openai.chat.completions.create({
-                    messages,
-                    model: llmModel,
-                    temperature,
-                    stream: true,
-                });
+                    if (suspected.has('temperature') && !temperatureDisabled) {
+                        temperatureDisabled = true;
+                        return openStream();
+                    }
+                    if (suspected.has('tools') && useTools && !toolsDisabled) {
+                        toolsDisabled = true;
+                        return openStream();
+                    }
+                }
+                if (status === 502 || status === 503) {
+                    throw new Error(
+                        `Provider returned ${status} (service unavailable). ` +
+                        `The model may be overloaded or temporarily down. ` +
+                        `Original: ${error.message}`
+                    );
+                }
+                if (status === 400) {
+                    throw new Error(
+                        `Provider returned 400 (bad request). ` +
+                        `The model may not support the parameters sent (e.g. tools, temperature). ` +
+                        `Original: ${error.message}`
+                    );
+                }
             }
 
             throw error;
         }
     }
-
     async function* streamResponse(): AsyncIterable<string> {
         try {
             for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
@@ -240,15 +334,24 @@ async function createOpenAIStream(
                 const toolCalls = new Map<number, ToolCallAccumulator>();
                 let assistantContent = '';
                 let finishReason: string | null | undefined;
+                // Some providers reuse the same index for multiple parallel tool calls,
+                // causing them to merge into one. Track ids to detect collisions.
+                let syntheticIndexCounter = 0;
+                const idToIndex = new Map<string, number>();
 
                 for await (const chunk of completion) {
                     if (controller?.isAborted) {
                         return;
                     }
 
+                    // Some OpenAI-compatible providers send chunks with empty choices
+                    // (e.g. usage-only chunks). Guard against undefined choice / delta.
                     const choice = chunk.choices[0];
-                    const delta = choice.delta;
+                    if (!choice) {
+                        continue;
+                    }
 
+                    const delta = choice.delta;
                     if (!delta) {
                         continue;
                     }
@@ -260,8 +363,34 @@ async function createOpenAIStream(
 
                     if (delta.tool_calls) {
                         for (const tcDelta of delta.tool_calls) {
-                            const index = tcDelta.index ?? 0;
-                            const existing = toolCalls.get(index) ?? {
+                            // Some providers reuse the same index for multiple parallel
+                            // tool calls, causing them to merge into one (e.g. name
+                            // becomes "web_fetchweb_fetchweb_fetch"). When a delta
+                            // carries an id (start of a new tool call) but the index
+                            // is already occupied by a different id, assign a synthetic
+                            // index to keep them separate.
+                            let effectiveIndex: number;
+
+                            if (tcDelta.id) {
+                                const knownIndex = idToIndex.get(tcDelta.id);
+                                if (knownIndex !== undefined) {
+                                    effectiveIndex = knownIndex;
+                                } else {
+                                    const existing = toolCalls.get(tcDelta.index ?? 0);
+                                    if (existing && existing.id && existing.id !== tcDelta.id) {
+                                        effectiveIndex = 1000 + syntheticIndexCounter++;
+                                    } else {
+                                        effectiveIndex = tcDelta.index ?? 0;
+                                    }
+                                    idToIndex.set(tcDelta.id, effectiveIndex);
+                                }
+                            } else {
+                                const existingEntry = toolCalls.get(tcDelta.index ?? 0);
+                                const knownIndex = idToIndex.get(existingEntry?.id ?? '');
+                                effectiveIndex = knownIndex ?? (tcDelta.index ?? 0);
+                            }
+
+                            const existing = toolCalls.get(effectiveIndex) ?? {
                                 id: '',
                                 name: '',
                                 argsBuffer: '',
@@ -279,7 +408,7 @@ async function createOpenAIStream(
                                 existing.argsBuffer += tcDelta.function.arguments;
                             }
 
-                            toolCalls.set(index, existing);
+                            toolCalls.set(effectiveIndex, existing);
                         }
                     }
 
@@ -289,6 +418,76 @@ async function createOpenAIStream(
                 }
 
                 if (finishReason !== 'tool_calls' || toolCalls.size === 0 || !toolContext) {
+                    // No structured tool calls — check for text-based tool call patterns
+                    // that some providers emit in the content field instead.
+                    if (toolContext && assistantContent.length > 0) {
+                        const extracted = extractChatTextToolCalls(assistantContent);
+                        if (extracted.length > 0) {
+                            // Strip the tool call text from the content we yield
+                            const cleanedContent = assistantContent.replace(
+                                /<\|tool_call_begin\|>[\s\S]*?<\|tool_call_end\|>/g,
+                                ''
+                            ).replace(/\n{3,}/g, '\n\n').trim();
+                            if (cleanedContent) {
+                                // Already yielded during streaming, no need to yield again
+                            }
+
+                            const assistantMessage: ChatCompletionAssistantMessageParam = {
+                                role: 'assistant',
+                                content: cleanedContent || null,
+                                tool_calls: extracted.map<ChatCompletionMessageToolCall>((tc) => ({
+                                    id: tc.id || `call_${Math.random().toString(36).slice(2, 10)}`,
+                                    type: 'function',
+                                    function: { name: tc.name, arguments: tc.args || '{}' },
+                                })),
+                            };
+                            messages.push(assistantMessage);
+
+                            for (const tc of assistantMessage.tool_calls!) {
+                                if (controller?.isAborted) {
+                                    return;
+                                }
+
+                                let parsedArgs: Record<string, unknown> = {};
+                                try {
+                                    parsedArgs = tc.function.arguments
+                                        ? JSON.parse(tc.function.arguments) as Record<string, unknown>
+                                        : {};
+                                } catch {
+                                    // summarizeToolCall handles missing fields gracefully
+                                }
+
+                                const summary = summarizeToolCall(tc.function.name, parsedArgs);
+
+                                await updateAgentUi(toolContext.nvim, 'start_tool', [
+                                    tc.function.name,
+                                    summary,
+                                    tc.function.arguments || '{}',
+                                ]);
+
+                                const result = await executeToolCall(tc.function.name, tc.function.arguments);
+
+                                await updateAgentUi(toolContext.nvim, 'complete_tool', [
+                                    tc.function.name,
+                                    summary,
+                                    !result.isError,
+                                    result.output,
+                                ]);
+
+                                yield formatToolLine(summary, !result.isError);
+
+                                const toolMessage: ChatCompletionToolMessageParam = {
+                                    role: 'tool',
+                                    tool_call_id: tc.id,
+                                    content: result.output,
+                                };
+                                messages.push(toolMessage);
+                            }
+
+                            // Continue the loop to let the model respond to tool results
+                        }
+                    }
+
                     return;
                 }
 
@@ -352,6 +551,25 @@ async function createOpenAIStream(
         } catch (error) {
             if (controller?.isAborted) {
                 return;
+            }
+
+            // Provide clearer error messages for common provider failures.
+            if (error instanceof Error) {
+                const status = (error as unknown as { status?: number }).status;
+                if (status === 502 || status === 503) {
+                    throw new Error(
+                        `Provider returned ${status} (service unavailable). ` +
+                        `The model may be overloaded or temporarily down. ` +
+                        `Original: ${error.message}`
+                    );
+                }
+                if (status === 400) {
+                    throw new Error(
+                        `Provider returned 400 (bad request). ` +
+                        `The model may not support the parameters sent (e.g. tools, temperature). ` +
+                        `Original: ${error.message}`
+                    );
+                }
             }
 
             throw error;

--- a/src/AI/shared/data/modelCatalog.ts
+++ b/src/AI/shared/data/modelCatalog.ts
@@ -32,13 +32,167 @@ export interface ModelPricing {
     inputPerM: number;
     outputPerM: number;
     cachedInputPerM?: number;
+    reasoningPerM?: number;
 }
+
+export interface ModelCapabilities {
+    /** Whether the model supports reasoning / thinking tokens. */
+    reasoning: boolean;
+    /**
+     * Which field in streaming deltas carries interleaved reasoning content.
+     * - `'reasoning_content'` → DeepSeek-style
+     * - `'reasoning_details'` → Gemini/Google-style structured reasoning
+     * - `undefined` → reasoning not supported or uses raw `reasoning` delta
+     *
+     * The BYOK session inspects this to know which delta fields to watch for
+     * reasoning output so it can route it to `assistant.reasoning_delta`.
+     */
+    reasoningField?: 'reasoning_content' | 'reasoning_details';
+    /** Whether the model supports tool / function calling. */
+    toolCall: boolean;
+    /** Whether the `temperature` parameter is accepted. */
+    temperature: boolean;
+    /** Whether the model supports structured / JSON output. */
+    structuredOutput: boolean;
+    /** Whether the model accepts file attachments (images, PDFs, etc). */
+    attachment: boolean;
+    /** Input modalities the model supports (e.g. 'text', 'image', 'audio'). */
+    inputModalities: string[];
+    /** Output modalities the model supports (e.g. 'text', 'audio'). */
+    outputModalities: string[];
+    /** Reasoning cost per million tokens (if separate from output cost). */
+    reasoningCostPerM?: number;
+    /** Knowledge cutoff date (e.g. '2025-04'). */
+    knowledge?: string;
+    /** When the model was released. */
+    releaseDate?: string;
+    /** Model family (e.g. 'gpt', 'claude', 'deepseek'). */
+    family?: string;
+    /** Whether the model has open weights. */
+    /** Whether the model has open weights. */
+    openWeights?: boolean;
+    /**
+     * Per-parameter descriptors merged from `BUILTIN_PARAM_DESCRIPTORS` and
+     * overlaid with provider/model `canSend` flags from models.dev (Phase 3
+     * of the BYOK parameter overhaul). Keyed by the OpenAI Chat Completions
+     * API parameter name (e.g. `temperature`, `reasoning_effort`, `top_p`).
+     *
+     * The picker (`pickByokRuntime` → `renderDynamicParamPicker`) iterates
+     * this map to build the per-session `dynamicParams` payload, skipping
+     * descriptors with `canSend === false`.
+     */
+    supportedParams?: Record<string, ParamDescriptor>;
+}
+
+/**
+ * Describes a single optional Chat Completions parameter so the BYOK picker
+ * can render a UI for it without hardcoding per-param logic.
+ *
+ * Lives in source code (not on models.dev) because models.dev only exposes a
+ * handful of boolean capability flags — it does NOT carry per-param
+ * type/min/max metadata. The `canSend` flag is the bridge: models.dev
+ * boolean flags overlay onto our descriptor table to disable specific keys
+ * per model (e.g. `temperature: false`).
+ */
+export interface ParamDescriptor {
+    /** Picker label, e.g. 'Reasoning effort'. */
+    label: string;
+    /** Optional longer description shown in details. */
+    description?: string;
+    /** Discriminator for the picker dispatch. */
+    type: 'number' | 'enum' | 'boolean' | 'string';
+    /** OpenAI Chat Completions API key sent in the request body. */
+    apiKey: string;
+    /** Default value (informational; picker may surface in the prompt). */
+    defaultValue?: unknown;
+    /** Allowed enum values when `type === 'enum'`. */
+    enumValues?: readonly string[];
+    /** Inclusive minimum when `type === 'number'`. */
+    min?: number;
+    /** Inclusive maximum when `type === 'number'`. */
+    max?: number;
+    /** Step / increment when `type === 'number'`. */
+    step?: number;
+    /**
+     * When false, the picker skips this descriptor entirely. Used by the
+     * models.dev overlay to disable params the model is known to reject
+     * without removing the descriptor from the registry.
+     */
+    canSend?: boolean;
+    /**
+     * How to encode the value when sending to the provider.
+     *   - `'literal'`: send the picker value unchanged (e.g. `reasoning_effort: 'medium'`).
+     *   - `'boolean'`: coerce any non-null picker value to `true`. Used for BYOK
+     *     proxies that accept the param as a plain on/off boolean.
+     * The picker also dispatches UX off this field: `'literal'` shows the enum
+     * picker; `'boolean'` shows a yes/no toggle.
+     */
+    sendAs?: 'literal' | 'boolean';
+}
+
+/**
+ * Source-of-truth registry of optional Chat Completions parameters the BYOK
+ * picker knows how to prompt for. New parameters added here automatically
+ * surface in the picker (Phase 3) and become candidates for the dynamic
+ * `OPTIONAL_PARAMS` strip-and-retry registry consumed by `byokSession.ts`.
+ */
+export const BUILTIN_PARAM_DESCRIPTORS: Readonly<Record<string, ParamDescriptor>> = {
+    reasoning_effort: {
+        label: 'Reasoning effort',
+        description: 'How much the model should think before responding.',
+        type: 'enum',
+        apiKey: 'reasoning_effort',
+        enumValues: ['low', 'medium', 'high'],
+        defaultValue: 'medium',
+    },
+    temperature: {
+        label: 'Temperature',
+        description: 'Sampling temperature. Lower = more deterministic.',
+        type: 'number',
+        apiKey: 'temperature',
+        min: 0,
+        max: 2,
+        step: 0.1,
+        defaultValue: 1,
+    },
+    top_p: {
+        label: 'Top-p',
+        description: 'Nucleus sampling probability mass.',
+        type: 'number',
+        apiKey: 'top_p',
+        min: 0,
+        max: 1,
+        step: 0.1,
+        defaultValue: 1,
+    },
+    frequency_penalty: {
+        label: 'Frequency penalty',
+        description: 'Penalises repeated tokens by frequency.',
+        type: 'number',
+        apiKey: 'frequency_penalty',
+        min: -2,
+        max: 2,
+        step: 0.1,
+        defaultValue: 0,
+    },
+    presence_penalty: {
+        label: 'Presence penalty',
+        description: 'Penalises tokens already present in the response.',
+        type: 'number',
+        apiKey: 'presence_penalty',
+        min: -2,
+        max: 2,
+        step: 0.1,
+        defaultValue: 0,
+    },
+};
 
 export interface ModelInfo {
     id: string;
     label: string;
     contextWindow: number;
     pricing?: ModelPricing;
+    capabilities?: ModelCapabilities;
 }
 
 export interface CatalogFetchOptions {
@@ -136,6 +290,14 @@ const STATIC_OPENCODE: Record<string, { contextWindow: number; pricing?: ModelPr
     'trinity-large-preview-free': { contextWindow: 200_000, pricing: { inputPerM: 0, outputPerM: 0 } },
 };
 
+// Oxlo — https://api.oxlo.ai/v1/models
+// Pricing and context from the /models endpoint; static entries provide fallback data.
+const STATIC_OXLO: Record<string, { contextWindow: number; pricing?: ModelPricing }> = {
+    'deepseek-r1-70b': { contextWindow: 32_000, pricing: { inputPerM: 0, outputPerM: 0 } },
+    'llama-3.3-70b': { contextWindow: 32_000, pricing: { inputPerM: 0, outputPerM: 0 } },
+    'kimi-k2-thinking': { contextWindow: 32_000, pricing: { inputPerM: 0, outputPerM: 0 } },
+};
+
 const STATIC_FALLBACK_MODELS: Record<SupportedProvider, ModelInfo[]> = {
     'deep-infra': [
         { id: 'moonshotai/Kimi-K2-Instruct', label: 'moonshotai/Kimi-K2-Instruct', contextWindow: 128_000, pricing: { inputPerM: 0.75, outputPerM: 4.00, cachedInputPerM: 0.15 } },
@@ -168,6 +330,15 @@ const STATIC_FALLBACK_MODELS: Record<SupportedProvider, ModelInfo[]> = {
         { id: 'glm-5.1', label: 'glm-5.1', contextWindow: 200_000, pricing: STATIC_OPENCODE['glm-5.1'].pricing! },
         { id: 'minimax-m2.7', label: 'minimax-m2.7', contextWindow: 205_000, pricing: STATIC_OPENCODE['minimax-m2.7'].pricing! },
         { id: 'qwen3.6-plus', label: 'qwen3.6-plus', contextWindow: 256_000, pricing: STATIC_OPENCODE['qwen3.6-plus'].pricing! },
+    ],
+    'oxlo': [
+        { id: 'deepseek-r1-70b', label: 'deepseek-r1-70b', contextWindow: 32_000, pricing: { inputPerM: 0, outputPerM: 0 } },
+        { id: 'llama-3.3-70b', label: 'llama-3.3-70b', contextWindow: 32_000, pricing: { inputPerM: 0, outputPerM: 0 } },
+        { id: 'kimi-k2-thinking', label: 'kimi-k2-thinking', contextWindow: 32_000, pricing: { inputPerM: 0, outputPerM: 0 } },
+    ],
+    'crof': [
+        { id: 'crof-mini', label: 'crof-mini', contextWindow: 32_000 },
+        { id: 'crof-standard', label: 'crof-standard', contextWindow: 128_000 },
     ],
 };
 
@@ -393,15 +564,108 @@ async function fetchOpenCode(apiKey: string): Promise<ModelInfo[]> {
         };
     })
 
-    models.push({
-        id: 'opencode/big-pickle',
-        label: 'big-pickle',
-        contextWindow: 200_000,
-        pricing: { inputPerM: 0, outputPerM: 0 },
-    });
-
     return models;
 }
+
+async function fetchOxlo(apiKey: string): Promise<ModelInfo[]> {
+    const res = await fetch('https://api.oxlo.ai/v1/models', {
+        headers: { Authorization: `Bearer ${apiKey}` },
+    });
+
+    if (!res.ok) {
+        throw new Error(`Oxlo /models returned ${res.status}`);
+    }
+
+    const json = await res.json() as { data: Array<{ id: string; context_length?: number }> };
+
+    return json.data.map((m): ModelInfo => {
+        const meta = STATIC_OXLO[m.id];
+
+        return {
+            id: m.id,
+            label: m.id,
+            contextWindow: m.context_length ?? meta.contextWindow ?? 0,
+            ...(meta.pricing ? { pricing: meta.pricing } : {}),
+        };
+    });
+}
+
+interface CrofModel {
+    id: string;
+    name?: string;
+    context_length?: number;
+    context_window?: number;
+    max_completion_tokens?: number;
+    /** Whether the model accepts the `reasoning_effort` parameter. */
+    reasoning_effort?: boolean;
+    /** Whether the model has its own (non-OpenAI-style) reasoning capability. */
+    custom_reasoning?: boolean;
+    pricing?: {
+        prompt?: string | number;
+        completion?: string | number;
+        cache_prompt?: string | number;
+    };
+}
+
+async function fetchCrof(): Promise<ModelInfo[]> {
+    const res = await fetch('https://crof.ai/v1/models');
+
+    if (!res.ok) {
+        throw new Error(`Crof models returned ${res.status}`);
+    }
+
+    const json = await res.json() as { data: CrofModel[] };
+
+    return json.data.map((m): ModelInfo => {
+        const reasoning = m.reasoning_effort === true || m.custom_reasoning === true;
+
+        const supportedParams: Record<string, ParamDescriptor> = {};
+        for (const [key, desc] of Object.entries(BUILTIN_PARAM_DESCRIPTORS)) {
+            const overlay: Partial<ParamDescriptor> = key === 'reasoning_effort'
+                ? { canSend: m.reasoning_effort === true }
+                : {};
+            supportedParams[key] = { ...desc, ...overlay };
+        }
+
+        const capabilities: ModelCapabilities = {
+            reasoning,
+            toolCall: true,
+            temperature: true,
+            structuredOutput: false,
+            attachment: false,
+            inputModalities: ['text'],
+            outputModalities: ['text'],
+            supportedParams,
+        };
+
+        const pricing = toCrofPricing(m.pricing);
+
+        return {
+            id: m.id,
+            label: m.name ?? m.id,
+            contextWindow: m.context_length ?? m.context_window ?? 0,
+            capabilities,
+            ...(pricing != null ? { pricing } : {}),
+        };
+    });
+}
+
+function toCrofPricing(p: CrofModel['pricing']): ModelPricing | undefined {
+    if (!p) return undefined;
+    const input = typeof p.prompt === 'string' ? parseFloat(p.prompt) : p.prompt;
+    const output = typeof p.completion === 'string' ? parseFloat(p.completion) : p.completion;
+    if (input == null || output == null || Number.isNaN(input) || Number.isNaN(output)) {
+        return undefined;
+    }
+    const cached = typeof p.cache_prompt === 'string' ? parseFloat(p.cache_prompt) : p.cache_prompt;
+
+    return {
+        inputPerM: input,
+        outputPerM: output,
+        ...(cached != null && !Number.isNaN(cached) ? { cachedInputPerM: cached } : {}),
+    };
+}
+
 
 async function fetchLive(provider: SupportedProvider): Promise<ModelInfo[]> {
     switch (provider) {
@@ -419,6 +683,10 @@ async function fetchLive(provider: SupportedProvider): Promise<ModelInfo[]> {
             return fetchMistral(getProviderApiKey(provider));
         case 'open-code':
             return fetchOpenCode(getProviderApiKey(provider));
+        case 'oxlo':
+            return fetchOxlo(getProviderApiKey(provider));
+        case 'crof':
+            return fetchCrof();
         default: {
             const exhaustive: never = provider;
 
@@ -468,14 +736,30 @@ export function formatModelInfoForPicker(modelInfo: ModelInfo): string {
         ? `${Math.round(modelInfo.contextWindow / 1000)}k ctx`.padEnd(10)
         : '? ctx    '.padEnd(10);
 
-    const priceStr = modelInfo.pricing
+    let priceStr = modelInfo.pricing
         ? `$${modelInfo.pricing.inputPerM.toFixed(2)}/$${modelInfo.pricing.outputPerM.toFixed(2)} in/out` +
-        (modelInfo.pricing.cachedInputPerM !== undefined
+        (modelInfo.pricing.cachedInputPerM != null
             ? `  cached $${modelInfo.pricing.cachedInputPerM.toFixed(2)}`
             : '')
         : '? pricing';
 
+    if (modelInfo.pricing?.reasoningPerM != null) {
+        priceStr += `  reason $${modelInfo.pricing.reasoningPerM.toFixed(2)}`;
+    }
+
+    const badges: string[] = [];
+    const c = modelInfo.capabilities;
+
+    if (c) {
+        if (c.reasoning) badges.push('think');
+        if (c.toolCall) badges.push('tools');
+        if (c.attachment) badges.push('attach');
+        if (!c.temperature) badges.push('fixed-temp');
+        if (c.structuredOutput) badges.push('json');
+    }
+
+    const badgeStr = badges.length > 0 ? ` [${badges.join(',')}]` : '';
     const label = modelInfo.label.padEnd(48);
 
-    return `${label}  ${ctxStr}  ${priceStr}`;
+    return `${label}  ${ctxStr}  ${priceStr}${badgeStr}`;
 }

--- a/src/AI/shared/data/modelsDevCatalog.ts
+++ b/src/AI/shared/data/modelsDevCatalog.ts
@@ -1,0 +1,434 @@
+/**
+ * Models.dev catalog — dynamic model capability metadata.
+ *
+ * Fetches https://models.dev/api.json and enriches our existing ModelInfo
+ * with capability data (reasoning, tool_call, temperature, structured_output,
+ * modalities, etc.). This data drives:
+ *
+ *   1. The model-details split-screen dashboard shown after model selection.
+ *   2. The BYOK session's awareness of which reasoning field to watch
+ *      (`reasoning_content` vs `reasoning_details` vs raw `reasoning`).
+ *   3. Optional BYOK dynamic settings (reasoning effort, temperature, etc.)
+ *      presented after the model is picked.
+ *
+ * Results are cached on disk under `~/.kra/model-catalog/modelsdev.json`
+ * with a 24-hour TTL, identical to the per-provider cache strategy.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { kraHome } from '@/filePaths';
+import { type SupportedProvider } from '@/AI/shared/data/providers';
+import {
+    BUILTIN_PARAM_DESCRIPTORS,
+    type ModelCapabilities,
+    type ParamDescriptor,
+    type ModelPricing,
+} from '@/AI/shared/data/modelCatalog';
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+/** Raw model entry from models.dev/api.json */
+export interface ModelsDevModel {
+    id: string;
+    name?: string;
+    family?: string;
+    attachment?: boolean;
+    reasoning?: boolean;
+    /** True or an object like { field: 'reasoning_content' } */
+    interleaved?: boolean | { field: string };
+    tool_call?: boolean;
+    temperature?: boolean;
+    structured_output?: boolean;
+    modalities?: {
+        input?: string[];
+        output?: string[];
+    };
+    open_weights?: boolean;
+    knowledge?: string;
+    release_date?: string;
+    last_updated?: string;
+    cost?: {
+        input?: number;
+        output?: number;
+        cache_read?: number;
+        cache_write?: number;
+        input_audio?: number;
+        output_audio?: number;
+        reasoning?: number;
+        context_over_200k?: number;
+    };
+    limit?: {
+        context?: number;
+        input?: number;
+        output?: number;
+    };
+}
+
+/** Raw provider entry from models.dev/api.json */
+export interface ModelsDevProvider {
+    id: string;
+    name?: string;
+    api?: string;
+    env?: string[];
+    npm?: string;
+    doc?: string;
+    models: Record<string, ModelsDevModel>;
+}
+
+export interface ModelsDevModelInfo {
+    /** The model ID within the provider (e.g. 'deepseek-reasoner'). */
+    id: string;
+    /** Human-friendly display name. */
+    name: string;
+    /** Provider key in models.dev (e.g. 'deepseek'). */
+    provider: string;
+    /** Provider display name (e.g. 'DeepSeek'). */
+    providerName: string;
+    capabilities: ModelCapabilities;
+    pricing?: ModelPricing;
+    contextWindow: number;
+    maxOutputTokens?: number;
+}
+
+// ─── Provider mapping ───────────────────────────────────────────────────────
+
+/**
+ * Maps our internal SupportedProvider identifiers to the keys used by
+ * models.dev/api.json. Not all our providers exist there; the ones that
+ * don't simply return an empty array from the catalog.
+ */
+const PROVIDER_TO_MODELSDEV: Record<string, string> = {
+    'deep-seek': 'deepseek',
+    'open-ai': 'openai',
+    'open-router': 'openrouter',
+    'gemini': 'google',
+    'mistral': 'mistral',
+    'deep-infra': 'deepinfra',
+    'open-code': 'opencode',
+    'oxlo': 'oxlo',
+};
+
+// ─── Cache ───────────────────────────────────────────────────────────────────
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface CacheEntry {
+    fetchedAt: number;
+    providers: Record<string, ModelsDevProvider>;
+}
+
+function cachePath(): string {
+    return path.join(kraHome(), 'model-catalog', 'modelsdev.json');
+}
+
+function readCache(): CacheEntry | undefined {
+    try {
+        const raw = fs.readFileSync(cachePath(), 'utf8');
+        const parsed = JSON.parse(raw) as CacheEntry;
+        if (typeof parsed.fetchedAt !== 'number' || typeof parsed.providers !== 'object') {
+            return undefined;
+        }
+
+        return parsed;
+    } catch {
+        return undefined;
+    }
+}
+
+function writeCache(providers: Record<string, ModelsDevProvider>): void {
+    try {
+        const dir = path.dirname(cachePath());
+        fs.mkdirSync(dir, { recursive: true });
+        const entry: CacheEntry = { fetchedAt: Date.now(), providers };
+        fs.writeFileSync(cachePath(), JSON.stringify(entry, null, 2), 'utf8');
+    } catch {
+        // best-effort; not fatal
+    }
+}
+
+// ─── Live fetch ──────────────────────────────────────────────────────────────
+
+const MODELSDEV_URL = 'https://models.dev/api.json';
+
+async function fetchModelsDev(): Promise<Record<string, ModelsDevProvider>> {
+    const res = await fetch(MODELSDEV_URL);
+    if (!res.ok) {
+        throw new Error(`models.dev/api.json returned ${res.status}`);
+    }
+    const json = await res.json() as Record<string, ModelsDevProvider>;
+
+    return json;
+}
+
+// ─── Internal cache ──────────────────────────────────────────────────────────
+
+let cachedProviders: Record<string, ModelsDevProvider> | undefined;
+
+async function getProviders(opts?: { forceRefresh?: boolean }): Promise<Record<string, ModelsDevProvider>> {
+    if (cachedProviders && !opts?.forceRefresh) {
+        return cachedProviders;
+    }
+
+    // Try disk cache first
+    if (!opts?.forceRefresh) {
+        const disk = readCache();
+        if (disk && Date.now() - disk.fetchedAt < CACHE_TTL_MS) {
+            cachedProviders = disk.providers;
+
+            return cachedProviders;
+        }
+    }
+
+    try {
+        const providers = await fetchModelsDev();
+        writeCache(providers);
+        cachedProviders = providers;
+
+        return providers;
+    } catch {
+        // Fall back to stale cache or empty
+        const stale = readCache();
+        if (stale) {
+            cachedProviders = stale.providers;
+
+            return cachedProviders;
+        }
+
+        return {};
+    }
+}
+
+// ─── Transform helpers ────────────────────────────────────────────────────────
+
+function extractReasoningField(model: ModelsDevModel): 'reasoning_content' | 'reasoning_details' | undefined {
+    const interleaved = model.interleaved;
+    if (typeof interleaved === 'object' && interleaved !== null) {
+        const field = (interleaved as { field: string }).field;
+        if (field === 'reasoning_content' || field === 'reasoning_details') {
+            return field;
+        }
+
+        // Unknown interleaved field — fall back to reasoning_content
+        // (the most common delta field across OpenAI-compatible providers).
+        return 'reasoning_content';
+    }
+    // If reasoning is true but no interleaved object, default to reasoning_content
+    // (most OpenAI-compatible providers use reasoning_content)
+    if (model.reasoning) {
+        return 'reasoning_content';
+    }
+
+    return undefined;
+}
+
+function buildSupportedParams(model: ModelsDevModel): Record<string, ParamDescriptor> {
+    // Overlay models.dev boolean capability flags onto the source-of-truth
+    // descriptor table to flip `canSend` per model. Keys not represented in
+    // models.dev are passed through unchanged (canSend defaults to true).
+    const overlay: Record<string, Partial<ParamDescriptor>> = {
+        temperature: { canSend: model.temperature !== false },
+        reasoning_effort: { canSend: model.reasoning === true },
+    };
+
+    const out: Record<string, ParamDescriptor> = {};
+    for (const [key, desc] of Object.entries(BUILTIN_PARAM_DESCRIPTORS)) {
+        out[key] = { ...desc, ...(overlay[key] ?? {}) };
+    }
+
+    return out;
+}
+
+function toModelCapabilities(model: ModelsDevModel): ModelCapabilities {
+    const reasoningField = extractReasoningField(model);
+
+    return {
+        reasoning: model.reasoning ?? false,
+        ...(reasoningField != null ? { reasoningField } : {}),
+        toolCall: model.tool_call ?? false,
+        temperature: model.temperature ?? true,
+        structuredOutput: model.structured_output ?? false,
+        attachment: model.attachment ?? false,
+        inputModalities: model.modalities?.input ?? ['text'],
+        outputModalities: model.modalities?.output ?? ['text'],
+        ...(model.cost?.reasoning != null ? { reasoningCostPerM: model.cost.reasoning } : {}),
+        ...(model.knowledge != null ? { knowledge: model.knowledge } : {}),
+        ...(model.release_date != null ? { releaseDate: model.release_date } : {}),
+        ...(model.family != null ? { family: model.family } : {}),
+        ...(model.open_weights != null ? { openWeights: model.open_weights } : {}),
+        supportedParams: buildSupportedParams(model),
+    };
+}
+
+function toPricing(cost: ModelsDevModel['cost']): ModelPricing | undefined {
+    if (cost?.input == null || cost.output == null) return undefined;
+
+    return {
+        inputPerM: cost.input,
+        outputPerM: cost.output,
+        ...(cost.cache_read != null ? { cachedInputPerM: cost.cache_read } : {}),
+        ...(cost.reasoning != null ? { reasoningPerM: cost.reasoning } : {}),
+    };
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetch model metadata from models.dev for a specific provider.
+ * Returns an enriched list matching models by ID and augmenting them
+ * with capability data.
+ */
+export async function getModelsDevCatalog(
+    provider: SupportedProvider,
+    opts?: { forceRefresh?: boolean }
+): Promise<ModelsDevModelInfo[]> {
+    const providers = await getProviders(opts);
+    const modelsDevKey = PROVIDER_TO_MODELSDEV[provider];
+    if (!modelsDevKey) return [];
+    const providerData = providers[modelsDevKey];
+    if (!providerData) return [];
+
+    return Object.values(providerData.models).map((model): ModelsDevModelInfo => {
+        const pricing = toPricing(model.cost);
+        const maxOutputTokens = model.limit?.output;
+
+        return {
+            id: model.id,
+            name: model.name ?? model.id,
+            provider: modelsDevKey,
+            providerName: providerData.name ?? modelsDevKey,
+            capabilities: toModelCapabilities(model),
+            ...(pricing != null ? { pricing } : {}),
+            contextWindow: model.limit?.context ?? 0,
+            ...(maxOutputTokens != null ? { maxOutputTokens } : {}),
+        };
+    });
+}
+
+/**
+ * Look up a single model's capabilities from models.dev.
+ * Searches across all providers for a match.
+ */
+export async function lookupModelCapabilities(
+    modelId: string,
+    opts?: { forceRefresh?: boolean }
+): Promise<ModelsDevModelInfo | undefined> {
+    const providers = await getProviders(opts);
+
+    for (const [providerKey, providerData] of Object.entries(providers)) {
+        const model = providerData.models[modelId];
+        if (model) {
+            const pricing = toPricing(model.cost);
+            const maxOutputTokens = model.limit?.output;
+
+            return {
+                id: model.id,
+                name: model.name ?? model.id,
+                provider: providerKey,
+                providerName: providerData.name ?? providerKey,
+                capabilities: toModelCapabilities(model),
+                ...(pricing != null ? { pricing } : {}),
+                contextWindow: model.limit?.context ?? 0,
+                ...(maxOutputTokens != null ? { maxOutputTokens } : {}),
+            };
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Look up capabilities for a model within a specific provider.
+ * Uses the provider mapping so it correctly handles our internal names
+ * (e.g. 'deep-seek' → models.dev's 'deepseek').
+ */
+export async function lookupModelCapabilitiesForProvider(
+    modelId: string,
+    provider: SupportedProvider,
+    opts?: { forceRefresh?: boolean }
+): Promise<ModelsDevModelInfo | undefined> {
+    const catalog = await getModelsDevCatalog(provider, opts);
+
+    return catalog.find((m) => m.id === modelId);
+}
+
+/**
+ * Build a summary string describing a model's capabilities.
+ * Used in the model-details dashboard.
+ */
+export function formatCapabilitiesSummary(info: ModelsDevModelInfo): string {
+    const lines: string[] = [];
+    const c = info.capabilities;
+
+    lines.push(`{bold}{cyan-fg}${info.name}{/cyan-fg}{/bold}`);
+    lines.push(`{gray-fg}Provider: ${info.providerName}  |  Family: ${c.family ?? '—'}{/}`);
+    lines.push('');
+
+    // Context & output limits
+    const ctxStr = info.contextWindow > 0
+        ? `${Math.round(info.contextWindow / 1000).toLocaleString()}k`
+        : '?';
+    const outStr = info.maxOutputTokens
+        ? `${Math.round(info.maxOutputTokens / 1000).toLocaleString()}k`
+        : '?';
+    lines.push(`{bold}Context window:{/}  ${ctxStr} tokens`);
+    lines.push(`{bold}Max output:{/}       ${outStr} tokens`);
+
+    // Pricing
+    if (info.pricing) {
+        const inP = `$${info.pricing.inputPerM.toFixed(2)}`;
+        const outP = `$${info.pricing.outputPerM.toFixed(2)}`;
+        let priceLine = `{bold}Pricing:{/}          ${inP} / ${outP} in/out per 1M tokens`;
+        if (info.pricing.cachedInputPerM != null) {
+            priceLine += `  cached $${info.pricing.cachedInputPerM.toFixed(2)}`;
+        }
+        if (info.pricing.reasoningPerM != null) {
+            priceLine += `  reasoning $${info.pricing.reasoningPerM.toFixed(2)}`;
+        }
+        lines.push(priceLine);
+    }
+
+    lines.push('');
+    lines.push('{bold}Capabilities:{/}');
+
+    // Reasoning
+    if (c.reasoning) {
+        const fieldInfo = c.reasoningField ? ` (delta: ${c.reasoningField})` : '';
+        lines.push(`  ✓ Reasoning${fieldInfo}`);
+    } else {
+        lines.push(`  ✗ Reasoning`);
+    }
+
+    // Tool calling
+    lines.push(c.toolCall ? '  ✓ Tool calling' : '  ✗ Tool calling');
+
+    // Temperature
+    lines.push(c.temperature ? '  ✓ Temperature' : '  ✗ Temperature (fixed)');
+
+    // Structured output
+    lines.push(c.structuredOutput ? '  ✓ Structured output' : '  ✗ Structured output');
+
+    // Attachments
+    lines.push(c.attachment ? '  ✓ File attachments' : '  ✗ File attachments');
+
+    // Modalities
+    lines.push(`  Input:  ${c.inputModalities.join(', ')}`);
+    lines.push(`  Output: ${c.outputModalities.join(', ')}`);
+
+    // Open weights
+    if (c.openWeights != null) {
+        lines.push(c.openWeights ? '  ✓ Open weights' : '  ✗ Open weights');
+    }
+
+    // Knowledge cutoff
+    if (c.knowledge) {
+        lines.push(`{bold}Knowledge:{/}        ${c.knowledge}`);
+    }
+
+    // Release date
+    if (c.releaseDate) {
+        lines.push(`{bold}Released:{/}         ${c.releaseDate}`);
+    }
+
+    return lines.join('\n');
+}

--- a/src/AI/shared/data/providers.ts
+++ b/src/AI/shared/data/providers.ts
@@ -13,6 +13,8 @@
 import * as keys from '@/AI/AIChat/data/keys';
 
 export const SUPPORTED_PROVIDERS = [
+    'crof',
+    'oxlo',
     'deep-infra',
     'open-code',
     'deep-seek',
@@ -40,6 +42,10 @@ export function getProviderBaseURL(provider: string): string {
             return 'https://api.openai.com/v1';
         case 'mistral':
             return 'https://api.mistral.ai/v1';
+        case 'oxlo':
+            return 'https://api.oxlo.ai/v1';
+        case 'crof':
+            return 'https://crof.ai/v1/';
         default:
             throw new Error(`Provider '${provider}' has no configured baseURL.`);
     }
@@ -59,6 +65,10 @@ export function getProviderApiKey(provider: string): string {
             return keys.getMistralKey();
         case 'open-code':
             return keys.getOpenCodeKey();
+        case 'oxlo':
+            return keys.getOxloKey();
+        case 'crof':
+            return keys.getCrofKey();
         case 'open-ai': {
             const fromEnv = process.env['OPENAI_API_KEY'];
 

--- a/src/packagePaths.ts
+++ b/src/packagePaths.ts
@@ -60,6 +60,7 @@ export const autosaveJsPath = assetPath('dest', 'automationScripts', 'autosave',
 
 // Compiled docs coordinator entry point
 export const docsCoordinatorJsPath = assetPath('dest', 'src', 'AI', 'AIAgent', 'shared', 'docs', 'coordinator.js');
+export const docsLiveProgressJsPath = assetPath('dest', 'src', 'AI', 'AIAgent', 'shared', 'docs', 'liveProgressCli.js');
 
 // Python worker that wraps Crawl4AI (shipped as raw .py)
 export const docsPythonWorkerPath = path.join(automationScriptsDir, 'python', 'kra_docs_worker.py');


### PR DESCRIPTION
… new providers, and docs progress improvements

Add `copf` (crof.ai) and `oxlo` as new BYOK provider entries.

Introduce ModelCapabilities/ParamDescriptor system for per-model metadata (reasoning, tool calling, temperature, structured output, attachments, supported params) sourced from models.dev and surfaced in the model picker.

Add dynamic parameter picker UI (enum, number, boolean) driven by ModelCapabilities.supportedParams, replacing hardcoded per-param logic.

Add text-based tool call extraction (<|tool_call_begin|> tokens and plain-text fallback) to both the BYOK agent session and legacy chat flow.

Overhaul BYOK session: progressive param stripping on 400 errors, buffered/non-streaming detection with persisted overrides, reasoning content extraction from delta fields, tool call index collision handling, and new event types (ParamStrippedEvent, StreamingBehaviorDetectedEvent).

Thread capabilities, reasoningEffort, temperature, and dynamicParams from orchestrator pick through to agent sessions; exclude confirm_task_complete for BYOK agents.

Launch docs crawl progress overlay as a managed child process; atomic coordinator status file writes; resilient readSnapshot with last-good cache.

Fix optional chaining bug in memory registry; add isSubAgent flag to sub-agent sessions; new prompt_action event handler.