### PR TITLE
feat: executor-persistence

### DIFF
--- a/ai-files/lua/kra_agent/ui/history.lua
+++ b/ai-files/lua/kra_agent/ui/history.lua
@@ -4,11 +4,32 @@ local state = require("kra_agent.ui.state")
 local rpc = require("kra_agent.util.rpc")
 local json = require("kra_agent.util.json")
 
-function M.upsert_history(tool_name, details, args_json)
+-- Resolve the existing history entry for a given tool_call_id, falling back
+-- to the legacy single active_entry_index when no id is provided. Returns
+-- (index, entry) or (nil, nil) if no entry exists yet.
+local function find_entry(tool_call_id)
+    if tool_call_id and state.entries_by_call_id[tool_call_id] then
+        local idx = state.entries_by_call_id[tool_call_id]
+        local entry = state.history[idx]
+        if entry then
+            return idx, entry
+        end
+        -- Stale mapping: the entry was wiped. Drop the dangling pointer.
+        state.entries_by_call_id[tool_call_id] = nil
+    end
+
+    if not tool_call_id and state.active_entry_index and state.history[state.active_entry_index] then
+        return state.active_entry_index, state.history[state.active_entry_index]
+    end
+
+    return nil, nil
+end
+
+function M.upsert_history(tool_name, details, args_json, tool_call_id)
     local timestamp = os.date("%H:%M:%S")
 
-    if state.active_entry_index and state.history[state.active_entry_index] then
-        local entry = state.history[state.active_entry_index]
+    local _, entry = find_entry(tool_call_id)
+    if entry then
         entry.details = details
         entry.updated_at = timestamp
         if args_json and args_json ~= "" and (entry.args_json == nil or entry.args_json == "") then
@@ -17,25 +38,33 @@ function M.upsert_history(tool_name, details, args_json)
         return entry
     end
 
-    local entry = {
+    entry = {
         args_json = args_json or "",
         details = details,
         started_at = timestamp,
         status = "running",
         title = tool_name,
+        tool_call_id = tool_call_id,
         updated_at = timestamp,
     }
     table.insert(state.history, entry)
-    state.active_entry_index = #state.history
+    local idx = #state.history
+    if tool_call_id then
+        state.entries_by_call_id[tool_call_id] = idx
+    else
+        -- Legacy callers (no tool_call_id) rely on the single active pointer.
+        state.active_entry_index = idx
+    end
     return entry
 end
 
-function M.complete_history(tool_name, details, success, full_result)
-    local entry
-    if state.active_entry_index and state.history[state.active_entry_index] then
-        entry = state.history[state.active_entry_index]
-    else
-        entry = M.upsert_history(tool_name, details)
+function M.complete_history(tool_name, details, success, full_result, tool_call_id)
+    local _, entry = find_entry(tool_call_id)
+    if not entry then
+        -- No matching start_tool was recorded — create a placeholder so the
+        -- result still shows up in history. Args will be empty in this case;
+        -- that is intentional, since they were never reported.
+        entry = M.upsert_history(tool_name, details, nil, tool_call_id)
     end
 
     entry.title = tool_name
@@ -44,7 +73,12 @@ function M.complete_history(tool_name, details, success, full_result)
     entry.details = details
     entry.status = success and "done" or "failed"
     entry.updated_at = os.date("%H:%M:%S")
-    state.active_entry_index = nil
+
+    if tool_call_id then
+        state.entries_by_call_id[tool_call_id] = nil
+    else
+        state.active_entry_index = nil
+    end
 end
 
 local function open_history_view(entry)

--- a/ai-files/lua/kra_agent/ui/init.lua
+++ b/ai-files/lua/kra_agent/ui/init.lua
@@ -49,8 +49,8 @@ function M.start_turn(model)
     })
 end
 
-function M.start_tool(tool_name, details, args_json)
-    history.upsert_history(tool_name, details, args_json)
+function M.start_tool(tool_name, details, args_json, tool_call_id)
+    history.upsert_history(tool_name, details, args_json, tool_call_id)
     set_state({
         title = string.format("Tool · %s", tool_name),
         body = details,
@@ -60,8 +60,8 @@ function M.start_tool(tool_name, details, args_json)
     })
 end
 
-function M.update_tool(tool_name, details)
-    history.upsert_history(tool_name, details)
+function M.update_tool(tool_name, details, tool_call_id)
+    history.upsert_history(tool_name, details, nil, tool_call_id)
     set_state({
         title = string.format("Tool · %s", tool_name),
         body = details,
@@ -71,8 +71,8 @@ function M.update_tool(tool_name, details)
     })
 end
 
-function M.complete_tool(tool_name, details, success, full_result)
-    history.complete_history(tool_name, details, success, full_result)
+function M.complete_tool(tool_name, details, success, full_result, tool_call_id)
+    history.complete_history(tool_name, details, success, full_result, tool_call_id)
     set_state({
         title = string.format("Tool · %s", tool_name),
         body = string.format("%s\n\nPress <Space>h for tool history.", details),

--- a/ai-files/lua/kra_agent/ui/state.lua
+++ b/ai-files/lua/kra_agent/ui/state.lua
@@ -1,5 +1,11 @@
 local state = {
     active_entry_index = nil,
+    -- Map of tool_call_id -> history index. Lets concurrent tool executions
+    -- (multiple in-flight at once) update the right history entry instead of
+    -- clobbering whichever one happened to be active_entry_index. The single
+    -- active_entry_index is kept as a fallback for legacy callers that don't
+    -- pass a tool_call_id (e.g. AIChat path).
+    entries_by_call_id = {},
     body = "Ready",
     history = {},
     icon = "󱚩",

--- a/src/AI/AIAgent/providers/byok/byokSession.ts
+++ b/src/AI/AIAgent/providers/byok/byokSession.ts
@@ -441,6 +441,10 @@ export class OpenAICompatibleSession implements AgentSession {
         this.cachedStreamingMode = override.streamingMode;
     }
 
+    public getMessages(): ChatCompletionMessageParam[] {
+        return [...this.messages];
+    }
+
     public on: AgentSession['on'] = (event, handler) => {
         const list = (this.listeners[event] ??= []) as EventListener<typeof event>[];
         list.push(handler);
@@ -502,6 +506,12 @@ export class OpenAICompatibleSession implements AgentSession {
 
         const sysContent = this.buildSystemMessage();
         this.messages.push({ role: 'system', content: sysContent });
+
+        if (this.opts.initialMessages) {
+            for (const msg of this.opts.initialMessages) {
+                this.messages.push(msg);
+            }
+        }
     }
 
     private buildSystemMessage(): string {
@@ -1280,6 +1290,7 @@ export class OpenAICompatibleSession implements AgentSession {
                 toolCallId: call.id,
                 success,
                 result: { content: output },
+                ...(success ? {} : { error: output }),
             },
         });
     }
@@ -1309,3 +1320,4 @@ export class OpenAICompatibleSession implements AgentSession {
         return this.executableToolBridge.executeTool(title, args);
     };
 }
+

--- a/src/AI/AIAgent/shared/main/agentConversation.ts
+++ b/src/AI/AIAgent/shared/main/agentConversation.ts
@@ -384,6 +384,8 @@ function buildDelegationBlock(opts: OrchestratorSystemMessageOpts): string {
 
         lines.push(`- \`execute\` — concrete multi-step work (refactor, feature, multi-file edit). Returns ONLY a curated event log + summary; raw tool traffic stays out of your context. Do NOT copy findings/file contents into \`plan\` — the executor automatically receives ${transcriptNote}.`);
         lines.push('  - If executor returns `status: needs_decision`, it hit a real design crossroad. Present the `decisionPoint.question` (and `options[]` if any) to the user via `confirm_task_complete` — do NOT autonomously decide. Once the user picks, re-issue `execute` with an updated plan.');
+        lines.push('  - `needs_replan` and `blocked` also allow re-issue with an updated plan.');
+        lines.push('  - **Session continuation**: If the result includes a `sessionId`, pass it back as `sessionId` on the re-issued `execute` call. The executor then continues from its stored conversation rather than starting fresh — you do NOT need to repeat prior context in the new plan.');
     }
 
     lines.push('');

--- a/src/AI/AIAgent/shared/subAgents/executeTool.ts
+++ b/src/AI/AIAgent/shared/subAgents/executeTool.ts
@@ -21,7 +21,13 @@
 import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
 import type { LocalTool } from '@/AI/AIAgent/shared/types/agentTypes';
 import type { ExecutorRuntime } from '@/AI/AIAgent/shared/subAgents/types';
-import { runSubAgentTask, type SubAgentChatBridge, type SubAgentEvent } from '@/AI/AIAgent/shared/subAgents/session';
+import {
+    disposeSubAgentHandle,
+    runSubAgentTask,
+    type SubAgentChatBridge,
+    type SubAgentEvent,
+    type SubAgentSessionHandle,
+} from '@/AI/AIAgent/shared/subAgents/session';
 import { buildExecutorTranscriptBlocks } from '@/AI/AIAgent/shared/subAgents/buildExecutorTranscript';
 import type { TranscriptEntry } from '@/AI/AIAgent/shared/main/orchestratorTranscript';
 
@@ -33,6 +39,8 @@ export interface CreateExecuteToolOptions {
 }
 
 interface ExecuteArgs {
+    /** Optional. Pass back the sessionId from a previous paused execution to resume it. */
+    sessionId?: string;
     plan: string;
     successCriteria?: string;
 }
@@ -60,6 +68,36 @@ export interface DecisionPoint {
     options?: string[];
 }
 
+/** @internal Live executor session kept alive across pauses. */
+interface StoredExecutorSession {
+    handle: SubAgentSessionHandle;
+    sessionId: string;
+}
+
+/** @internal Single-slot store — only one executor at a time. */
+let storedExecutorSession: StoredExecutorSession | null = null;
+let sessionCounter = 0;
+
+/**
+ * Best-effort dispose of the currently stored executor session, if any.
+ * Used when starting a fresh run that supersedes an old paused one.
+ */
+async function disposeStoredExecutorSession(): Promise<void> {
+    if (!storedExecutorSession) {
+        return;
+    }
+    const previous = storedExecutorSession;
+    storedExecutorSession = null;
+    await disposeSubAgentHandle(previous.handle);
+}
+
+const PAUSABLE_STATUSES: ExecutionResult['status'][] = [
+    'blocked',
+    'needs_replan',
+    'needs_decision',
+];
+
+
 export interface ExecutionResult {
     status: 'completed' | 'partial' | 'blocked' | 'needs_replan' | 'needs_decision';
     summary: string;
@@ -76,6 +114,11 @@ const EXECUTE_PARAMETERS: Record<string, unknown> = {
             type: 'string',
             description: 'Concise directive plan: numbered steps naming files/symbols + intended outcomes. Do NOT restate findings or paste file contents — the executor receives a transcript of your prior investigations, reads, and reasoning automatically.',
         },
+        sessionId: {
+            type: 'string',
+            description: 'Optional. Pass back the sessionId from a previous paused execution to resume it. When set, the executor continues from its stored conversation rather than starting fresh.',
+        },
+
         successCriteria: {
             type: 'string',
             description: 'Optional explicit criteria for "done". Executor only marks `completed` if met; otherwise returns `partial`/`blocked`.',
@@ -127,14 +170,54 @@ export function createExecuteTool(opts: CreateExecuteToolOptions): LocalTool {
                 : [];
             const run = (async (): Promise<string> => {
                 const systemPrompt = buildExecutorSystemPrompt(settings);
-                const taskPrompt = buildExecutorTaskPrompt(args, transcriptSlice);
 
-                const { result, events } = await runSubAgentTask({
+                let existingHandle: SubAgentSessionHandle | undefined;
+                let taskPrompt: string;
+
+                if (
+                    args.sessionId
+                    && storedExecutorSession
+                    && storedExecutorSession.sessionId === args.sessionId
+                ) {
+                    // ── Resume path ────────────────────────────────────────
+                    // The stored messages are everything after the system prompt.
+                    // The fresh session's init() will push its own system prompt,
+                    // then these stored messages, then taskPrompt (the resume msg).
+                    // The kept-alive session has the full conversation history
+                    // (tool calls + results), so we just send a fresh prompt and
+                    // let the executor pick up where it left off. Both BYOK and
+                    // Copilot SDK support multi-turn send() on the same session.
+                    existingHandle = storedExecutorSession.handle;
+                    storedExecutorSession = null; // will re-store below if still paused
+
+                    const resumeParts: string[] = [
+                        '[Resume] The orchestrator has provided updated direction.',
+                    ];
+                    if (transcriptSlice.length > 0) {
+                        resumeParts.push(
+                            '',
+                            'Additional context gathered since you paused:',
+                            buildExecutorTranscriptBlocks(transcriptSlice),
+                        );
+                    }
+                    resumeParts.push('', `Proceed with:\n\n${args.plan}`);
+                    taskPrompt = resumeParts.join('\n');
+                } else {
+                    // Fresh path. Tear down any orphaned paused session first —
+                    // the daemon's session pool is finite and we don't want to
+                    // leak handles when the orchestrator gives up on a resume.
+                    await disposeStoredExecutorSession();
+                    taskPrompt = buildExecutorTaskPrompt(args, transcriptSlice);
+                }
+
+                const { result, events, liveHandle } = await runSubAgentTask({
                     runtime,
                     mcpServers,
                     workingDirectory,
                     systemPrompt,
                     taskPrompt,
+                    ...(existingHandle ? { existingHandle } : {}),
+                    keepAliveOnPause: true,
                     toolWhitelist: settings.toolWhitelist,
                     resultSchema: buildResultSchema(),
                     ...(runtime.contextWindow !== undefined ? { contextWindow: runtime.contextWindow } : {}),
@@ -142,6 +225,11 @@ export function createExecuteTool(opts: CreateExecuteToolOptions): LocalTool {
                 });
 
                 if (!result) {
+                    // Executor never called submit_result — the live session
+                    // is in an unknown state and unsafe to resume. Dispose it.
+                    if (liveHandle) {
+                        await disposeSubAgentHandle(liveHandle);
+                    }
                     return [
                         'Executor did not call submit_result. It may have hit a tool-call',
                         'limit, refused the task, or been aborted by the user.',
@@ -152,7 +240,19 @@ export function createExecuteTool(opts: CreateExecuteToolOptions): LocalTool {
 
                 const parsed = coerceResult(result);
 
-                return formatExecutionResult(parsed);
+                // Manage session store for continuation. The session is held
+                // open across pauses so the executor can resume with full
+                // conversation context (tool calls + results) on both providers.
+                let sessionId: string | undefined;
+                if (PAUSABLE_STATUSES.includes(parsed.status) && liveHandle) {
+                    sessionId = `exec_${++sessionCounter}`;
+                    storedExecutorSession = { handle: liveHandle, sessionId };
+                } else if (liveHandle) {
+                    // Terminal status (or non-pausable) — release the session.
+                    await disposeSubAgentHandle(liveHandle);
+                }
+
+                return formatExecutionResult(parsed, sessionId);
             })();
 
             activeRun = run;
@@ -350,7 +450,7 @@ export function coerceResult(raw: Record<string, unknown>): ExecutionResult {
     return result;
 }
 
-export function formatExecutionResult(r: ExecutionResult): string {
+export function formatExecutionResult(r: ExecutionResult, sessionId?: string): string {
     const lines: string[] = [
         `status: ${r.status}`,
         `summary: ${r.summary}`,
@@ -390,6 +490,10 @@ export function formatExecutionResult(r: ExecutionResult): string {
         }
     }
 
+    if (sessionId) {
+        lines.push('', `sessionId: ${sessionId}`);
+    }
+
     return lines.join('\n');
 }
 
@@ -403,3 +507,4 @@ function summariseRawEvents(events: SubAgentEvent[]): string {
         })
         .join(', ');
 }
+

--- a/src/AI/AIAgent/shared/subAgents/session.ts
+++ b/src/AI/AIAgent/shared/subAgents/session.ts
@@ -26,6 +26,7 @@ import type {
     LocalTool,
 } from '@/AI/AIAgent/shared/types/agentTypes';
 import type { SubAgentRuntime } from '@/AI/AIAgent/shared/subAgents/types';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import {
     appendToChat,
 } from '@/AI/AIAgent/shared/utils/agentToolHook';
@@ -86,6 +87,37 @@ export interface SubAgentRunOptions {
      * same chat file.
      */
     chatBridge?: SubAgentChatBridge;
+    /**
+     * Optional. Messages to inject after the system prompt.
+     * Used for BYOK-only session continuation — the stored conversation
+     * (sans system message) is passed here so the agent can resume. Ignored
+     * when `existingHandle` is provided (session is already live with history).
+     */
+    initialMessages?: ChatCompletionMessageParam[];
+    /**
+     * Optional. Reuse a previously kept-alive sub-agent session
+     */
+    existingHandle?: SubAgentSessionHandle;
+    /**
+     * Optional. When true, do NOT call `session.disconnect()` after the turn.
+     */
+    keepAliveOnPause?: boolean;
+}
+
+/**
+ * Mutable handle for a kept-alive sub-agent session. The submit_result tool
+ * handler and the event-emit closure are bound at session-creation time but
+ * reference these mutable slots so subsequent turns can rebind them without
+ * re-registering tools or re-attaching listeners.
+ */
+export interface SubAgentSessionHandle {
+    session: AgentSession;
+    /** Per-turn capture target — reset before each `runSubAgentTask` call. */
+    submitSlot: { captured?: Record<string, unknown>; resolveSubmitted?: () => void };
+    /** Per-turn event sink — reset before each call so events route to the current run's array. */
+    emitSlot: { current: (e: SubAgentEvent) => void };
+    bridge?: SubAgentChatBridge;
+    parentState?: AgentConversationState;
 }
 
 export interface SubAgentRunResult {
@@ -93,6 +125,34 @@ export interface SubAgentRunResult {
     result: Record<string, unknown> | undefined;
     /** Captured event log (post-hoc; for the orchestrator's audit trail). */
     events: SubAgentEvent[];
+    /**
+     * The session's full message array after execution.
+     * Only populated when the sub-agent called submit_result AND the underlying
+     * provider supports `getMessages()` (BYOK only). Prefer `liveHandle` for
+     * cross-provider session continuation.
+     */
+    messages?: ChatCompletionMessageParam[];
+    /**
+     * Populated when `keepAliveOnPause` was true. Pass back as `existingHandle`
+     * on the next `runSubAgentTask` call to continue the same session, or
+     * dispose via `disposeSubAgentHandle` to release resources.
+     */
+    liveHandle?: SubAgentSessionHandle;
+}
+
+/**
+ * Tear down a kept-alive sub-agent session. Best-effort — swallows errors
+ * because cleanup is fire-and-forget.
+ */
+export async function disposeSubAgentHandle(handle: SubAgentSessionHandle): Promise<void> {
+    if (handle.parentState && handle.parentState.activeSubAgentSession === handle.session) {
+        handle.parentState.activeSubAgentSession = undefined;
+    }
+    try {
+        await handle.session.disconnect();
+    } catch {
+        // disconnect is best-effort; nothing useful to do on failure.
+    }
 }
 
 export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgentRunResult> {
@@ -102,113 +162,151 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
         opts.onEvent?.(e);
     };
 
-    let captured: Record<string, unknown> | undefined;
-    let resolveSubmitted: (() => void) | undefined;
-    const submitted = new Promise<void>((resolve) => {
-        resolveSubmitted = resolve;
-    });
+    let handle: SubAgentSessionHandle;
+    let isReused: boolean;
 
-    const submitTool: LocalTool = {
-        name: 'submit_result',
-        description:
-            'Submit your final structured result. Calling this signals the task is complete. ' +
-            'After calling this, output a brief acknowledgement and STOP — do not call any further tools.',
-        parameters: opts.resultSchema,
-        serverLabel: 'kra-subagent',
-        handler: async (args) => {
-            captured = args;
-            resolveSubmitted?.();
+    if (opts.existingHandle) {
+        // ── Reuse path ───────────────────────────────────────────────────
+        // Session is already live with full conversation history (tool calls
+        // and tool results included). The submit_result tool was registered
+        // at original creation; its handler closes over `submitSlot`, which
+        // we reset below. Listeners and bridge wiring are preserved.
+        handle = opts.existingHandle;
+        isReused = true;
 
-            return 'Result accepted. End your turn now without calling any more tools.';
-        },
-    };
+        if (handle.parentState) {
+            handle.parentState.activeSubAgentSession = handle.session;
+        }
+    } else {
+        // ── Fresh path ───────────────────────────────────────────────────
+        const submitSlot: SubAgentSessionHandle['submitSlot'] = {};
+        const emitSlot: SubAgentSessionHandle['emitSlot'] = { current: emit };
 
-    const bridge = opts.chatBridge;
+        const submitTool: LocalTool = {
+            name: 'submit_result',
+            description:
+                'Submit your final structured result. Calling this signals the task is complete. ' +
+                'After calling this, output a brief acknowledgement and STOP — do not call any further tools.',
+            parameters: opts.resultSchema,
+            serverLabel: 'kra-subagent',
+            handler: async (args) => {
+                submitSlot.captured = args;
+                submitSlot.resolveSubmitted?.();
 
-    const onPreToolUse = async (input: AgentPreToolUseHookInput): Promise<AgentPreToolUseHookOutput> => {
-        // submit_result is a synthetic local tool — always allow it.
-        if (input.toolName === 'submit_result') {
+                return 'Result accepted. End your turn now without calling any more tools.';
+            },
+        };
+
+        const bridge = opts.chatBridge;
+
+        const onPreToolUse = async (input: AgentPreToolUseHookInput): Promise<AgentPreToolUseHookOutput> => {
+            if (input.toolName === 'submit_result') {
+                return { permissionDecision: 'allow' };
+            }
+
+            if (bridge) {
+                return bridge.parentOnPreToolUse({
+                    ...input,
+                    agentLabel: bridge.agentLabel,
+                });
+            }
+
             return { permissionDecision: 'allow' };
-        }
+        };
 
-        if (bridge) {
-            return bridge.parentOnPreToolUse({
-                ...input,
-                agentLabel: bridge.agentLabel,
-            });
-        }
+        const onPostToolUse = async (
+            input: AgentPostToolUseHookInput
+        ): Promise<AgentPostToolUseHookOutput | void> => {
+            if (input.toolName === 'submit_result') {
+                return;
+            }
 
-        return { permissionDecision: 'allow' };
-    };
+            if (bridge) {
+                return bridge.parentOnPostToolUse({
+                    ...input,
+                    agentLabel: bridge.agentLabel,
+                });
+            }
 
-    const onPostToolUse = async (
-        input: AgentPostToolUseHookInput
-    ): Promise<AgentPostToolUseHookOutput | void> => {
-        if (input.toolName === 'submit_result') {
             return;
+        };
+
+        const session: AgentSession = await opts.runtime.client.createSession({
+            model: opts.runtime.model,
+            workingDirectory: opts.workingDirectory,
+            mcpServers: opts.mcpServers,
+            localTools: [submitTool],
+            systemMessage: { mode: 'replace', content: opts.systemPrompt },
+            ...(opts.contextWindow !== undefined ? { contextWindow: opts.contextWindow } : {}),
+            excludedTools: [
+                'str_replace_editor', 'write_file', 'read_file', 'edit', 'view',
+                'grep', 'glob', 'create', 'apply_patch',
+                'bash', 'shell', 'run_in_terminal', 'execute', 'report_intent',
+            ],
+            ...(opts.initialMessages ? { initialMessages: opts.initialMessages } : {}),
+            allowedTools: [...opts.toolWhitelist, 'submit_result'],
+            onPreToolUse,
+            onPostToolUse,
+            isSubAgent: true,
+        });
+
+        // Listeners read from emitSlot.current, so reused sessions route events
+        // to the CURRENT run's array rather than the original run's (closed over).
+        session.on('assistant.message_delta', (e) => {
+            emitSlot.current({ kind: 'message', text: e.data.deltaContent });
+        });
+        session.on('tool.execution_start', (e) => {
+            emitSlot.current({ kind: 'tool_start', toolName: e.data.toolName });
+        });
+        session.on('tool.execution_complete', (e) => {
+            emitSlot.current({ kind: 'tool_complete', success: e.data.success });
+        });
+
+        const parentState = bridge?.getParentState();
+        if (parentState) {
+            parentState.activeSubAgentSession = session;
         }
 
-        if (bridge) {
-            return bridge.parentOnPostToolUse({
-                ...input,
+        if (bridge && parentState) {
+            await setupSessionEventHandlers(parentState, session, {
                 agentLabel: bridge.agentLabel,
             });
         }
 
-        return;
-    };
+        handle = {
+            session,
+            submitSlot,
+            emitSlot,
+            ...(bridge ? { bridge } : {}),
+            ...(parentState ? { parentState } : {}),
+        };
 
-    // The provider wrappers honour `allowedTools` by filtering the MCP/built-in
-    // tool inventory advertised to the model BEFORE the turn starts. We still
-    // pass the static `excludedTools` list so the SDK's own built-in editors
-    // (which we replace with our MCP-served versions) never appear.
-    const session: AgentSession = await opts.runtime.client.createSession({
-        model: opts.runtime.model,
-        workingDirectory: opts.workingDirectory,
-        mcpServers: opts.mcpServers,
-        localTools: [submitTool],
-        systemMessage: { mode: 'replace', content: opts.systemPrompt },
-        ...(opts.contextWindow !== undefined ? { contextWindow: opts.contextWindow } : {}),
-        excludedTools: [
-            'str_replace_editor', 'write_file', 'read_file', 'edit', 'view',
-            'grep', 'glob', 'create', 'apply_patch',
-            'bash', 'shell', 'run_in_terminal', 'execute', 'report_intent',
-        ],
-        allowedTools: [...opts.toolWhitelist, 'submit_result'],
-        onPreToolUse,
-        onPostToolUse,
-        isSubAgent: true,
-    });
-    // Always capture into the local event log for the caller's audit trail.
-    session.on('assistant.message_delta', (e) => {
-        emit({ kind: 'message', text: e.data.deltaContent });
-    });
-    session.on('tool.execution_start', (e) => {
-        emit({ kind: 'tool_start', toolName: e.data.toolName });
-    });
-    session.on('tool.execution_complete', (e) => {
-        emit({ kind: 'tool_complete', success: e.data.success });
-    });
-
-    // Track this session on the parent state so the user's `stop_stream`
-    // action can also abort the sub-agent (otherwise hitting stop only stops
-    // the orchestrator and the sub-agent keeps running tools).
-    const parentState = bridge?.getParentState();
-
-    if (parentState) {
-        parentState.activeSubAgentSession = session;
+        isReused = false;
     }
 
-    // If bridged, mirror the session into the orchestrator's chat/nvim UI.
+    // Per-turn rebinding: reset capture state and route events into THIS run.
+    delete handle.submitSlot.captured;
+    delete handle.submitSlot.resolveSubmitted;
+    handle.emitSlot.current = emit;
+
+    const submitted = new Promise<void>((resolve) => {
+        handle.submitSlot.resolveSubmitted = resolve;
+    });
+
+    const session = handle.session;
+    const bridge = handle.bridge;
+    const parentState = handle.parentState;
+
+    // Emit the sub-agent header for every turn (fresh OR resumed) so the chat
+    // shows the executor handing off cleanly. On resume this acts as a visual
+    // marker that the executor has picked the conversation back up.
     if (bridge && parentState) {
-        await setupSessionEventHandlers(parentState, session, {
-            agentLabel: bridge.agentLabel,
-        });
         const subAgentHeader = formatSubAgentHeader(bridge.headerEmoji, bridge.agentLabel, opts.runtime.model);
         await appendToChat(parentState.chatFile, subAgentHeader);
-        // appendToChat alone leaves the header invisible until a refresh.
         appendToAgentChatLayout(parentState.nvim, subAgentHeader);
     }
+
+    let finalMessages: ChatCompletionMessageParam[] | undefined;
 
     try {
         // Provider semantics differ: BYOK's send() blocks until the turn loop
@@ -216,12 +314,8 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
         // the prompt and the model runs asynchronously, with completion signalled
         // via the `session.idle` event. We wait for idle in both cases so the
         // sub-agent reliably finishes (and submit_result fires) before we
-        // disconnect.
-        // We ALSO race against `submitted` (resolved synchronously by the
-        // submit_result handler): some models keep emitting text or denied
-        // tool calls after submitting, which delays or never fires `idle`.
-        // Once we have a captured result there is nothing useful left for the
-        // model to do, so we hand control back to the orchestrator immediately.
+        // disconnect. We race against `submitted` (resolved by submit_result)
+        // because some models keep emitting after submit, delaying `idle`.
         const idle = new Promise<void>((resolve) => {
             session.on('session.idle', () => resolve());
         });
@@ -234,12 +328,48 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
             await appendToChat(parentState.chatFile, assistantHeader);
             appendToAgentChatLayout(parentState.nvim, assistantHeader);
         }
-        if (parentState && parentState.activeSubAgentSession === session) {
-            parentState.activeSubAgentSession = undefined;
+
+        if (opts.keepAliveOnPause) {
+            // Skip disconnect; caller owns lifecycle via the returned liveHandle.
+            // Leave activeSubAgentSession set so user-abort still tears it down.
+        } else {
+            if (parentState && parentState.activeSubAgentSession === session) {
+                parentState.activeSubAgentSession = undefined;
+            }
+
+            // Capture messages BEFORE disconnect. The Copilot SDK's getMessages()
+            // is an RPC into the session daemon; once disconnect() tears the
+            // session down, the in-flight RPC rejects with `Session not found`.
+            if (handle.submitSlot.captured) {
+                try {
+                    finalMessages = await session.getMessages?.();
+                } catch {
+                    finalMessages = undefined;
+                }
+            }
+
+            try {
+                await session.disconnect();
+            } catch {
+                // Disconnect is best-effort; never let cleanup errors mask the result.
+            }
         }
-        await session.disconnect();
     }
 
-    return { result: captured, events };
+    const captured = handle.submitSlot.captured;
+    const result: SubAgentRunResult = { result: captured, events };
+
+    if (finalMessages) {
+        result.messages = finalMessages;
+    }
+    if (opts.keepAliveOnPause) {
+        result.liveHandle = handle;
+    }
+
+    // Suppress unused-variable warning for isReused — retained for future
+    // diagnostics / logging hooks.
+    void isReused;
+
+    return result;
 }
 

--- a/src/AI/AIAgent/shared/types/agentTypes.ts
+++ b/src/AI/AIAgent/shared/types/agentTypes.ts
@@ -1,5 +1,6 @@
 import type * as neovim from 'neovim';
 import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import type { AgentHistory, BashSnapshot } from '@/AI/AIAgent/shared/utils/agentHistory';
 
 export type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
@@ -120,6 +121,12 @@ export interface AgentSession {
     disconnect: () => Promise<void>;
     listExecutableTools?: () => Array<{ title: string; server: string; name: string }>;
     executeTool?: (title: string, args: Record<string, unknown>) => Promise<string>;
+    /**
+     * Optional. Returns a copy of the current conversation messages array.
+     * BYOK sessions implement this for session-continuation support;
+     * Copilot SDK sessions do not (returns undefined).
+     */
+    getMessages?: () => ChatCompletionMessageParam[] | Promise<ChatCompletionMessageParam[]>;
 }
 
 
@@ -196,6 +203,13 @@ export interface AgentSessionOptions {
      * thresholds).
      */
     isSubAgent?: boolean;
+    /**
+     * Optional. Messages to inject after the system prompt during init().
+     * Used by executor session continuation — the stored conversation
+     * (sans system message) is passed here so a fresh session picks up
+     * where the previous one left off.
+     */
+    initialMessages?: ChatCompletionMessageParam[];
 }
 
 export interface LocalTool {

--- a/src/AI/AIAgent/shared/utils/agentSessionEvents.ts
+++ b/src/AI/AIAgent/shared/utils/agentSessionEvents.ts
@@ -345,19 +345,19 @@ export async function setupSessionEventHandlers(
 
         const details = `Running ${toolName}\n\nArguments:\n${formatToolArguments(event.data.arguments)}`;
         const argsJson = JSON.stringify(event.data.arguments ?? {}, null, 2);
-        void updateAgentUi(state.nvim, 'start_tool', [toolName, details, argsJson]);
+        void updateAgentUi(state.nvim, 'start_tool', [toolName, details, argsJson, event.data.toolCallId]);
     });
 
     session.on('tool.execution_progress', (event) => {
         currentToolLabel = toolLabels.get(event.data.toolCallId) ?? currentToolLabel;
         const details = `Running tool\n\n${formatToolProgress(event.data.progressMessage)}`;
-        void updateAgentUi(state.nvim, 'update_tool', [currentToolLabel, details]);
+        void updateAgentUi(state.nvim, 'update_tool', [currentToolLabel, details, event.data.toolCallId]);
     });
 
     session.on('tool.execution_partial_result', (event) => {
         currentToolLabel = toolLabels.get(event.data.toolCallId) ?? currentToolLabel;
         const details = `Streaming tool output\n\n${formatToolProgress(event.data.partialOutput)}`;
-        void updateAgentUi(state.nvim, 'update_tool', [currentToolLabel, details]);
+        void updateAgentUi(state.nvim, 'update_tool', [currentToolLabel, details, event.data.toolCallId]);
     });
 
     session.on('tool.execution_complete', (event) => {
@@ -385,6 +385,7 @@ export async function setupSessionEventHandlers(
             details,
             event.data.success,
             fullResult,
+            event.data.toolCallId,
         ]);
 
         state.nvim

--- a/src/AI/AIAgent/shared/utils/agentUi.ts
+++ b/src/AI/AIAgent/shared/utils/agentUi.ts
@@ -119,7 +119,17 @@ export function formatToolCompletion(
     error?: unknown
 ): string {
     if (!success) {
-        return truncateMultiline(extractErrorMessage(error));
+        const errorText = extractErrorMessage(error);
+        if (errorText !== 'Tool failed.') {
+            return truncateMultiline(errorText);
+        }
+
+        const fallback = result?.detailedContent ?? result?.content;
+        if (fallback) {
+            return truncateMultiline(fallback);
+        }
+
+        return truncateMultiline(errorText);
     }
 
     const resultText = result?.detailedContent ?? result?.content ?? 'Completed successfully.';


### PR DESCRIPTION
executor context persists when need_decision/blocked/need_replan are called by the executor, investigator can call executor again with session id and executor will continue where it left off.