### PR TITLE
project-wide-diagnostic-after-edit

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -59,11 +59,11 @@ Use `<leader>d` to open the proposal diff tab at any time to review what changed
 3. **Review** — Use `<leader>d` to open the proposal diff tab. Inspect, edit files, then apply or reject
 4. **Apply** — `<leader>a` (or `a` in the diff tab) acknowledges the changes (already written to disk)
 5. **Continue** — Submit the next prompt; changes accumulate as uncommitted diffs across turns
-6. **End session** — When the agent calls `confirm_task_complete` and you select "End session", the session closes
+6. **End session** — When the agent calls `ask_kra` and you select "End session", the session closes
 
 ### Confirm-Before-Done Protocol
 
-The agent is instructed to always call `confirm_task_complete` before ending a turn. This presents a popup in Neovim with a summary and 2–4 choices. Selecting a choice sends your reply back to the agent. Only "End session" terminates the turn.
+The agent is instructed to always call `ask_kra` before ending a turn. This presents a popup in Neovim with a summary and 2–4 choices. Selecting a choice sends your reply back to the agent. Only "End session" terminates the turn.
 
 ### Agent History (per-session)
 
@@ -121,7 +121,7 @@ graph TB
     subgraph "Session Control"
         CONTINUE[Continue session]
         SDIFF[Optional session diff browser]
-        CONFIRM{confirm_task_complete}
+        CONFIRM{ask_kra}
         END[End session]
 
         DONE --> CONTINUE --> PROMPT

--- a/__tests__/AI/AIAgent/buildOrchestratorSystemMessage.test.ts
+++ b/__tests__/AI/AIAgent/buildOrchestratorSystemMessage.test.ts
@@ -10,7 +10,7 @@ describe('buildOrchestratorSystemMessage', () => {
         expect(out).toContain('<surgical_edits>');
         expect(out).toContain('<creating_files>');
         expect(out).toContain('<long_term_memory');
-        expect(out).toContain('Reminder: Always call confirm_task_complete');
+        expect(out).toContain('Reminder: Always call ask_kra');
     });
 
     it('omits the delegation block when no sub-agents are enabled', () => {

--- a/__tests__/AI/AIAgent/subAgents/buildExecutorTranscript.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/buildExecutorTranscript.test.ts
@@ -100,12 +100,12 @@ describe('buildExecutorTranscriptBlocks', () => {
         expect(chat).toContain(fullFile);
     });
 
-    it('filters out unrelated tool families (web_*, ask_user, confirm_task_complete, sub-agents)', () => {
+    it('filters out unrelated tool families (web_*, ask_user, ask_kra, sub-agents)', () => {
         const slice: TranscriptEntry[] = [
             { kind: 'tool_call', toolName: 'web_search', args: { query: 'foo' }, result: 'WEB RESULT', success: true },
             { kind: 'tool_call', toolName: 'web_fetch', args: { url: 'http://x' }, result: 'PAGE', success: true },
             { kind: 'tool_call', toolName: 'ask_user', args: { question: 'q' }, result: 'a', success: true },
-            { kind: 'tool_call', toolName: 'confirm_task_complete', args: {}, result: '', success: true },
+            { kind: 'tool_call', toolName: 'ask_kra', args: {}, result: '', success: true },
             { kind: 'tool_call', toolName: 'execute', args: {}, result: 'sub-agent ran', success: true },
             { kind: 'tool_call', toolName: 'get_outline', args: { file_path: 'a.ts' }, result: 'KEEP_THIS', success: true },
         ];

--- a/__tests__/AI/AIAgent/subAgents/whitelist.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/whitelist.test.ts
@@ -32,7 +32,7 @@ describe('matchesSubAgentWhitelist', () => {
 
     it('rejects tools not in the whitelist', () => {
         expect(matchesSubAgentWhitelist('bash', whitelist)).toBe(false);
-        expect(matchesSubAgentWhitelist('confirm_task_complete', whitelist)).toBe(false);
+        expect(matchesSubAgentWhitelist('ask_kra', whitelist)).toBe(false);
         expect(matchesSubAgentWhitelist('kra-bash-bash', whitelist)).toBe(false);
     });
 

--- a/ai-files/lua/kra_agent/popups/permission.lua
+++ b/ai-files/lua/kra_agent/popups/permission.lua
@@ -324,6 +324,20 @@ function M.request_permission(channel_id, payload)
         end
     end
 
+    local function prompt_deny_reason()
+        vim.ui.input({ prompt = "Deny reason (Enter = skip, Esc = cancel back): " }, function(reason)
+            if reason == nil then
+                vim.schedule(function()
+                    if win and vim.api.nvim_win_is_valid(win) then
+                        vim.api.nvim_set_current_win(win)
+                    end
+                end)
+                return
+            end
+            send_permission(channel_id, "deny", reason)
+        end)
+    end
+
     local function execute_action(action_id)
         if action_id == "allow" then
             send_permission(channel_id, "allow")
@@ -340,7 +354,7 @@ function M.request_permission(channel_id, payload)
         elseif action_id == "yolo" then
             send_permission(channel_id, "yolo")
         else
-            send_permission(channel_id, "deny")
+            prompt_deny_reason()
         end
     end
 

--- a/docs/agent/tools-and-mcp.md
+++ b/docs/agent/tools-and-mcp.md
@@ -166,7 +166,7 @@ Behavior notes:
 - `Ctrl-C` (`stop_stream`) aborts the executor and returns control to the
   orchestrator. The orchestrator sees the partial event log captured so far.
 - Executor tool whitelist (default): `read_lines`, `get_outline`, `anchor_edit`,
-  `create_file`, `search`, `lsp_query`, `bash`. `confirm_task_complete` and
+  `create_file`, `search`, `lsp_query`, `bash`. `ask_kra` and
   other end-of-turn tools are forbidden — the orchestrator owns the turn.
 - Hard cap of `maxToolCalls` (default 60) tool calls before the executor is
   expected to submit — prevents runaway loops on bad plans.

--- a/docs/agent/workflow-and-keymaps.md
+++ b/docs/agent/workflow-and-keymaps.md
@@ -47,7 +47,7 @@ Opens searchable history of all tool calls in this session.
 
 Auto-approved tools:
 
-- `confirm_task_complete`
+- `ask_kra`
 
 All other tools require approval in strict mode.
 

--- a/src/AI/AIAgent/mcp/serverConfig.ts
+++ b/src/AI/AIAgent/mcp/serverConfig.ts
@@ -20,7 +20,7 @@ export async function buildCoreMcpServers(): Promise<Record<string, MCPServerCon
 
     return {
         ...configuredServers,
-        'kra-session-complete': stdioServer('sessionCompleteMcpServer.js', ['confirm_task_complete']),
+        'kra-session-complete': stdioServer('sessionCompleteMcpServer.js', ['ask_kra']),
         'kra-file-context': stdioServer('fileContextMcpServer.js', [
             'get_outline',
             'read_lines',

--- a/src/AI/AIAgent/shared/fileContext/format.ts
+++ b/src/AI/AIAgent/shared/fileContext/format.ts
@@ -1,6 +1,5 @@
 import { formatOutline, getFileOutline } from '../utils/fileOutline';
-import { getDiagnosticsForFile } from '../utils/lspDiagnostics';
-import { getLspDiagnosticsForFile } from '../utils/lspDiagnosticsBridge';
+import { getProjectDiagnostics } from '../utils/lspDiagnosticsBridge';
 
 /**
  * Build a compact outline string for read_function not-found errors so we don't
@@ -30,35 +29,13 @@ export function totalRequestedLines(starts: number[], ends: number[]): number {
 }
 
 /**
- * Append diagnostics (errors + warnings, single-file scope) to an edit
- * summary so the agent sees them in the same turn it made the change.
- *
- * Source order:
- *   1. If the file's extension has a configured LSP server in settings.toml,
- *      ask that server (pull-mode `textDocument/diagnostic`, falling back to
- *      cached push-mode `publishDiagnostics`). This is the same code path
- *      used by editors like VS Code and Neovim.
- *   2. Otherwise (or if the LSP path returned nothing usable), fall back to
- *      the in-process TypeScript Compiler API check for .ts/.js files.
- *
- * Silent no-op when neither path produces diagnostics.
+ * Append diagnostics to an edit summary so the agent sees them in the same
+ * turn it made the change — no need for it to run `tsc` / `npm run build` /
+ * `cargo check` / `go build` etc. separately. Routing happens inside
+ * `getProjectDiagnostics`; see lspDiagnosticsBridge.ts for the source order.
  */
 export async function withDiagnostics(filePath: string, summary: string): Promise<string> {
-    let diags: string | undefined;
-
-    try {
-        diags = await getLspDiagnosticsForFile(filePath);
-    } catch {
-        // ignore; try the in-process fallback
-    }
-
-    if (!diags) {
-        try {
-            diags = getDiagnosticsForFile(filePath);
-        } catch {
-            return summary;
-        }
-    }
+    const diags = await getProjectDiagnostics(filePath);
 
     return diags ? `${summary}\n\n${diags}` : summary;
 }

--- a/src/AI/AIAgent/shared/fileContext/tools.ts
+++ b/src/AI/AIAgent/shared/fileContext/tools.ts
@@ -59,6 +59,7 @@ export const TOOLS = [
             'Examples: replace single line → { op:"replace", anchor:"const TIMEOUT_MS = 5000;", content:"const TIMEOUT_MS = 30000;" }.',
             'Replace multi-line region → { op:"replace", anchor:"function oldImpl() {", end_anchor:"} // oldImpl", content:"function newImpl() {\\n    return doIt();\\n}" }.',
             'Insert after import → { op:"insert", anchor:"import { foo } from \'./foo\';", position:"after", content:"import { bar } from \'./bar\';" }.',
+            'After every successful edit, project-wide diagnostics are appended automatically (errors across the whole project; warnings on the edited file). Do NOT run `tsc` / `npm run build` / `cargo check` / `go build` etc. yourself — only run them if the diagnostics block is truncated ("...and N more") or absent for a language you expect to be checked.',
         ].join(' '),
         inputSchema: {
             type: 'object',
@@ -104,7 +105,7 @@ export const TOOLS = [
 
     {
         name: 'create_file',
-        description: 'Creates a NEW file (refuses if the path already exists; use anchor_edit to modify existing files). Parent directories are created automatically; writes are atomic.',
+        description: 'Creates a NEW file (refuses if the path already exists; use anchor_edit to modify existing files). Parent directories are created automatically; writes are atomic. After a successful create, project-wide diagnostics are appended automatically — do NOT run `tsc` / `npm run build` / `cargo check` / `go build` etc. yourself unless the diagnostics block is truncated or absent.',
         inputSchema: {
             type: 'object',
             properties: {

--- a/src/AI/AIAgent/shared/main/agentConversation.ts
+++ b/src/AI/AIAgent/shared/main/agentConversation.ts
@@ -166,7 +166,7 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
         model: options.model,
         workingDirectory: cwd,
         mcpServers: mergedMcpServers,
-        excludedTools: ['str_replace_editor', 'write_file', 'read_file', 'edit', 'view', 'grep', 'glob', 'create', 'apply_patch', 'report_intent', ...(options.provider === 'byok' ? ['confirm_task_complete'] : [])],
+        excludedTools: ['str_replace_editor', 'write_file', 'read_file', 'edit', 'view', 'grep', 'glob', 'create', 'apply_patch', 'report_intent', ...(options.provider === 'copilot' ? ['ask_user'] : [])],
         ...(orchestratorLocalTools.length > 0 ? { localTools: orchestratorLocalTools } : {}),
         ...(options.contextWindow !== undefined ? { contextWindow: options.contextWindow } : {}),
         ...(options.modelCapabilities ? { modelCapabilities: options.modelCapabilities } : {}),
@@ -349,14 +349,14 @@ export function buildOrchestratorSystemMessage(opts: OrchestratorSystemMessageOp
     sections.push(buildLongTermMemoryBlock(investigateEnabled));
 
     if (opts.isCopilot) {
-        sections.push('Reminder: Always call confirm_task_complete before ending your turn.');
+        sections.push('Reminder: Always call ask_kra before ending your turn.');
     }
 
     return sections.join('\n\n');
 }
 
 const TURN_COMPLETION_BLOCK = `<turn_completion priority="critical">
-End every turn by calling \`confirm_task_complete\` with a concise summary and 2–4 concrete choices — whether you finished, are blocked, or need clarification. Never end with plain text.
+End every turn by calling \`ask_kra\` with a concise summary and 2–4 concrete choices — whether you finished, are blocked, or need clarification. Never end with plain text.
 </turn_completion>`;
 
 const WORKSPACE_BLOCK = `<workspace>
@@ -365,6 +365,10 @@ You are in a detached proposal workspace. Edits land in the real repository only
 
 const CREATING_FILES_BLOCK = `<creating_files>
 Use \`create_file\` for new files only. It refuses if the file already exists. For existing files, use the \`edit\` tool.
+
+Do NOT use bash/shell for file mutations (no \`cat > file\`, \`echo ... >\`, \`sed -i\`, \`tee\`, heredocs writing files, etc.). Use \`anchor_edit\` for in-place changes. If you need to almost completely rewrite a file, delete it via bash \`rm\` and then \`create_file\` with the new content.
+
+Project-wide LSP diagnostics are auto-appended to every \`edit\`/\`create_file\` result for the touched language. Do NOT run \`tsc\`, \`tsc --noEmit\`, \`npm run build\`, \`cargo check\`, \`go build\`, or similar type-check/build commands just to surface errors — that work has already been done. Only invoke build/test commands when you actually need their side effects (running tests, producing artifacts).
 </creating_files>`;
 
 function buildDelegationBlock(opts: OrchestratorSystemMessageOpts): string {
@@ -383,7 +387,7 @@ function buildDelegationBlock(opts: OrchestratorSystemMessageOpts): string {
             : 'a transcript of your prior file reads and reasoning since the last execute';
 
         lines.push(`- \`execute\` — concrete multi-step work (refactor, feature, multi-file edit). Returns ONLY a curated event log + summary; raw tool traffic stays out of your context. Do NOT copy findings/file contents into \`plan\` — the executor automatically receives ${transcriptNote}.`);
-        lines.push('  - If executor returns `status: needs_decision`, it hit a real design crossroad. Present the `decisionPoint.question` (and `options[]` if any) to the user via `confirm_task_complete` — do NOT autonomously decide. Once the user picks, re-issue `execute` with an updated plan.');
+        lines.push('  - If executor returns `status: needs_decision`, it hit a real design crossroad. Present the `decisionPoint.question` (and `options[]` if any) to the user via `ask_kra` — do NOT autonomously decide. Once the user picks, re-issue `execute` with an updated plan.');
         lines.push('  - `needs_replan` and `blocked` also allow re-issue with an updated plan.');
         lines.push('  - **Session continuation**: If the result includes a `sessionId`, pass it back as `sessionId` on the re-issued `execute` call. The executor then continues from its stored conversation rather than starting fresh — you do NOT need to repeat prior context in the new plan.');
     }
@@ -456,6 +460,8 @@ Multi-edit: pass several entries in one call. Anchors resolve against ORIGINAL f
       content: "import { bar } from './bar';" }
 
 The anchor IS the contract — only matched region changes. Pick tight unique anchors; widen ONLY to disambiguate.
+
+**Minimum-footprint rule:** the lines you replace must be approximately the lines that actually change. If only 2 lines change, only ~2 lines should be in \`anchor\` + \`content\` — not 20, not 200, not the whole function or file. Do NOT pad the anchor or content with surrounding unchanged code as a "buffer". If a small edit is rejected, read the reason carefully, and retry with a *different* small anchor (or several small edits batched in one call); never widen scope to the whole block/file as a workaround. Whole-file rewrites belong to \`rm\` + \`create_file\`, not \`anchor_edit\`.
 </surgical_edits>`;
 }
 
@@ -482,3 +488,6 @@ ${discoveryRule}
 - \`edit_memory\` to refine in place (re-embeds on title/body change) instead of creating duplicates.
 </long_term_memory>`;
 }
+
+
+

--- a/src/AI/AIAgent/shared/main/turnReminder.ts
+++ b/src/AI/AIAgent/shared/main/turnReminder.ts
@@ -1,10 +1,10 @@
 /**
  * Cross-provider turn reminder. Inject after every user prompt (or as the
  * first hint of every assistant turn) to keep the agent disciplined about
- * calling `confirm_task_complete` before ending its turn.
+ * calling `ask_kra` before ending its turn.
  *
  * Lives in `shared/` so both Copilot and BYOK providers reference the same
  * string — no duplication, no drift.
  */
 export const TURN_REMINDER =
-    'REMINDER: Call confirm_task_complete before ending your turn — whether you are done, need clarification, or want to ask the user anything.';
+    'REMINDER: Call ask_kra before ending your turn — whether you are done, need clarification, or want to ask the user anything.';

--- a/src/AI/AIAgent/shared/subAgents/buildExecutorTranscript.ts
+++ b/src/AI/AIAgent/shared/subAgents/buildExecutorTranscript.ts
@@ -41,7 +41,7 @@ export function buildExecutorTranscriptBlocks(slice: TranscriptEntry[]): string 
         }
 
         if (entry.kind === 'tool_call' && !isFileContextToolName(entry.toolName)) {
-            // Drop unrelated tool families (web_*, ask_user, confirm_task_complete,
+            // Drop unrelated tool families (web_*, ask_user, ask_kra,
             // sub-agent dispatch results, etc.).
             continue;
         }

--- a/src/AI/AIAgent/shared/types/agentTypes.ts
+++ b/src/AI/AIAgent/shared/types/agentTypes.ts
@@ -284,6 +284,8 @@ export interface AgentConversationState {
 export interface ToolApprovalResult {
     action: 'allow' | 'deny' | 'allow-family' | 'yolo';
     modifiedArgs?: unknown;
+    /** Optional free-form reason supplied by the user when explicitly denying. */
+    denyReason?: string;
 }
 
 // ─── Hook input/output (used by both providers and agentToolHook) ────────────

--- a/src/AI/AIAgent/shared/utils/agentToolApproval.ts
+++ b/src/AI/AIAgent/shared/utils/agentToolApproval.ts
@@ -104,7 +104,7 @@ export function getToolFamily(toolName: string): string {
 }
 
 export function shouldAutoApproveTool(toolName: string): boolean {
-    return toolName === 'confirm_task_complete';
+    return toolName === 'ask_kra';
 }
 
 export function extractWriteRequest(toolArgs: unknown, workspacePath: string): ToolWriteRequest | undefined {

--- a/src/AI/AIAgent/shared/utils/agentToolHook.ts
+++ b/src/AI/AIAgent/shared/utils/agentToolHook.ts
@@ -480,7 +480,8 @@ export async function promptToolApproval(
                 return;
             }
 
-            resolve({ action: 'deny' });
+            const reasonRaw = typeof args[1] === 'string' ? args[1].trim() : '';
+            resolve({ action: 'deny', ...(reasonRaw.length > 0 ? { denyReason: reasonRaw } : {}) });
         };
 
         nvimClient.on('notification', handler);
@@ -595,7 +596,7 @@ export async function applyStrReplaceEditorDirectly(
     };
 }
 
-export async function handleConfirmTaskComplete(
+export async function handleAskKra(
     state: AgentConversationState,
     input: AgentPreToolUseHookInput
 ): Promise<AgentPreToolUseHookOutput> {
@@ -639,7 +640,7 @@ export async function handleConfirmTaskComplete(
     // (free, no extra credit) and acts on the user's reply.
     return {
         permissionDecision: 'deny',
-        permissionDecisionReason: `User says: "${answer}". Continue based on this reply. Do not end your turn — call confirm_task_complete again only when you need the user again.`,
+        permissionDecisionReason: `User says: "${answer}". Continue based on this reply. Do not end your turn — call ask_kra again only when you need the user again.`,
     };
 }
 
@@ -788,11 +789,11 @@ export async function handlePreToolUse(
     const toolFamily = getToolFamily(input.toolName);
     const workspacePath = state.cwd;
 
-    // `confirm_task_complete` can arrive as bare name or MCP-prefixed
-    // (e.g. "kra-session-complete:confirm_task_complete", or with underscores
+    // `ask_kra` can arrive as bare name or MCP-prefixed
+    // (e.g. "kra-session-complete:ask_kra", or with underscores
     // depending on SDK version). Use includes() so any format matches.
-    if (input.toolName.includes('confirm_task_complete')) {
-        return handleConfirmTaskComplete(state, input);
+    if (input.toolName.includes('ask_kra')) {
+        return handleAskKra(state, input);
     }
 
     if (shouldAutoApproveTool(input.toolName)) {
@@ -882,9 +883,14 @@ export async function handlePreToolUse(
     }
 
     if (decision.action === 'deny') {
+        const baseReason = 'Denied by user. Do not retry this tool call. Call ask_kra immediately to explain what you were trying to do and ask the user what they want instead.';
+        const reason = decision.denyReason
+            ? `User denied this tool call with reason: "${decision.denyReason}". Treat the user's reason as authoritative direction and follow it. Only call ask_kra if you need more information to proceed.`
+            : baseReason;
+
         return {
             permissionDecision: 'deny',
-            permissionDecisionReason: 'Denied by user. Do not retry this tool call. Call confirm_task_complete immediately to explain what you were trying to do and ask the user what they want instead.',
+            permissionDecisionReason: reason,
         };
     }
 
@@ -992,3 +998,4 @@ export async function handlePreToolUse(
 
     return { permissionDecision: 'allow' };
 }
+

--- a/src/AI/AIAgent/shared/utils/agentUi.ts
+++ b/src/AI/AIAgent/shared/utils/agentUi.ts
@@ -13,7 +13,7 @@ export function formatToolLine(toolSummary: string, success: boolean): string {
 }
 
 /**
- * Written to the chat file when confirm_task_complete fires so the user can
+ * Written to the chat file when ask_kra fires so the user can
  * see what the AI is asking before and after they answer the popup.
  */
 export function formatConfirmQuestion(question: string, choices: string[]): string {

--- a/src/AI/AIAgent/shared/utils/lspClient.ts
+++ b/src/AI/AIAgent/shared/utils/lspClient.ts
@@ -202,6 +202,7 @@ export class LspClient {
                 workspace: {
                     workspaceFolders: true,
                     configuration: false,
+                    diagnostics: { refreshSupport: true },
                 },
             },
             initializationOptions: this.spec.initOptions ?? null,

--- a/src/AI/AIAgent/shared/utils/lspDiagnostics.ts
+++ b/src/AI/AIAgent/shared/utils/lspDiagnostics.ts
@@ -6,12 +6,18 @@
  * we share the LanguageService across edits in the same session so warm
  * checks are sub-second.
  *
- * Public entry point: getDiagnosticsForFile(filePath) — returns a formatted
- * string of errors+warnings for that single file, or undefined if there are
- * none, the file is not a TS/JS source, or the project couldn't be loaded.
+ * Public entry points:
+ *   - getDiagnosticsForProject(filePath) — runs a project-wide check (errors
+ *     across every TS source under the project's tsconfig, plus warnings on
+ *     the just-edited file). Returns a formatted block, with a net-change
+ *     footer when the error count moved since the last edit, or undefined
+ *     when there are no errors and no resolved errors to announce.
+ *   - getDiagnosticsForFile(filePath) — single-file errors+warnings. Kept
+ *     for callers that want the cheap path (e.g. fallback / tests).
  *
- * The MCP server appends the result to edit / create_file responses so
- * the agent sees type errors in the same turn it made the change.
+ * The MCP server appends the project-scope result to edit / create_file
+ * responses so the agent sees the full type picture in the same turn it
+ * made the change — no need for it to run `tsc` separately.
  */
 
 import * as ts from 'typescript';
@@ -21,14 +27,23 @@ import * as fs from 'fs';
 const TS_EXTS = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs']);
 
 const MAX_DIAGNOSTICS = 20;
+const MAX_PROJECT_DIAGNOSTICS = 30;
+
+export function isTsLikeFile(filePath: string): boolean {
+    return TS_EXTS.has(path.extname(filePath).toLowerCase());
+}
 
 interface IProject {
     rootDir: string;
+    configPath: string | undefined;
     compilerOptions: ts.CompilerOptions;
     rootFiles: Set<string>;
     fileVersions: Map<string, number>;
     fileSnapshots: Map<string, string>;
     service: ts.LanguageService;
+    // -1 means "never measured"; used for the net-change footer so the agent
+    // gets explicit positive feedback when an edit fixes errors.
+    lastErrorCount: number;
 }
 
 const projects = new Map<string, IProject>();
@@ -55,12 +70,14 @@ function loadProject(filePath: string): IProject | undefined {
 
     const project: IProject = {
         rootDir,
+        configPath,
         compilerOptions,
         rootFiles,
         fileVersions: new Map(),
         fileSnapshots: new Map(),
         // Set after host construction below.
         service: null as unknown as ts.LanguageService,
+        lastErrorCount: -1,
     };
 
     const host: ts.LanguageServiceHost = {
@@ -90,17 +107,196 @@ function loadProject(filePath: string): IProject | undefined {
     return project;
 }
 
-function formatDiagnostic(d: ts.Diagnostic): string {
-    const msg = ts.flattenDiagnosticMessageText(d.messageText, '\n  ');
+function formatDiagnosticBody(d: ts.Diagnostic): string {
+    const msg = ts.flattenDiagnosticMessageText(d.messageText, '\n    ');
     const sev = d.category === ts.DiagnosticCategory.Error ? 'error' : 'warning';
     if (d.file && d.start !== undefined) {
         const { line, character } = d.file.getLineAndCharacterOfPosition(d.start);
 
-        return `  L${line + 1}:${character + 1}  ${sev} TS${d.code}: ${msg}`;
+        return `L${line + 1}:${character + 1}  ${sev} TS${d.code}: ${msg}`;
     }
 
-    return `  ${sev} TS${d.code}: ${msg}`;
+    return `${sev} TS${d.code}: ${msg}`;
 }
+
+function formatDiagnostic(d: ts.Diagnostic): string {
+    return `  ${formatDiagnosticBody(d)}`;
+}
+
+function isUnderProjectRoot(absPath: string, rootDir: string): boolean {
+    const rel = path.relative(rootDir, absPath);
+    if (rel === '' ) return true;
+    if (rel.startsWith('..') || path.isAbsolute(rel)) return false;
+    if (rel.split(path.sep).includes('node_modules')) return false;
+
+    return true;
+}
+
+function isCheckableProjectFile(absPath: string, rootDir: string): boolean {
+    if (!isUnderProjectRoot(absPath, rootDir)) return false;
+    if (absPath.endsWith('.d.ts')) return false;
+
+    return true;
+}
+
+/**
+ * Project-wide diagnostics: errors across every TS source under the same
+ * tsconfig as `editedFilePath`, plus warnings on the edited file itself.
+ *
+ * Returns:
+ *   - A formatted block when the project has at least one error/warning to
+ *     show, or when the error count *dropped* since the last call (so the
+ *     agent gets a positive "net change" signal even with zero errors).
+ *   - undefined when there's nothing to say (no errors now, none last time,
+ *     no warnings on the edited file, or the file isn't TS/JS).
+ */
+export function getDiagnosticsForProject(editedFilePath: string): string | undefined {
+    const ext = path.extname(editedFilePath).toLowerCase();
+    if (!TS_EXTS.has(ext)) return undefined;
+
+    const editedAbs = path.resolve(editedFilePath);
+
+    let project: IProject | undefined;
+    try {
+        project = loadProject(editedAbs);
+    } catch {
+        return undefined;
+    }
+    if (!project) return undefined;
+
+    // Re-snapshot the just-edited file from disk so the LanguageService sees
+    // the freshest version. Other files keep whatever snapshot/version they
+    // already had (TS reads them lazily through the host's readFile).
+    let editedExists = true;
+    try {
+        const content = fs.readFileSync(editedAbs, 'utf8');
+        const v = (project.fileVersions.get(editedAbs) ?? 0) + 1;
+        project.fileVersions.set(editedAbs, v);
+        project.fileSnapshots.set(editedAbs, content);
+        project.rootFiles.add(editedAbs);
+    } catch {
+        // File was deleted or is not readable — still useful to report
+        // diagnostics for the rest of the project.
+        editedExists = false;
+    }
+
+    const program = project.service.getProgram();
+    if (!program) return undefined;
+
+    const fileDiags = new Map<string, ts.Diagnostic[]>();
+    let totalErrors = 0;
+    let totalWarnings = 0;
+
+    for (const sf of program.getSourceFiles()) {
+        const abs = path.resolve(sf.fileName);
+        if (!isCheckableProjectFile(abs, project.rootDir)) continue;
+
+        const isEdited = abs === editedAbs;
+
+        let diags: ts.Diagnostic[];
+        try {
+            diags = [
+                ...project.service.getSyntacticDiagnostics(abs),
+                ...project.service.getSemanticDiagnostics(abs),
+            ];
+        } catch {
+            continue;
+        }
+
+        // Errors everywhere; warnings only on the edited file (otherwise stale
+        // warnings in unrelated files would pollute every turn).
+        const filtered = diags.filter((d) => {
+            if (d.category === ts.DiagnosticCategory.Error) return true;
+            if (isEdited && d.category === ts.DiagnosticCategory.Warning) return true;
+
+            return false;
+        });
+
+        if (filtered.length === 0) continue;
+
+        for (const d of filtered) {
+            if (d.category === ts.DiagnosticCategory.Error) totalErrors++;
+            else if (d.category === ts.DiagnosticCategory.Warning) totalWarnings++;
+        }
+
+        fileDiags.set(abs, filtered);
+    }
+
+    const previousErrors = project.lastErrorCount;
+    project.lastErrorCount = totalErrors;
+
+    const delta = previousErrors >= 0 ? totalErrors - previousErrors : null;
+
+    if (fileDiags.size === 0) {
+        // Positive feedback when the agent's edit cleared errors.
+        if (delta !== null && delta < 0) {
+            const fixed = Math.abs(delta);
+
+            return `Diagnostics for project: 0 errors. (net change since last edit: -${fixed} error${fixed === 1 ? '' : 's'})`;
+        }
+
+        return undefined;
+    }
+
+    const orderedFiles = Array.from(fileDiags.keys()).sort((a, b) => {
+        if (a === editedAbs && b !== editedAbs) return -1;
+        if (b === editedAbs && a !== editedAbs) return 1;
+
+        return a.localeCompare(b);
+    });
+
+    const headerCounts = [
+        `${totalErrors} error${totalErrors === 1 ? '' : 's'}`,
+        totalWarnings > 0 ? `${totalWarnings} warning${totalWarnings === 1 ? '' : 's'}` : null,
+    ].filter(Boolean).join(', ');
+
+    const lines: string[] = [`Diagnostics for project (${headerCounts}):`];
+
+    let shown = 0;
+    let truncated = 0;
+
+    for (const f of orderedFiles) {
+        const rel = path.relative(project.rootDir, f) || path.basename(f);
+        const fileLines: string[] = [];
+
+        for (const d of fileDiags.get(f)!) {
+            if (shown >= MAX_PROJECT_DIAGNOSTICS) {
+                truncated++;
+                continue;
+            }
+            fileLines.push(`    ${formatDiagnosticBody(d)}`);
+            shown++;
+        }
+
+        if (fileLines.length > 0) {
+            lines.push(`  ${rel}:`);
+            lines.push(...fileLines);
+        }
+    }
+
+    if (truncated > 0) {
+        const tsconfigArg = project.configPath
+            ? ` -p ${path.relative(project.rootDir, project.configPath) || project.configPath}`
+            : '';
+
+        lines.push(`  ...and ${truncated} more — run \`npx tsc --noEmit${tsconfigArg}\` for the full list.`);
+    }
+
+    if (delta !== null && delta !== 0) {
+        const sign = delta > 0 ? '+' : '';
+
+        lines.push('');
+        lines.push(`(net change since last edit: ${sign}${delta} error${Math.abs(delta) === 1 ? '' : 's'})`);
+    }
+
+    if (!editedExists) {
+        lines.push('');
+        lines.push(`(${path.relative(project.rootDir, editedAbs) || path.basename(editedAbs)} was not readable; reporting the rest of the project.)`);
+    }
+
+    return lines.join('\n');
+}
+
 
 export function getDiagnosticsForFile(filePath: string): string | undefined {
     const ext = path.extname(filePath).toLowerCase();

--- a/src/AI/AIAgent/shared/utils/lspDiagnosticsBridge.ts
+++ b/src/AI/AIAgent/shared/utils/lspDiagnosticsBridge.ts
@@ -1,27 +1,43 @@
 /**
- * Bridge between the post-edit `withDiagnostics()` hook in
- * fileContextMcpServer.ts and the generic LSP layer.
+ * Single entry point for post-edit diagnostics. Resolves to the cheapest
+ * source that can answer for the given file:
  *
- * For any file with a configured language server, asks that server for
- * diagnostics (errors + warnings) using pull mode (`textDocument/diagnostic`)
- * if the server advertises a diagnosticProvider, falling back to push mode
- * (cached `publishDiagnostics`) with a short timed wait otherwise.
+ *   1. If the file's configured LSP server advertises
+ *      `diagnosticProvider.workspaceDiagnostics`, ask it for project-wide
+ *      pull diagnostics via `workspace/diagnostic` (LSP 3.17). This is the
+ *      preferred path for languages like Go (gopls) and Rust (rust-analyzer)
+ *      when their `[lsp.*]` blocks are active.
+ *   2. Else if the file is TypeScript/JavaScript, run a project-wide check
+ *      against the in-process TypeScript Compiler API (no TS LSP server in
+ *      the wild advertises workspaceDiagnostics today: typescript-language-
+ *      server, vtsls and biome are all push-only).
+ *   3. Else if the file has a configured LSP server, ask it for single-file
+ *      diagnostics via `textDocument/diagnostic` (pull) or cached
+ *      `publishDiagnostics` (push).
+ *   4. Else return undefined.
  *
- * Output format mirrors the legacy in-process TS diagnostics formatter so
- * downstream rendering is identical.
+ * On unexpected error in (1) or (2) we fall through to (3) / single-file TS
+ * fallback so the agent never loses diagnostics due to a transient failure.
  */
 
 import * as path from 'path';
 import { getLspRegistry } from './lspRegistry';
-import { fileUri } from './lspClient';
+import { fileUri, LspClient } from './lspClient';
 import {
     DocumentDiagnosticRequest,
+    WorkspaceDiagnosticRequest,
     Diagnostic,
     DiagnosticSeverity,
 } from 'vscode-languageserver-protocol/node.js';
+import {
+    getDiagnosticsForFile,
+    getDiagnosticsForProject,
+    isTsLikeFile,
+} from './lspDiagnostics';
 
 const DEFAULT_PUSH_WAIT_MS = 800;
 const MAX_DIAGNOSTICS = 20;
+const MAX_WORKSPACE_DIAGNOSTICS = 30;
 
 function severityLabel(sev: DiagnosticSeverity | undefined): string {
     switch (sev) {
@@ -50,9 +66,10 @@ function isErrorOrWarning(d: Diagnostic): boolean {
 }
 
 /**
- * Returns a formatted diagnostics block for the file, or undefined when the
- * file has no configured server, the server can't be reached, or the file
- * has no error/warning diagnostics.
+ * Single-file diagnostics from a configured LSP server. Used as the
+ * fallback path inside `getProjectDiagnostics`. Public so tests / future
+ * callers can hit it directly, but new code should prefer
+ * `getProjectDiagnostics`.
  */
 export async function getLspDiagnosticsForFile(filePath: string, waitMs = DEFAULT_PUSH_WAIT_MS): Promise<string | undefined> {
     const absPath = path.resolve(filePath);
@@ -123,3 +140,171 @@ export async function getLspDiagnosticsForFile(filePath: string, waitMs = DEFAUL
 
     return `Diagnostics for ${rel} (${filtered.length}):\n${shown.join('\n')}${more}`;
 }
+
+async function tryWorkspaceDiagnostics(
+    client: LspClient,
+    editedAbs: string,
+): Promise<string | undefined> {
+    const dp = client.capabilities?.diagnosticProvider;
+    const supportsWorkspace = typeof dp === 'object'
+        && (dp as { workspaceDiagnostics?: boolean }).workspaceDiagnostics === true;
+    if (!supportsWorkspace) return undefined;
+
+    type WsItem = { kind?: string; uri: string; items?: Diagnostic[] };
+    type WsReport = { items?: WsItem[] };
+
+    let report: WsReport | undefined;
+    try {
+        report = await client.sendRequest<unknown, WsReport>(
+            WorkspaceDiagnosticRequest.type,
+            { previousResultIds: [] },
+        );
+    } catch {
+        return undefined;
+    }
+    if (!report.items) return undefined;
+
+    const byFile = new Map<string, Diagnostic[]>();
+    let totalErrors = 0;
+    let totalWarnings = 0;
+
+    for (const it of report.items) {
+        if (it.kind && it.kind !== 'full') continue;
+        if (!it.items || it.items.length === 0) continue;
+
+        const abs = path.resolve(uriToFilePath(it.uri));
+        const isEdited = abs === editedAbs;
+
+        const keep = it.items.filter((d) => {
+            if (d.severity === DiagnosticSeverity.Error) return true;
+            if (isEdited && d.severity === DiagnosticSeverity.Warning) return true;
+
+            return false;
+        });
+        if (keep.length === 0) continue;
+
+        for (const d of keep) {
+            if (d.severity === DiagnosticSeverity.Error) totalErrors++;
+            else if (d.severity === DiagnosticSeverity.Warning) totalWarnings++;
+        }
+        byFile.set(abs, keep);
+    }
+
+    if (byFile.size === 0) return undefined;
+
+    const ordered = Array.from(byFile.keys()).sort((a, b) => {
+        if (a === editedAbs && b !== editedAbs) return -1;
+        if (b === editedAbs && a !== editedAbs) return 1;
+
+        return a.localeCompare(b);
+    });
+
+    const headerCounts = [
+        `${totalErrors} error${totalErrors === 1 ? '' : 's'}`,
+        totalWarnings > 0 ? `${totalWarnings} warning${totalWarnings === 1 ? '' : 's'}` : null,
+    ].filter(Boolean).join(', ');
+
+    const lines: string[] = [`Diagnostics for project (${headerCounts}):`];
+    let shown = 0;
+    let truncated = 0;
+
+    for (const f of ordered) {
+        const rel = path.relative(process.cwd(), f) || path.basename(f);
+        const fileLines: string[] = [];
+
+        for (const d of byFile.get(f) ?? []) {
+            if (shown >= MAX_WORKSPACE_DIAGNOSTICS) {
+                truncated++;
+                continue;
+            }
+            fileLines.push(`    ${formatOne(d).trimStart()}`);
+            shown++;
+        }
+
+        if (fileLines.length > 0) {
+            lines.push(`  ${rel}:`);
+            lines.push(...fileLines);
+        }
+    }
+
+    if (truncated > 0) lines.push(`  ...and ${truncated} more.`);
+
+    return lines.join('\n');
+}
+
+function uriToFilePath(uri: string): string {
+    if (uri.startsWith('file://')) {
+        try {
+            return decodeURIComponent(new URL(uri).pathname);
+        } catch {
+            return uri.slice(7);
+        }
+    }
+
+    return uri;
+}
+
+/**
+ * Single public entry point used by the post-edit `withDiagnostics()` hook.
+ * Routes through the cheapest source that can answer for `filePath` — see
+ * the file-level docstring for the full preference order. Never throws.
+ */
+export async function getProjectDiagnostics(filePath: string): Promise<string | undefined> {
+    const absPath = path.resolve(filePath);
+
+    let registry;
+    try {
+        registry = await getLspRegistry();
+    } catch {
+        registry = undefined;
+    }
+
+    const hasServer = registry ? registry.hasServerFor(absPath) : false;
+
+    if (hasServer && registry) {
+        let client;
+        try {
+            client = await registry.getClientFor(absPath);
+        } catch {
+            client = undefined;
+        }
+
+        if (client) {
+            try {
+                await client.refreshFile(absPath);
+                await client.openFile(absPath);
+            } catch {
+                // proceed; workspace diagnostics may still work
+            }
+
+            const ws = await tryWorkspaceDiagnostics(client, absPath);
+            if (ws) return ws;
+        }
+    }
+
+    if (isTsLikeFile(absPath)) {
+        try {
+            const proj = getDiagnosticsForProject(absPath);
+            if (proj) return proj;
+        } catch {
+            // fall through to single-file fallback
+        }
+
+        try {
+            return getDiagnosticsForFile(absPath);
+        } catch {
+            return undefined;
+        }
+    }
+
+    if (hasServer) {
+        try {
+            return await getLspDiagnosticsForFile(absPath);
+        } catch {
+            return undefined;
+        }
+    }
+
+    return undefined;
+}
+

--- a/src/AI/AIAgent/shared/utils/sessionCompleteMcpServer.ts
+++ b/src/AI/AIAgent/shared/utils/sessionCompleteMcpServer.ts
@@ -1,5 +1,5 @@
 /**
- * Minimal stdio MCP server that exposes a single tool: confirm_task_complete.
+ * Minimal stdio MCP server that exposes a single tool: ask_kra.
  *
  * The AI is instructed to call this tool whenever it believes the task is
  * done OR whenever it needs to ask the user anything (clarifications,
@@ -13,14 +13,12 @@
 import { runStdioMcpServer } from '../../mcp/stdioServer';
 
 const TOOL_DEFINITION = {
-    name: 'confirm_task_complete',
+    name: 'ask_kra',
     description: [
-        'You MUST call this tool in two situations:',
-        '1. When you believe all assigned tasks are complete and you want to end your turn.',
-        '2. When you need to ask the user anything — clarifications, decisions, follow-up questions, or next steps.',
-        'Do NOT end your turn with plain text. Always call this tool instead.',
-        'Pass a concise summary of what was done (or what you need to ask) in the "summary" argument,',
-        'and a list of 2–4 concrete choices for the user in the "choices" argument.',
+        'Ask the user a question, surface a decision point, or signal that you are ending your turn.',
+        'Call this tool whenever you need clarification, permission to proceed, a design decision, want to confirm next steps before acting, or are finished with the current request and want to hand control back to the user. Do NOT end your turn with plain text — always call this tool instead.',
+        'Pass a concise summary of what you accomplished or what you need to ask in the "summary" argument,',
+        'and a list of 2–4 concrete choices for the user in the "choices" argument (the UI also lets the user type a freeform reply).',
         'The user will pick a choice or type a custom reply; their answer will be returned to you so you can continue.',
     ].join(' '),
     inputSchema: {
@@ -50,3 +48,4 @@ runStdioMcpServer({
         isError: false,
     }),
 });
+

--- a/src/AI/shared/utils/conversationUtils/chatHeaders.ts
+++ b/src/AI/shared/utils/conversationUtils/chatHeaders.ts
@@ -76,7 +76,7 @@ export function extractTimestampFromHeader(line: string): string {
 /**
  * Replace the last `(draft)` marker in the chat file with a timestamped
  * USER header. No-op if no draft marker is present (e.g. when the agent
- * resumes mid-turn after `confirm_task_complete`).
+ * resumes mid-turn after `ask_kra`).
  */
 export async function materializeUserDraft(
     filePath: string,


### PR DESCRIPTION
project-wide diagnostics now trigger after every file edit confirm_turn_complete is replaced with ask_kra, tool is now given to BYOK as well.