### PR TITLE
feat: hybrid retrieval

### DIFF
--- a/__tests__/AI/AIAgent/docsSearch.test.ts
+++ b/__tests__/AI/AIAgent/docsSearch.test.ts
@@ -47,11 +47,14 @@ function row(overrides: Partial<MockRow>): MockRow {
 }
 
 function mockTable(rows: MockRow[]): void {
-    const search = jest.fn().mockReturnValue({
+    // Vector search returns the seeded rows; FTS search (string query) returns
+    // empty so the unit tests exercise the vector-only path and the score
+    // assertions remain meaningful.
+    const search = jest.fn().mockImplementation((query: unknown) => ({
         limit: jest.fn().mockReturnValue({
-            toArray: jest.fn().mockResolvedValue(rows),
+            toArray: jest.fn().mockResolvedValue(typeof query === 'string' ? [] : rows),
         }),
-    });
+    }));
     mockedGetDocChunksTable.mockResolvedValue({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         table: { search } as any,

--- a/docs/agent/docs-crawling.md
+++ b/docs/agent/docs-crawling.md
@@ -186,9 +186,11 @@ page.
 ## Querying from the agent
 
 The `kra-memory` MCP server exposes a `docs_search(query, k?, sourceAlias?)` tool
-backed by `src/AI/AIAgent/shared/docs/search.ts`. It vector-searches the
-`doc_chunks` table, dedupes hits per `(sourceAlias, url)` page, and returns up
-to 3 best-scoring sections per page with the markdown content inlined (capped
+backed by `src/AI/AIAgent/shared/docs/search.ts`. It runs hybrid retrieval
+on the `doc_chunks` table (vector + full-text fused via RRF — see
+[Hybrid retrieval](memory-and-indexing.md#hybrid-retrieval-vector--fts)),
+dedupes hits per `(sourceAlias, url)` page, and returns up to 3
+best-scoring sections per page with the markdown content inlined (capped
 at 1200 characters per section, flagged with `truncated: true` when cut).
 Default `k = 8`, hard cap 50.
 

--- a/docs/agent/memory-and-indexing.md
+++ b/docs/agent/memory-and-indexing.md
@@ -79,3 +79,52 @@ Index implementation highlights:
 - Chunking by fixed line windows + overlap
 - Content-hash chunk IDs to avoid re-embedding unchanged chunks
 - Stored in `<repo>/.kra-memory/lance/code_chunks.lance/`
+
+## Multi-repo search (active repo group)
+
+`semantic_search` (code scope) can fan out across multiple indexed repos in
+a single session, not just the current one.
+
+- Active set lives in `~/.kra-memory/groups.json` (`active: ["<repoKey>", …]`).
+- Selected via `kra memory → Indexed repos`: `space` toggles a repo, `a`
+  saves the selection as the active group. Selection state is rendered
+  next to each row.
+- The MCP launcher injects the resolved keys as
+  `KRA_SEARCH_REPO_KEYS=key1,key2,…` into the memory server.
+- `searchCode` resolves the active set, opens each repo's `code_chunks`
+  table (cached per `repoKey`), runs hybrid retrieval per repo in
+  parallel, then groups results by `<repoKey>::<path>`.
+- Cross-repo hits are emitted with the repo's alias and an absolute
+  `path` so `read_lines` works regardless of which repo is on disk.
+- Falls back to single-repo mode when the active set is empty (current
+  repo only, relative paths — unchanged from before).
+
+Findings/revisits remain per-repo — only the code index is shared across
+the active group.
+
+## Hybrid retrieval (vector + FTS)
+
+Both code and docs search use Reciprocal Rank Fusion to combine semantic
+(vector) and lexical (full-text) rankings:
+
+1. Run vector search and FTS in parallel (`fetchK` candidates each).
+2. Fuse with RRF (`k = 60`); normalize scores to `[0, 1]` so they remain
+   comparable to the cosine scores returned by memory search when
+   `scope = 'both'`.
+3. Vector-only candidates below `MIN_SCORE` are dropped; any hit that
+   surfaced via FTS survives regardless (a keyword match is its own
+   evidence).
+4. When FTS returns nothing (index missing, query parser rejected the
+   text, or no lexical matches), fall back to pure cosine scoring so
+   score magnitudes are preserved.
+
+The FTS index on `content` is created lazily on the first table open
+after the upgrade for both `code_chunks` and `doc_chunks`. Errors are
+swallowed — search transparently falls back to vector-only when the
+index is unavailable.
+
+Free-form queries are sanitized (operator characters stripped) before
+being handed to the LanceDB FTS parser, so code-y queries can't crash
+the parser.
+
+Shared implementation: `src/AI/AIAgent/shared/memory/hybridSearch.ts`.

--- a/src/AI/AIAgent/shared/docs/search.ts
+++ b/src/AI/AIAgent/shared/docs/search.ts
@@ -9,6 +9,7 @@
  */
 import { embedOne } from '../memory/embedder';
 import { getDocChunksTable } from '../memory/db';
+import { hybridSearch } from '../memory/hybridSearch';
 import type { DocChunkRow } from './types';
 
 const MIN_SCORE = 0.5;
@@ -57,13 +58,15 @@ export async function docsSearch(input: DocsSearchInput): Promise<DocsSearchHit[
     const queryVector = await embedOne(input.query);
 
     const fetchK = Math.min(Math.max(k * 8, 40), 400);
-    const rows = (await table.search(queryVector).limit(fetchK).toArray()) as Array<DocChunkRow & { _distance?: number }>;
+    const fused = await hybridSearch(table, input.query, queryVector, {
+        fetchK,
+        minVectorScore: MIN_SCORE,
+    });
 
     const aliasFilter = input.sourceAlias?.trim();
 
-    const raw: RawDocHit[] = rows
-        .map((row) => ({ row, score: distanceToScore(row._distance) }))
-        .filter((hit) => hit.score >= MIN_SCORE)
+    const raw: RawDocHit[] = fused
+        .map((hit) => ({ row: hit.row as unknown as DocChunkRow, score: hit.score }))
         .filter((hit) => !aliasFilter || hit.row.sourceAlias === aliasFilter);
 
     const grouped = groupByPage(raw);
@@ -130,13 +133,6 @@ function buildSection(hit: RawDocHit): DocsSearchSection {
         truncated,
         tokenCount: hit.row.tokenCount,
     };
-}
-
-function distanceToScore(distance: number | undefined): number {
-    if (typeof distance !== 'number' || Number.isNaN(distance)) return 0;
-    if (distance <= 0) return 1;
-
-    return 1 / (1 + distance);
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/src/AI/AIAgent/shared/memory/db.ts
+++ b/src/AI/AIAgent/shared/memory/db.ts
@@ -15,6 +15,7 @@
 
 import path from 'path';
 import { connect, type Connection, type Table } from '@lancedb/lancedb';
+import { ensureContentFtsIndex } from './hybridSearch';
 import type { CodeChunkRow, MemoryRow } from './types';
 import type { DocChunkRow } from '../docs/types';
 import { _resetRepoStorageCacheForTest, resolveRepoStorage, repoStorageDirForKey } from './repoKey';
@@ -30,6 +31,9 @@ let docsDbCache: Connection | null = null;
 let memoryFindingsTableCache: Table | null = null;
 let memoryRevisitsTableCache: Table | null = null;
 const codeChunksTableCache: Map<string, Table> = new Map();
+const codeFtsEnsuredKeys: Set<string> = new Set();
+const docFtsEnsuredKeys: Set<string> = new Set();
+const DOC_FTS_KEY = 'doc_chunks';
 let docChunksTableCache: Table | null = null;
 const legacyDropAttemptedKeys: Set<string> = new Set();
 
@@ -167,6 +171,8 @@ export function _resetCachesForTest(): void {
     memoryFindingsTableCache = null;
     memoryRevisitsTableCache = null;
     codeChunksTableCache.clear();
+    codeFtsEnsuredKeys.clear();
+    docFtsEnsuredKeys.clear();
     docChunksTableCache = null;
     legacyDropAttemptedKeys.clear();
     _resetRepoStorageCacheForTest();
@@ -190,6 +196,7 @@ export async function memoryDirectoryRoot(repoKey?: string): Promise<string> {
 export function docsDirectoryRoot(): string {
     return kraDocsRoot;
 }
+
 
 export interface GetCodeChunksTableResult {
     table: Table | null;
@@ -220,6 +227,7 @@ export async function getCodeChunksTable(seedRow: CodeChunkRow | null, repoKey?:
         if (tableNames.includes(CODE_CHUNKS_TABLE)) {
             const t = await db.openTable(CODE_CHUNKS_TABLE);
             codeChunksTableCache.set(key, t);
+void ensureContentFtsIndex(t, key, codeFtsEnsuredKeys);
 
             return { table: t, justCreated: false };
         }
@@ -233,6 +241,7 @@ export async function getCodeChunksTable(seedRow: CodeChunkRow | null, repoKey?:
             [seedRow as unknown as Record<string, unknown>],
         );
         codeChunksTableCache.set(key, t);
+void ensureContentFtsIndex(t, key, codeFtsEnsuredKeys);
 
         return { table: t, justCreated: true };
     });
@@ -285,6 +294,7 @@ export async function getDocChunksTable(seedRow: DocChunkRow | null): Promise<Ge
 
         if (tableNames.includes(DOC_CHUNKS_TABLE)) {
             docChunksTableCache = await db.openTable(DOC_CHUNKS_TABLE);
+            void ensureContentFtsIndex(docChunksTableCache, DOC_FTS_KEY, docFtsEnsuredKeys);
 
             return { table: docChunksTableCache, justCreated: false };
         }
@@ -297,6 +307,7 @@ export async function getDocChunksTable(seedRow: DocChunkRow | null): Promise<Ge
             DOC_CHUNKS_TABLE,
             [seedRow as unknown as Record<string, unknown>],
         );
+        void ensureContentFtsIndex(docChunksTableCache, DOC_FTS_KEY, docFtsEnsuredKeys);
 
         return { table: docChunksTableCache, justCreated: true };
     });
@@ -321,3 +332,6 @@ export async function countDocChunks(): Promise<number> {
         return 0;
     }
 }
+
+
+

--- a/src/AI/AIAgent/shared/memory/hybridSearch.ts
+++ b/src/AI/AIAgent/shared/memory/hybridSearch.ts
@@ -1,0 +1,193 @@
+/**
+ * Hybrid (vector + full-text) retrieval for any LanceDB table whose schema
+ * has an `id: string` primary key, a `content: string` column, and a
+ * vector column compatible with the query vector.
+ *
+ * Both `code_chunks` (per-repo, used by semantic_search) and `doc_chunks`
+ * (global, used by docs_search) share this exact retrieval shape. The
+ * caller is responsible for grouping/formatting the results.
+ *
+ * Algorithm:
+ *   1. Run vector search and FTS in parallel (fetchK candidates each).
+ *   2. Fuse the two rankings with Reciprocal Rank Fusion (k = RRF_K).
+ *   3. Drop vector-only candidates whose cosine score is below
+ *      `minVectorScore` (a hit that survived FTS is kept regardless).
+ *   4. Normalize the RRF scores to [0, 1] so they remain comparable to the
+ *      cosine scores produced by other code paths.
+ *
+ * If the FTS index does not exist yet (created lazily on first table open),
+ * or the FTS query parser rejects the input, the function transparently
+ * falls back to vector-only.
+ */
+
+import { Index, type Table } from '@lancedb/lancedb';
+
+// Reciprocal Rank Fusion constant. 60 is the value from the original
+// Cormack et al. paper and the de-facto default in Elasticsearch / Vespa.
+const RRF_K = 60;
+
+export interface HybridSearchOptions {
+    /**
+     * Maximum number of candidates to pull from each ranking before
+     * fusion. The caller typically sets this to 8x the requested k so
+     * downstream grouping/dedup still leaves enough distinct entries.
+     */
+    fetchK: number;
+    /**
+     * Minimum cosine similarity for a vector-only candidate to be kept.
+     * Hits that also appear in the FTS ranking bypass this threshold.
+     */
+    minVectorScore: number;
+}
+
+export interface HybridSearchHit {
+    /** The raw LanceDB row (caller casts to its row type). */
+    row: Record<string, unknown>;
+    /** Normalized fusion score in [0, 1]. */
+    score: number;
+}
+
+/**
+ * Run a hybrid vector + FTS search on the given table and return rows
+ * fused by RRF, sorted high-to-low by normalized score.
+ */
+export async function hybridSearch(
+    table: Table,
+    queryText: string,
+    queryVector: number[],
+    opts: HybridSearchOptions,
+): Promise<HybridSearchHit[]> {
+    const ftsQuery = sanitizeFtsQuery(queryText);
+
+    const [vectorRows, ftsRows] = await Promise.all([
+        table.search(queryVector).limit(opts.fetchK).toArray(),
+        ftsQuery
+            ? table.search(ftsQuery, 'fts', 'content').limit(opts.fetchK).toArray().catch(() => [])
+            : Promise.resolve([] as Record<string, unknown>[]),
+    ]);
+
+    // When FTS returned nothing (index missing, parser rejected the query,
+    // or the corpus has no lexical matches), fall back to pure cosine scoring.
+    // RRF without a second ranking would just throw away score magnitudes.
+    if (ftsRows.length === 0) {
+        const out: HybridSearchHit[] = [];
+        for (const row of vectorRows) {
+            const r: Record<string, unknown> = row;
+            const score = distanceToScore((r as { _distance?: number })._distance);
+            if (score < opts.minVectorScore) continue;
+            out.push({ row: r, score });
+        }
+        out.sort((a, b) => b.score - a.score);
+
+        return out;
+    }
+
+    const fused = fuseRankings(vectorRows, ftsRows, opts.minVectorScore);
+
+    fused.sort((a, b) => b.score - a.score);
+
+    const max = fused.reduce((m, h) => Math.max(m, h.score), 0);
+    if (max <= 0) return fused;
+
+    const norm = 1 / max;
+    for (const h of fused) h.score *= norm;
+
+    return fused;
+}
+
+/**
+ * Best-effort: ensure an FTS index exists on the `content` column of the
+ * given table. Idempotent across process lifetime via the supplied
+ * `ensuredKeys` set (callers track this per-table). Errors are swallowed
+ * so hybrid search transparently falls back to vector-only when the index
+ * is unavailable.
+ */
+export async function ensureContentFtsIndex(
+    table: Table,
+    cacheKey: string,
+    ensuredKeys: Set<string>,
+): Promise<void> {
+    if (ensuredKeys.has(cacheKey)) return;
+    ensuredKeys.add(cacheKey);
+    try {
+        const indices = await table.listIndices();
+        const hasFts = indices.some(
+            (i) => i.indexType.toLowerCase().includes('fts') && i.columns.includes('content'),
+        );
+        if (hasFts) return;
+        await table.createIndex('content', { config: Index.fts({ withPosition: false }) });
+    } catch {
+        ensuredKeys.delete(cacheKey);
+    }
+}
+
+/**
+ * Convert a LanceDB L2 distance to a similarity in [0, 1] via 1/(1+d).
+ * Monotonic so sort order is preserved.
+ */
+export function distanceToScore(distance: number | undefined): number {
+    if (typeof distance !== 'number' || !Number.isFinite(distance)) return 0;
+    if (distance <= 0) return 1;
+
+    return 1 / (1 + distance);
+}
+
+interface FuseEntry {
+    row: Record<string, unknown>;
+    vRank?: number;
+    fRank?: number;
+    vScore?: number;
+}
+
+function fuseRankings(
+    vectorRows: Record<string, unknown>[],
+    ftsRows: Record<string, unknown>[],
+    minVectorScore: number,
+): HybridSearchHit[] {
+    const byId = new Map<string, FuseEntry>();
+
+    vectorRows.forEach((row, idx) => {
+        const id = String((row as { id?: unknown }).id ?? '');
+        if (!id) return;
+        const score = distanceToScore((row as { _distance?: number })._distance);
+        byId.set(id, { row, vRank: idx, vScore: score });
+    });
+
+    ftsRows.forEach((row, idx) => {
+        const id = String((row as { id?: unknown }).id ?? '');
+        if (!id) return;
+        const existing = byId.get(id);
+        if (existing) {
+            existing.fRank = idx;
+        } else {
+            byId.set(id, { row, fRank: idx });
+        }
+    });
+
+    const out: HybridSearchHit[] = [];
+    for (const entry of byId.values()) {
+        const vectorOnly = entry.fRank === undefined;
+        if (vectorOnly && (entry.vScore ?? 0) < minVectorScore) continue;
+
+        let rrf = 0;
+        if (entry.vRank !== undefined) rrf += 1 / (RRF_K + entry.vRank + 1);
+        if (entry.fRank !== undefined) rrf += 1 / (RRF_K + entry.fRank + 1);
+
+        out.push({ row: entry.row, score: rrf });
+    }
+
+    return out;
+}
+
+/**
+ * Strip characters the LanceDB FTS query parser treats as operators so a
+ * free-form user query (which often contains code-y punctuation) can't
+ * crash the parser. Semantic search is the primary signal — FTS is just a
+ * lexical boost — so a permissive sanitizer is fine.
+ */
+function sanitizeFtsQuery(query: string): string {
+    return query
+        .replace(/[+\-!(){}\[\]^"~*?:\\\/]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}

--- a/src/AI/AIAgent/shared/memory/search.ts
+++ b/src/AI/AIAgent/shared/memory/search.ts
@@ -8,6 +8,7 @@
 import path from 'path';
 import { embedOne } from './embedder';
 import { getCodeChunksTable, getFindingsTable, getRevisitsTable } from './db';
+import { hybridSearch, distanceToScore } from './hybridSearch';
 import { matchGlob } from './indexer';
 import { getActiveSearchRepoKeys } from './groups';
 import { loadRegistry, type RegistryEntry } from './registry';
@@ -26,6 +27,7 @@ import {
 } from './types';
 
 interface RawCodeChunkHit {
+    id: string;
     path: string;
     language: string;
     startLine: number;
@@ -48,7 +50,7 @@ export async function semanticSearch(input: SemanticSearchInput): Promise<Semant
     const hits: SemanticSearchHit[] = [];
 
     if (scope === 'code' || scope === 'both') {
-        hits.push(...await searchCode(queryVector, k, input.pathGlob));
+        hits.push(...await searchCode(input.query, queryVector, k, input.pathGlob));
     }
 
     if (scope === 'memory' || scope === 'both') {
@@ -59,13 +61,16 @@ export async function semanticSearch(input: SemanticSearchInput): Promise<Semant
         hits.push(...await searchMemory(queryVector, k, input.memoryKind, input.selectedIds));
     }
 
-    const filtered = hits.filter((h) => h.score >= MIN_SCORE);
+    // Code hits are pre-filtered inside searchCode (vector-only candidates
+    // already had MIN_SCORE applied; FTS-only hits bypass the threshold by
+    // design). Memory hits still use the cosine threshold here.
+    const filtered = hits.filter((h) => h.type === 'code' || h.score >= MIN_SCORE);
     filtered.sort((a, b) => b.score - a.score);
 
     return filtered.slice(0, k);
 }
 
-async function searchCode(vector: number[], k: number, pathGlob?: string): Promise<SemanticSearchHit[]> {
+async function searchCode(query: string, vector: number[], k: number, pathGlob?: string): Promise<SemanticSearchHit[]> {
     const repoKeys = await resolveRepoSearchSet();
     if (repoKeys.length === 0) return [];
 
@@ -86,9 +91,25 @@ async function searchCode(vector: number[], k: number, pathGlob?: string): Promi
     const perRepoHits = await Promise.all(repoKeys.map(async (repoKey): Promise<RawCodeChunkHit[]> => {
         const { table } = await getCodeChunksTable(null, repoKey);
         if (!table) return [];
-        const rows = await table.search(vector).limit(fetchK).toArray();
 
-        return rows.map((row) => toRawCodeHit(row, repoKey));
+        const fused = await hybridSearch(table, query, vector, {
+            fetchK,
+            minVectorScore: MIN_SCORE,
+        });
+
+        return fused.map((hit): RawCodeChunkHit => {
+            const row = hit.row as unknown as CodeChunkRow;
+
+            return {
+                id: String((hit.row as { id?: unknown }).id ?? ''),
+                path: row.path,
+                language: row.language,
+                startLine: row.startLine,
+                endLine: row.endLine,
+                score: hit.score,
+                repoKey,
+            };
+        });
     }));
 
     const rawHits: RawCodeChunkHit[] = perRepoHits.flat()
@@ -98,6 +119,12 @@ async function searchCode(vector: number[], k: number, pathGlob?: string): Promi
     const topPaths = [...grouped.values()]
         .sort((a, b) => b.score - a.score)
         .slice(0, k);
+
+    // Normalize RRF scores to [0, 1] so they're comparable to the cosine
+    // scores returned by searchMemory when scope='both'. RRF values are tiny
+    // (~0.03 max) and would otherwise always sort below memory hits.
+    const maxScore = topPaths.reduce((m, g) => Math.max(m, g.score), 0);
+    const norm = maxScore > 0 ? 1 / maxScore : 1;
 
     return Promise.all(topPaths.map(async (group) => {
         const merged = mergeRanges(group.ranges);
@@ -114,9 +141,10 @@ async function searchCode(vector: number[], k: number, pathGlob?: string): Promi
             ...(multiRepo && meta ? { repo: meta.alias, rootPath: meta.rootPath } : {}),
         };
 
-        return { type: 'code', score: group.score, code } satisfies SemanticSearchHit;
+        return { type: 'code', score: group.score * norm, code } satisfies SemanticSearchHit;
     }));
 }
+
 
 async function resolveRepoSearchSet(): Promise<string[]> {
     const active = await getActiveSearchRepoKeys();
@@ -163,18 +191,6 @@ async function searchMemory(vector: number[], k: number, kind: MemoryLookupKind,
         .slice(0, k);
 }
 
-function toRawCodeHit(raw: Record<string, unknown>, repoKey: string): RawCodeChunkHit {
-    const row = raw as unknown as CodeChunkRow & { _distance?: number };
-
-    return {
-        path: row.path,
-        language: row.language,
-        startLine: row.startLine,
-        endLine: row.endLine,
-        score: distanceToScore(row._distance),
-        repoKey,
-    };
-}
 
 interface PathGroup {
     path: string;
@@ -234,14 +250,6 @@ function toMemoryHit(raw: Record<string, unknown>): SemanticSearchHit {
     };
 }
 
-function distanceToScore(distance: number | undefined): number {
-    if (typeof distance !== 'number' || !Number.isFinite(distance)) return 0;
-
-    // LanceDB returns L2 distance by default for BGE vectors. Convert to a
-    // similarity in [0, 1] by mapping with 1 / (1 + d). It's monotonic so the
-    // sort order is preserved and consumers get a friendlier score.
-    return 1 / (1 + distance);
-}
 
 function clamp(n: number, min: number, max: number): number {
     if (n < min) return min;


### PR DESCRIPTION
New shared hybridSearch helper running vector + FTS in parallel and fusing with Reciprocal Rank Fusion (k=60), normalized to [0,1].

Vector-only candidates below MIN_SCORE are dropped; FTS hits always survive. Falls back to pure cosine when FTS returns nothing so score magnitudes are preserved.

FTS index on `content` is created lazily on first table open for both code_chunks and doc_chunks; failures fall back transparently to vector-only.

searchCode and docsSearch both go through the shared helper, duplicated fusion / sanitizer / distance code removed.