### PR TITLE
fix: show sub-agent headers live and rename file-context edit → ancho…

### DIFF
--- a/__tests__/AI/AIAgent/subAgents/settings.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/settings.test.ts
@@ -10,7 +10,7 @@ describe('mergeExecutor', () => {
         expect(merged.allowReplanEscape).toBe(true);
         expect(merged.includeDiffsInLog).toBe(true);
         expect(merged.maxToolCalls).toBe(60);
-        expect(merged.toolWhitelist).toEqual(expect.arrayContaining(['read_lines', 'edit', 'bash']));
+        expect(merged.toolWhitelist).toEqual(expect.arrayContaining(['read_lines', 'anchor_edit', 'bash']));
     });
 
     it('respects partial overrides and falls back to defaults for the rest', () => {

--- a/__tests__/AI/AIAgent/subAgents/whitelist.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/whitelist.test.ts
@@ -4,7 +4,7 @@ describe('matchesSubAgentWhitelist', () => {
     const whitelist = [
         'read_lines',
         'get_outline',
-        'edit',
+        'anchor_edit',
         'lsp_query',
         'search',
         'submit_result',

--- a/docs/agent/tools-and-mcp.md
+++ b/docs/agent/tools-and-mcp.md
@@ -16,7 +16,7 @@ excludedTools: ['str_replace_editor', 'write_file', 'read_file', 'edit', 'view',
 | `get_outline(file_path)` | Structural outline (symbols + line numbers) |
 | `read_lines(...)` | Read exact line ranges (single or array form) |
 | `read_function(file_path, function_name)` | Return full function/class body by name |
-| `edit(file_path, edits[])` | Anchor-based edits (replace / insert / delete), each edit's anchor must match the file exactly once. Multiple edits per call. |
+| `anchor_edit(file_path, edits[])` | Anchor-based edits (replace / insert / delete), each edit's anchor must match the file exactly once. Multiple edits per call. Renamed from `edit` so the orchestrator's exclusion of Copilot's built-in `edit` tool no longer collides with the MCP tool. |
 | `create_file(file_path, content)` | Create new file |
 | `lsp_query(...)` | Hover/definition/references/etc via language server |
 
@@ -38,7 +38,7 @@ At least one of `name_pattern` or `content_pattern` is required.
 1. `search`
 2. `get_outline`
 3. `read_lines`
-4. `edit`
+4. `anchor_edit`
 
 Prefer array-form reads/edits for multiple disjoint ranges.
 
@@ -165,7 +165,7 @@ Behavior notes:
 - Only one execution runs at a time; concurrent calls are rejected.
 - `Ctrl-C` (`stop_stream`) aborts the executor and returns control to the
   orchestrator. The orchestrator sees the partial event log captured so far.
-- Executor tool whitelist (default): `read_lines`, `get_outline`, `edit`,
+- Executor tool whitelist (default): `read_lines`, `get_outline`, `anchor_edit`,
   `create_file`, `search`, `lsp_query`, `bash`. `confirm_task_complete` and
   other end-of-turn tools are forbidden — the orchestrator owns the turn.
 - Hard cap of `maxToolCalls` (default 60) tool calls before the executor is

--- a/src/AI/AIAgent/mcp/serverConfig.ts
+++ b/src/AI/AIAgent/mcp/serverConfig.ts
@@ -25,7 +25,7 @@ export async function buildCoreMcpServers(): Promise<Record<string, MCPServerCon
             'get_outline',
             'read_lines',
             'read_function',
-            'edit',
+            'anchor_edit',
             'create_file',
             'search',
             'lsp_query',

--- a/src/AI/AIAgent/shared/fileContext/dispatch.ts
+++ b/src/AI/AIAgent/shared/fileContext/dispatch.ts
@@ -37,7 +37,7 @@ export async function dispatchFileContextTool(
         case 'read_function':
             return handleReadFunction(filePath, args);
 
-        case 'edit':
+        case 'anchor_edit':
             return handleEdit(filePath, args);
 
         case 'create_file':

--- a/src/AI/AIAgent/shared/fileContext/tools.ts
+++ b/src/AI/AIAgent/shared/fileContext/tools.ts
@@ -64,7 +64,7 @@ export const TOOLS = [
     },
 
     {
-        name: 'edit',
+        name: 'anchor_edit',
         description: [
             'Anchor-based file editor. Edits are described by content, never by line numbers.',
             'Each entry in `edits` has an `op` ("replace" | "insert" | "delete") and an `anchor` — one or more contiguous lines copied verbatim from the file that uniquely identify the location. The anchor itself is never altered unless the op is replace/delete and it falls inside the affected range.',

--- a/src/AI/AIAgent/shared/subAgents/buildExecutorTranscript.ts
+++ b/src/AI/AIAgent/shared/subAgents/buildExecutorTranscript.ts
@@ -25,7 +25,7 @@ const FILE_CONTEXT_TOOLS = new Set([
     'get_outline',
     'read_function',
     'search',
-    'edit',
+    'anchor_edit',
     'create_file',
     'lsp_query',
 ]);

--- a/src/AI/AIAgent/shared/subAgents/session.ts
+++ b/src/AI/AIAgent/shared/subAgents/session.ts
@@ -30,6 +30,7 @@ import {
     appendToChat,
 } from '@/AI/AIAgent/shared/utils/agentToolHook';
 import { setupSessionEventHandlers } from '@/AI/AIAgent/shared/utils/agentSessionEvents';
+import { appendToAgentChatLayout } from '@/AI/AIAgent/shared/main/agentNeovimSetup';
 import {
     formatAssistantHeader,
     formatSubAgentHeader,
@@ -203,10 +204,10 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
         await setupSessionEventHandlers(parentState, session, {
             agentLabel: bridge.agentLabel,
         });
-        await appendToChat(
-            parentState.chatFile,
-            formatSubAgentHeader(bridge.headerEmoji, bridge.agentLabel, opts.runtime.model)
-        );
+        const subAgentHeader = formatSubAgentHeader(bridge.headerEmoji, bridge.agentLabel, opts.runtime.model);
+        await appendToChat(parentState.chatFile, subAgentHeader);
+        // appendToChat alone leaves the header invisible until a refresh.
+        appendToAgentChatLayout(parentState.nvim, subAgentHeader);
     }
 
     try {
@@ -229,10 +230,9 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
         await Promise.race([idle, submitted]);
     } finally {
         if (bridge && parentState) {
-            await appendToChat(
-                parentState.chatFile,
-                formatAssistantHeader(parentState.model)
-            );
+            const assistantHeader = formatAssistantHeader(parentState.model);
+            await appendToChat(parentState.chatFile, assistantHeader);
+            appendToAgentChatLayout(parentState.nvim, assistantHeader);
         }
         if (parentState && parentState.activeSubAgentSession === session) {
             parentState.activeSubAgentSession = undefined;
@@ -242,3 +242,4 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
 
     return { result: captured, events };
 }
+

--- a/src/AI/AIAgent/shared/subAgents/settings.ts
+++ b/src/AI/AIAgent/shared/subAgents/settings.ts
@@ -21,7 +21,7 @@ import type {
 const DEFAULT_EXECUTOR_TOOLS = [
     'read_lines',
     'get_outline',
-    'edit',
+    'anchor_edit',
     'create_file',
     'search',
     'lsp_query',

--- a/src/AI/AIAgent/shared/utils/agentToolHook.ts
+++ b/src/AI/AIAgent/shared/utils/agentToolHook.ts
@@ -37,10 +37,11 @@ import type {
 import { atomicWriteFile } from '@/AI/AIAgent/shared/utils/fileSafety';
 import { refreshAgentLayout } from '@/AI/AIAgent/shared/main/agentNeovimSetup';
 
-// Matches the kra-file-context 'edit' tool. We require 'edit' to appear as a
-// distinct token (preceded by start-of-string or a separator commonly used in
-// MCP tool names) so we don't accidentally match 'str_replace_editor',
-// 'edit_file', etc.
+// Matches the kra-file-context 'anchor_edit' tool. We require the trailing
+// 'edit' token to be preceded by a separator (start-of-string or one of the
+// MCP-namespacing characters) so we match `anchor_edit`, `kra-file-context__anchor_edit`,
+// `kra-file-context-anchor_edit`, etc., but never `str_replace_editor`/`edit_file`.
+// (The legacy bare name `edit` also matches via start-of-string.)
 function isAnchorEditTool(name: string): boolean {
     return /(?:^|[_:\-.])edit$/.test(name);
 }


### PR DESCRIPTION
…r_edit

session.ts: push INVESTIGATOR/EXECUTOR and returning ASSISTANT headers through appendToAgentChatLayout so they appear in the live nvim view (previously written to disk only)

rename kra-file-context `edit` tool to `anchor_edit` so the orchestrator's exclusion of Copilot's built-in `edit` no longer strips the MCP tool fixes BYOK orchestrator having no editor