### PR TITLE
feat: multi-repo semantic search

### DIFF
--- a/src/AI/AIAgent/commands/memory/sections/indexedRepos.ts
+++ b/src/AI/AIAgent/commands/memory/sections/indexedRepos.ts
@@ -8,6 +8,7 @@ import {
     type RegistryEntry,
 } from '@/AI/AIAgent/shared/memory/registry';
 import { computeRepoKey } from '@/AI/AIAgent/shared/memory/repoKey';
+import { loadGroups, setActiveGroup } from '@/AI/AIAgent/shared/memory/groups';
 import { kraMemoryRepoRoot } from '@/filePaths';
 import { inspectCurrentCodeIndex, runCurrentCodeIndex } from '@/AI/AIAgent/commands/indexCodebase';
 import {
@@ -79,9 +80,14 @@ export function mountIndexedReposSection(opts: {
     });
 
     let state: RepoState = { repos: [], repoFiles: {} };
+    // Multi-repo search group state. `selected` is the in-UI checkbox set
+    // (repoKeys); `active` is what's persisted in groups.json and used by
+    // new agent sessions for cross-repo semantic search.
+    const selected: Set<string> = new Set();
+    const active: Set<string> = new Set();
 
     function keymapText(): string {
-        return '{cyan-fg}enter{/cyan-fg} actions · {cyan-fg}i{/cyan-fg} re-index · {cyan-fg}d{/cyan-fg} drop · {cyan-fg}R{/cyan-fg} reset baseline · {cyan-fg}r{/cyan-fg} reload';
+        return '{cyan-fg}enter{/cyan-fg} actions · {cyan-fg}space{/cyan-fg} toggle · {cyan-fg}a{/cyan-fg} apply group · {cyan-fg}c{/cyan-fg} clear · {cyan-fg}i{/cyan-fg} re-index · {cyan-fg}d{/cyan-fg} drop · {cyan-fg}r{/cyan-fg} reload';
     }
 
     function flash(text: string, color = 'green'): void {
@@ -125,6 +131,14 @@ export function mountIndexedReposSection(opts: {
         }
 
         state = { repos, repoFiles };
+
+        const groups = await loadGroups();
+        active.clear();
+        for (const k of groups.active) active.add(k);
+        // Seed selection from active so the user sees the current group.
+        if (selected.size === 0) {
+            for (const k of groups.active) selected.add(k);
+        }
     }
 
     function selectedRepo(): RepoRow | undefined {
@@ -134,9 +148,21 @@ export function mountIndexedReposSection(opts: {
     }
 
     function renderList(): void {
-        const items = state.repos.map((r) => ` {cyan-fg}❑{/cyan-fg} {white-fg}${escTag(r.entry.alias)}{/white-fg} {gray-fg}· ${r.entry.chunksCount} chunks{/gray-fg}`);
+        const items = state.repos.map((r) => {
+            const isSelected = selected.has(r.entry.repoKey);
+            const isActive = active.has(r.entry.repoKey);
+            const marker = isActive
+                ? '{green-fg}[✓]{/green-fg}'
+                : isSelected
+                    ? '{yellow-fg}[+]{/yellow-fg}'
+                    : '{gray-fg}[ ]{/gray-fg}';
+
+            return ` ${marker} {cyan-fg}❑{/cyan-fg} {white-fg}${escTag(r.entry.alias)}{/white-fg} {gray-fg}· ${r.entry.chunksCount} chunks{/gray-fg}`;
+        });
+        const prevIdx = (list as unknown as { selected?: number }).selected ?? 0;
         list.setItems(items);
-        list.select(0);
+        const safeIdx = Math.max(0, Math.min(state.repos.length - 1, prevIdx));
+        list.select(safeIdx);
         refreshPanels();
         screen.render();
     }
@@ -151,18 +177,37 @@ export function mountIndexedReposSection(opts: {
     }
 
     function renderDetails(row?: RepoRow): string {
-        if (!row) return '{gray-fg}(no indexed repositories){/gray-fg}';
+        const activeAliases = state.repos
+            .filter((r) => active.has(r.entry.repoKey))
+            .map((r) => r.entry.alias);
+        const activeLine = activeAliases.length > 0
+            ? `{green-fg}active group ({/green-fg}{cyan-fg}${activeAliases.length}{/cyan-fg}{green-fg}){/green-fg} ${escTag(activeAliases.join(', '))}`
+            : '{gray-fg}active group: (none) — single-repo mode{/gray-fg}';
+        const selectedExtras = state.repos
+            .filter((r) => selected.has(r.entry.repoKey) && !active.has(r.entry.repoKey))
+            .map((r) => r.entry.alias);
+        const selectionLine = selectedExtras.length > 0
+            ? `{yellow-fg}pending selection +${selectedExtras.length}{/yellow-fg} ${escTag(selectedExtras.join(', '))}`
+            : '';
+
+        if (!row) {
+            return [activeLine, selectionLine, '', '{gray-fg}(no indexed repositories){/gray-fg}'].filter(Boolean).join('\n');
+        }
 
         return [
+            activeLine,
+            selectionLine,
+            '',
             `{cyan-fg}alias{/cyan-fg}            ${escTag(row.entry.alias)}`,
             `{cyan-fg}id{/cyan-fg}               ${escTag(row.id)}`,
             `{cyan-fg}rootPath{/cyan-fg}         ${escTag(row.entry.rootPath)}`,
+            `{cyan-fg}repoKey{/cyan-fg}          ${escTag(row.entry.repoKey)}`,
             `{cyan-fg}chunks{/cyan-fg}           ${row.entry.chunksCount}`,
             `{cyan-fg}lastIndexed{/cyan-fg}      ${row.entry.lastIndexedAt ? new Date(row.entry.lastIndexedAt).toISOString() : '(never)'}`,
             `{cyan-fg}lastCommit{/cyan-fg}       ${escTag(row.entry.lastIndexedCommit || '(none)')}`,
             '',
-            '{gray-fg}enter actions · i re-index · d drop · R reset baseline{/gray-fg}',
-        ].join('\n');
+            '{gray-fg}space toggle · a apply selection as active group · c clear selection{/gray-fg}',
+        ].filter((line) => line !== '').join('\n');
     }
 
     function renderFiles(row?: RepoRow): string {
@@ -366,6 +411,38 @@ export function mountIndexedReposSection(opts: {
         await reload();
         flash('reloaded');
         list.focus();
+    });
+
+    list.key(['space'], () => {
+        const row = selectedRepo();
+        if (!row) return;
+        const key = row.entry.repoKey;
+        if (selected.has(key)) {
+            selected.delete(key);
+        } else {
+            selected.add(key);
+        }
+        renderList();
+        flash(`${selected.size} selected`, 'yellow');
+    });
+
+    list.key(['a'], async () => {
+        const keys = state.repos
+            .map((r) => r.entry.repoKey)
+            .filter((k) => selected.has(k));
+        await setActiveGroup(keys);
+        active.clear();
+        for (const k of keys) active.add(k);
+        renderList();
+        flash(keys.length === 0
+            ? 'cleared active group (single-repo mode)'
+            : `active group set: ${keys.length} repo${keys.length === 1 ? '' : 's'}`);
+    });
+
+    list.key(['c'], () => {
+        selected.clear();
+        renderList();
+        flash('selection cleared', 'yellow');
     });
 
     void reload().then(() => {

--- a/src/AI/AIAgent/providers/byok/mcpClientPool.ts
+++ b/src/AI/AIAgent/providers/byok/mcpClientPool.ts
@@ -17,6 +17,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
 import { matchesSubAgentWhitelist } from '@/AI/AIAgent/shared/subAgents/whitelist';
+import { getActiveSearchRepoKeys } from '@/AI/AIAgent/shared/memory/groups';
 
 export interface RegisteredTool {
     server: string;
@@ -63,6 +64,12 @@ export async function buildMcpClientPool(options: BuildPoolOptions): Promise<Mcp
     const excluded = new Set(options.excludedTools ?? []);
     const allowedSet = options.allowedTools ? new Set(options.allowedTools) : null;
 
+    // Resolve the active multi-repo search group once per pool build so each
+    // spawned MCP server inherits the same set. Empty list ⇒ single-repo mode
+    // (memoryMcpServer falls back to WORKING_DIR's repo on its own).
+    const activeRepoKeys = await getActiveSearchRepoKeys();
+    const searchRepoKeysEnv = activeRepoKeys.length > 0 ? activeRepoKeys.join(',') : '';
+
     for (const [serverName, config] of Object.entries(options.servers)) {
         if (config.type !== 'local' && config.type !== 'stdio') {
             continue;
@@ -74,6 +81,7 @@ export async function buildMcpClientPool(options: BuildPoolOptions): Promise<Mcp
             ),
             ...(config.env ?? {}),
             WORKING_DIR: options.workingDirectory,
+            ...(searchRepoKeysEnv ? { KRA_SEARCH_REPO_KEYS: searchRepoKeysEnv } : {}),
         };
 
         const transport = new StdioClientTransport({

--- a/src/AI/AIAgent/shared/memory/db.ts
+++ b/src/AI/AIAgent/shared/memory/db.ts
@@ -17,53 +17,68 @@ import path from 'path';
 import { connect, type Connection, type Table } from '@lancedb/lancedb';
 import type { CodeChunkRow, MemoryRow } from './types';
 import type { DocChunkRow } from '../docs/types';
-import { _resetRepoStorageCacheForTest, resolveRepoStorage } from './repoKey';
+import { _resetRepoStorageCacheForTest, resolveRepoStorage, repoStorageDirForKey } from './repoKey';
 import { kraDocsLanceRoot, kraDocsRoot } from '@/filePaths';
 
 const MEMORY_FINDINGS_TABLE = 'memory_findings';
 const MEMORY_REVISITS_TABLE = 'memory_revisits';
 
-let dbCache: Connection | null = null;
+// Per-process caches keyed by repoKey so a single process can hold open
+// connections / tables for several repos simultaneously (multi-repo search).
+const dbCache: Map<string, Connection> = new Map();
 let docsDbCache: Connection | null = null;
 let memoryFindingsTableCache: Table | null = null;
 let memoryRevisitsTableCache: Table | null = null;
-let codeChunksTableCache: Table | null = null;
+const codeChunksTableCache: Map<string, Table> = new Map();
 let docChunksTableCache: Table | null = null;
+const legacyDropAttemptedKeys: Set<string> = new Set();
 
 const CODE_CHUNKS_TABLE = 'code_chunks';
 const DOC_CHUNKS_TABLE = 'doc_chunks';
 const LEGACY_MEMORY_TABLE = 'memory';
-let legacyDropAttempted = false;
 
-async function memoryRoot(): Promise<string> {
+async function memoryRoot(repoKey?: string): Promise<string> {
+    if (repoKey) {
+        return repoStorageDirForKey(repoKey);
+    }
     const info = await resolveRepoStorage();
 
     return info.repoStorageDir;
 }
 
-async function lanceRoot(): Promise<string> {
-    return path.join(await memoryRoot(), 'lance');
+async function lanceRoot(repoKey?: string): Promise<string> {
+    return path.join(await memoryRoot(repoKey), 'lance');
 }
 
-async function getDb(): Promise<Connection> {
-    if (dbCache) {
-        return dbCache;
+async function resolveRepoKey(repoKey?: string): Promise<string> {
+    if (repoKey) return repoKey;
+    const info = await resolveRepoStorage();
+
+    return info.repoKey;
+}
+
+async function getDb(repoKey?: string): Promise<Connection> {
+    const key = await resolveRepoKey(repoKey);
+    const cached = dbCache.get(key);
+    if (cached) {
+        return cached;
     }
 
-    dbCache = await connect(await lanceRoot());
-    if (!legacyDropAttempted) {
-        legacyDropAttempted = true;
+    const conn = await connect(await lanceRoot(key));
+    dbCache.set(key, conn);
+    if (!legacyDropAttemptedKeys.has(key)) {
+        legacyDropAttemptedKeys.add(key);
         try {
-            const names = await dbCache.tableNames();
+            const names = await conn.tableNames();
             if (names.includes(LEGACY_MEMORY_TABLE)) {
-                await dbCache.dropTable(LEGACY_MEMORY_TABLE);
+                await conn.dropTable(LEGACY_MEMORY_TABLE);
             }
         } catch {
             // best-effort cleanup; ignore failures
         }
     }
 
-    return dbCache;
+    return conn;
 }
 
 async function getDocsDb(): Promise<Connection> {
@@ -147,13 +162,13 @@ export async function getRevisitsTable(seedRow: MemoryRow | null): Promise<GetMe
  * Test-only reset of the in-process cache. Not exported via index.
  */
 export function _resetCachesForTest(): void {
-    dbCache = null;
+    dbCache.clear();
     docsDbCache = null;
     memoryFindingsTableCache = null;
     memoryRevisitsTableCache = null;
-    codeChunksTableCache = null;
+    codeChunksTableCache.clear();
     docChunksTableCache = null;
-    legacyDropAttempted = false;
+    legacyDropAttemptedKeys.clear();
     _resetRepoStorageCacheForTest();
 }
 
@@ -163,8 +178,8 @@ export function _resetCachesForTest(): void {
  * from `WORKING_DIR` (set by the parent process when the MCP server is
  * spawned) or `process.cwd()` for direct calls.
  */
-export async function memoryDirectoryRoot(): Promise<string> {
-    return memoryRoot();
+export async function memoryDirectoryRoot(repoKey?: string): Promise<string> {
+    return memoryRoot(repoKey);
 }
 
 /**
@@ -186,35 +201,40 @@ export interface GetCodeChunksTableResult {
  * table can be created on first use; pass `null` for read-only callers and
  * handle `table === null`.
  */
-export async function getCodeChunksTable(seedRow: CodeChunkRow | null): Promise<GetCodeChunksTableResult> {
-    if (codeChunksTableCache) {
-        return { table: codeChunksTableCache, justCreated: false };
+export async function getCodeChunksTable(seedRow: CodeChunkRow | null, repoKey?: string): Promise<GetCodeChunksTableResult> {
+    const key = await resolveRepoKey(repoKey);
+    const cached = codeChunksTableCache.get(key);
+    if (cached) {
+        return { table: cached, justCreated: false };
     }
 
     const next = mutex.then(async (): Promise<GetCodeChunksTableResult> => {
-        if (codeChunksTableCache) {
-            return { table: codeChunksTableCache, justCreated: false };
+        const cachedInner = codeChunksTableCache.get(key);
+        if (cachedInner) {
+            return { table: cachedInner, justCreated: false };
         }
 
-        const db = await getDb();
+        const db = await getDb(key);
         const tableNames = await db.tableNames();
 
         if (tableNames.includes(CODE_CHUNKS_TABLE)) {
-            codeChunksTableCache = await db.openTable(CODE_CHUNKS_TABLE);
+            const t = await db.openTable(CODE_CHUNKS_TABLE);
+            codeChunksTableCache.set(key, t);
 
-            return { table: codeChunksTableCache, justCreated: false };
+            return { table: t, justCreated: false };
         }
 
         if (!seedRow) {
             return { table: null, justCreated: false };
         }
 
-        codeChunksTableCache = await db.createTable(
+        const t = await db.createTable(
             CODE_CHUNKS_TABLE,
             [seedRow as unknown as Record<string, unknown>],
         );
+        codeChunksTableCache.set(key, t);
 
-        return { table: codeChunksTableCache, justCreated: true };
+        return { table: t, justCreated: true };
     });
 
     mutex = next.catch(() => undefined);

--- a/src/AI/AIAgent/shared/memory/groups.ts
+++ b/src/AI/AIAgent/shared/memory/groups.ts
@@ -1,0 +1,90 @@
+/**
+ * Search-group configuration for the kra-memory layer.
+ *
+ * A "group" is a list of repoKeys whose `code_chunks` indexes should be
+ * searched together by a single agent session. Persisted at
+ * `~/.kra/.kra-memory/groups.json`:
+ *
+ *   {
+ *     "version": 1,
+ *     "active": ["a861e0135e96df54", "d37c083c9d0ddfd2"],
+ *     "saved":  { "tools": ["a861…", "d37c…"] }
+ *   }
+ *
+ * `active` is what new agent sessions pick up by default. `saved` is for
+ * named groups (UI v2). When `active` is empty/missing, callers fall back
+ * to single-repo behavior (the current cwd's repo only).
+ *
+ * The MCP server reads `KRA_SEARCH_REPO_KEYS` (comma-separated) which the
+ * spawning provider derives from this file. The env var wins over the
+ * file when both are set, so a sub-process can be locked to a fixed group.
+ */
+
+import * as fs from 'fs/promises';
+import path from 'path';
+import { kraMemoryRoot } from '@/filePaths';
+
+export interface SearchGroups {
+    version: 1;
+    active: string[];
+    saved: Record<string, string[]>;
+}
+
+const EMPTY_GROUPS: SearchGroups = { version: 1, active: [], saved: {} };
+
+function groupsPath(): string {
+    return path.join(kraMemoryRoot, 'groups.json');
+}
+
+export async function loadGroups(): Promise<SearchGroups> {
+    try {
+        const raw = await fs.readFile(groupsPath(), 'utf8');
+        const parsed = JSON.parse(raw) as { version?: unknown; active?: unknown; saved?: unknown } | null;
+
+        if (typeof parsed !== 'object' || parsed === null || parsed.version !== 1) {
+            return { ...EMPTY_GROUPS, saved: {} };
+        }
+
+        const active = Array.isArray(parsed.active) ? (parsed.active as unknown[]).filter((k): k is string => typeof k === 'string' && k.length > 0) : [];
+        const saved: Record<string, string[]> = {};
+        if (parsed.saved !== null && typeof parsed.saved === 'object') {
+            for (const [name, list] of Object.entries(parsed.saved as Record<string, unknown>)) {
+                if (Array.isArray(list)) {
+                    saved[name] = (list as unknown[]).filter((k): k is string => typeof k === 'string' && k.length > 0);
+                }
+            }
+        }
+
+        return { version: 1, active, saved };
+    } catch {
+        return { ...EMPTY_GROUPS, saved: {} };
+    }
+}
+
+export async function saveGroups(groups: SearchGroups): Promise<void> {
+    await fs.mkdir(kraMemoryRoot, { recursive: true });
+    await fs.writeFile(groupsPath(), `${JSON.stringify(groups, null, 2)}\n`);
+}
+
+export async function setActiveGroup(repoKeys: string[]): Promise<void> {
+    const groups = await loadGroups();
+    const dedup = Array.from(new Set(repoKeys.filter((k) => typeof k === 'string' && k.length > 0)));
+    groups.active = dedup;
+    await saveGroups(groups);
+}
+
+/**
+ * Resolve the active list of repoKeys for the current process.
+ * `KRA_SEARCH_REPO_KEYS` env (comma-separated) wins over groups.json.
+ * Returns [] when neither is set — callers should fall back to single-repo.
+ */
+export async function getActiveSearchRepoKeys(): Promise<string[]> {
+    const env = process.env['KRA_SEARCH_REPO_KEYS'];
+    if (typeof env === 'string' && env.trim().length > 0) {
+        return env.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+    }
+
+    const groups = await loadGroups();
+
+    return groups.active;
+}

--- a/src/AI/AIAgent/shared/memory/search.ts
+++ b/src/AI/AIAgent/shared/memory/search.ts
@@ -5,9 +5,13 @@
  * matching the read_lines tool shape) so the agent knows where to look
  * without us shipping any source code in the response.
  */
+import path from 'path';
 import { embedOne } from './embedder';
 import { getCodeChunksTable, getFindingsTable, getRevisitsTable } from './db';
 import { matchGlob } from './indexer';
+import { getActiveSearchRepoKeys } from './groups';
+import { loadRegistry, type RegistryEntry } from './registry';
+import { resolveRepoStorage } from './repoKey';
 import {
     decodeRow,
     isFindingKind,
@@ -27,6 +31,7 @@ interface RawCodeChunkHit {
     startLine: number;
     endLine: number;
     score: number;
+    repoKey: string;
 }
 
 // Drop low-confidence semantic hits before returning to the caller. Anything
@@ -61,18 +66,32 @@ export async function semanticSearch(input: SemanticSearchInput): Promise<Semant
 }
 
 async function searchCode(vector: number[], k: number, pathGlob?: string): Promise<SemanticSearchHit[]> {
-    const { table } = await getCodeChunksTable(null);
+    const repoKeys = await resolveRepoSearchSet();
+    if (repoKeys.length === 0) return [];
 
-    if (!table) return [];
+    const multiRepo = repoKeys.length > 1;
+    const registry = multiRepo ? await loadRegistry() : null;
+    const repoMeta: Map<string, RegistryEntry | undefined> = new Map();
+    if (registry) {
+        for (const entry of Object.values(registry.repos)) {
+            repoMeta.set(entry.repoKey, entry);
+        }
+    }
 
     // Pull a wide net so deduping by path still leaves us with k distinct files.
     // Files commonly own multiple matching chunks; an unfiltered fetch of `k`
     // would routinely yield <k unique paths after grouping.
     const fetchK = Math.min(Math.max(k * 8, 40), 400);
-    const rows = await table.search(vector).limit(fetchK).toArray();
 
-    const rawHits: RawCodeChunkHit[] = rows
-        .map(toRawCodeHit)
+    const perRepoHits = await Promise.all(repoKeys.map(async (repoKey): Promise<RawCodeChunkHit[]> => {
+        const { table } = await getCodeChunksTable(null, repoKey);
+        if (!table) return [];
+        const rows = await table.search(vector).limit(fetchK).toArray();
+
+        return rows.map((row) => toRawCodeHit(row, repoKey));
+    }));
+
+    const rawHits: RawCodeChunkHit[] = perRepoHits.flat()
         .filter((hit) => !pathGlob || matchGlob(hit.path, pathGlob));
 
     const grouped = groupByPath(rawHits);
@@ -82,16 +101,35 @@ async function searchCode(vector: number[], k: number, pathGlob?: string): Promi
 
     return Promise.all(topPaths.map(async (group) => {
         const merged = mergeRanges(group.ranges);
+        const meta = repoMeta.get(group.repoKey);
+        const absolutePath = multiRepo && meta?.rootPath
+            ? path.isAbsolute(group.path) ? group.path : path.join(meta.rootPath, group.path)
+            : group.path;
         const code: CodeFileHitData = {
-            path: group.path,
+            path: absolutePath,
             language: group.language,
             lineCount: 0,
             startLines: merged.map((r) => r.start),
             endLines: merged.map((r) => r.end),
+            ...(multiRepo && meta ? { repo: meta.alias, rootPath: meta.rootPath } : {}),
         };
 
         return { type: 'code', score: group.score, code } satisfies SemanticSearchHit;
     }));
+}
+
+async function resolveRepoSearchSet(): Promise<string[]> {
+    const active = await getActiveSearchRepoKeys();
+    if (active.length > 0) return active;
+
+    // Default: just the current repo (preserves single-repo behavior).
+    try {
+        const info = await resolveRepoStorage();
+
+        return [info.repoKey];
+    } catch {
+        return [];
+    }
 }
 
 async function searchMemory(vector: number[], k: number, kind: MemoryLookupKind, selectedIds?: string[]): Promise<SemanticSearchHit[]> {
@@ -125,7 +163,7 @@ async function searchMemory(vector: number[], k: number, kind: MemoryLookupKind,
         .slice(0, k);
 }
 
-function toRawCodeHit(raw: Record<string, unknown>): RawCodeChunkHit {
+function toRawCodeHit(raw: Record<string, unknown>, repoKey: string): RawCodeChunkHit {
     const row = raw as unknown as CodeChunkRow & { _distance?: number };
 
     return {
@@ -134,6 +172,7 @@ function toRawCodeHit(raw: Record<string, unknown>): RawCodeChunkHit {
         startLine: row.startLine,
         endLine: row.endLine,
         score: distanceToScore(row._distance),
+        repoKey,
     };
 }
 
@@ -142,21 +181,24 @@ interface PathGroup {
     language: string;
     score: number;
     ranges: { start: number; end: number }[];
+    repoKey: string;
 }
 
 function groupByPath(hits: RawCodeChunkHit[]): Map<string, PathGroup> {
     const groups = new Map<string, PathGroup>();
     for (const hit of hits) {
-        const existing = groups.get(hit.path);
+        const groupKey = `${hit.repoKey}::${hit.path}`;
+        const existing = groups.get(groupKey);
         if (existing) {
             existing.ranges.push({ start: hit.startLine, end: hit.endLine });
             if (hit.score > existing.score) existing.score = hit.score;
         } else {
-            groups.set(hit.path, {
+            groups.set(groupKey, {
                 path: hit.path,
                 language: hit.language,
                 score: hit.score,
                 ranges: [{ start: hit.startLine, end: hit.endLine }],
+                repoKey: hit.repoKey,
             });
         }
     }

--- a/src/AI/AIAgent/shared/memory/types.ts
+++ b/src/AI/AIAgent/shared/memory/types.ts
@@ -173,6 +173,11 @@ export interface CodeFileHitData {
     endLines: number[];
     outline?: SemanticOutlineEntry[];
     outlineAccurate?: boolean;
+    // Set only when fan-out across multiple repos is active. `repo` is the
+    // registry alias and `rootPath` the absolute repo top-level so the
+    // agent can resolve `path` against the right working tree.
+    repo?: string;
+    rootPath?: string;
 }
 
 export interface SemanticSearchInput {


### PR DESCRIPTION
Search across multiple registered repos in one agent session instead of just the cwd's repo.

New groups.ts persists an active repo set in ~/.kra/.kra-memory/groups.json searchCode fans out vector queries across the active repos in parallel and tags hits with repo + absolute path (single-repo path unchanged) mcpClientPool injects KRA_SEARCH_REPO_KEYS into the spawned MCP server `kra memory` Indexed-repos tab gets multi-select: space/a/c

Backwards compatible: empty active set ⇒ today's single-repo behavior.