### PR TITLE
feat: unify color theme and enrich coloring

### DIFF
--- a/__tests__/system/grepUtils.test.ts
+++ b/__tests__/system/grepUtils.test.ts
@@ -183,7 +183,7 @@ describe('grepUtils', () => {
         it('returns error message when exec rejects', async () => {
             mockExecCommand.mockRejectedValueOnce(new Error('read error'));
             const result = await grepUtils.loadPreview(makeFile('./a.ts'), 'files');
-            expect(result).toBe('(could not read file)');
+            expect(result).toBe('{red-fg}(could not read file){/red-fg}');
         });
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "chalk-animation": "^2.0.3",
                 "cheerio": "^1.2.0",
                 "chokidar": "^5.0.0",
+                "cli-highlight": "^2.1.11",
                 "dotenv": "^16.4.7",
                 "events": "^3.3.0",
                 "fastembed": "^2.1.0",
@@ -2179,7 +2180,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -2197,6 +2197,12 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+            "license": "MIT"
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
@@ -2800,6 +2806,102 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/cli-highlight": {
+            "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+            "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+            "license": "ISC",
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "highlight.js": "^10.7.1",
+                "mz": "^2.4.0",
+                "parse5": "^5.1.1",
+                "parse5-htmlparser2-tree-adapter": "^6.0.0",
+                "yargs": "^16.0.0"
+            },
+            "bin": {
+                "highlight": "bin/highlight"
+            },
+            "engines": {
+                "node": ">=8.0.0",
+                "npm": ">=5.0.0"
+            }
+        },
+        "node_modules/cli-highlight/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/cli-highlight/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/cli-highlight/node_modules/parse5": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+            "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+            "license": "MIT"
+        },
+        "node_modules/cli-highlight/node_modules/parse5-htmlparser2-tree-adapter": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+            "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+            "license": "MIT",
+            "dependencies": {
+                "parse5": "^6.0.1"
+            }
+        },
+        "node_modules/cli-highlight/node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+            "license": "MIT"
+        },
+        "node_modules/cli-highlight/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cli-highlight/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/cli-progress": {
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
@@ -2824,22 +2926,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/co": {
@@ -3374,7 +3460,6 @@
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/enabled": {
@@ -3472,7 +3557,6 @@
         },
         "node_modules/escalade": {
             "version": "3.2.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -4187,7 +4271,6 @@
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
@@ -4436,6 +4519,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/hono": {
@@ -4711,7 +4803,6 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6090,6 +6181,17 @@
             "version": "2.1.3",
             "license": "MIT"
         },
+        "node_modules/mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "dev": true,
@@ -6940,7 +7042,6 @@
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -7471,7 +7572,6 @@
         },
         "node_modules/string-width": {
             "version": "4.2.3",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -7484,7 +7584,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -7636,6 +7735,27 @@
         "node_modules/text-hex": {
             "version": "1.0.0",
             "license": "MIT"
+        },
+        "node_modules/thenify": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0"
+            }
+        },
+        "node_modules/thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+            "license": "MIT",
+            "dependencies": {
+                "thenify": ">= 3.1.0 < 4"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
         },
         "node_modules/tinycolor2": {
             "version": "1.6.0",
@@ -8136,6 +8256,23 @@
                 "node": ">=12.17"
             }
         },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "license": "ISC"
@@ -8154,7 +8291,6 @@
         },
         "node_modules/y18n": {
             "version": "5.0.8",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "chalk-animation": "^2.0.3",
         "cheerio": "^1.2.0",
         "chokidar": "^5.0.0",
+        "cli-highlight": "^2.1.11",
         "dotenv": "^16.4.7",
         "events": "^3.3.0",
         "fastembed": "^2.1.0",

--- a/src/UI/dashboard/highlight.ts
+++ b/src/UI/dashboard/highlight.ts
@@ -1,0 +1,64 @@
+import { highlight, supportsLanguage } from 'cli-highlight';
+import * as path from 'path';
+
+const EXT_TO_LANG: Record<string, string> = {
+    '.ts': 'typescript',
+    '.tsx': 'typescript',
+    '.js': 'javascript',
+    '.jsx': 'javascript',
+    '.mjs': 'javascript',
+    '.cjs': 'javascript',
+    '.json': 'json',
+    '.md': 'markdown',
+    '.markdown': 'markdown',
+    '.py': 'python',
+    '.rb': 'ruby',
+    '.go': 'go',
+    '.rs': 'rust',
+    '.java': 'java',
+    '.c': 'c',
+    '.h': 'c',
+    '.cpp': 'cpp',
+    '.cc': 'cpp',
+    '.hpp': 'cpp',
+    '.cs': 'csharp',
+    '.sh': 'bash',
+    '.bash': 'bash',
+    '.zsh': 'bash',
+    '.yml': 'yaml',
+    '.yaml': 'yaml',
+    '.toml': 'ini',
+    '.ini': 'ini',
+    '.html': 'html',
+    '.htm': 'html',
+    '.xml': 'xml',
+    '.css': 'css',
+    '.scss': 'scss',
+    '.sql': 'sql',
+    '.lua': 'lua',
+    '.php': 'php',
+    '.swift': 'swift',
+    '.kt': 'kotlin',
+    '.vim': 'vim',
+    '.dockerfile': 'dockerfile',
+};
+
+export function languageForPath(filePath: string): string | null {
+    const base = path.basename(filePath).toLowerCase();
+    if (base === 'dockerfile') return 'dockerfile';
+    if (base === 'makefile') return 'makefile';
+    const ext = path.extname(filePath).toLowerCase();
+    const lang = EXT_TO_LANG[ext];
+    if (!lang) return null;
+    return supportsLanguage(lang) ? lang : null;
+}
+
+export function highlightCode(text: string, filePath: string): string {
+    const lang = languageForPath(filePath);
+    if (!lang) return text;
+    try {
+        return highlight(text, { language: lang, ignoreIllegals: true });
+    } catch {
+        return text;
+    }
+}

--- a/src/UI/dashboard/index.ts
+++ b/src/UI/dashboard/index.ts
@@ -1,4 +1,6 @@
 export { escTag, sanitizeForBlessed } from './escTag';
+export { highlightCode, languageForPath } from './highlight';
+export { theme, type ThemeKey } from './theme';
 export {
     createDashboardScreen,
     awaitScreenDestroy,

--- a/src/UI/dashboard/theme.ts
+++ b/src/UI/dashboard/theme.ts
@@ -1,0 +1,35 @@
+// Shared semantic color palette for blessed dashboards.
+//
+// Use these helpers instead of inline {color-fg}…{/color-fg} tags so the look
+// stays consistent across dashboards and we can re-skin in one place.
+//
+// All helpers accept a string-coercible value and return a blessed-tagged
+// string. They DO NOT escape the value — pass already-escaped content if it
+// contains user data with `{` or `}` characters.
+
+const wrap = (open: string, close: string) => (s: string | number): string =>
+    `${open}${s}${close}`;
+
+export const theme = {
+    label:   wrap('{cyan-fg}', '{/cyan-fg}'),
+    value:   wrap('{white-fg}', '{/white-fg}'),
+    dim:     wrap('{gray-fg}', '{/gray-fg}'),
+    path:    wrap('{blue-fg}', '{/blue-fg}'),
+    dir:     wrap('{blue-fg}', '{/blue-fg}'),
+    file:    wrap('{green-fg}', '{/green-fg}'),
+    link:    wrap('{magenta-fg}', '{/magenta-fg}'),
+    size:    wrap('{green-fg}', '{/green-fg}'),
+    date:    wrap('{magenta-fg}', '{/magenta-fg}'),
+    count:   wrap('{yellow-fg}', '{/yellow-fg}'),
+    key:     wrap('{cyan-fg}', '{/cyan-fg}'),
+    section: wrap('{magenta-fg}{bold}', '{/bold}{/magenta-fg}'),
+    title:   wrap('{cyan-fg}{bold}', '{/bold}{/cyan-fg}'),
+    success: wrap('{green-fg}', '{/green-fg}'),
+    warn:    wrap('{yellow-fg}', '{/yellow-fg}'),
+    err:     wrap('{red-fg}', '{/red-fg}'),
+    hl:      wrap('{yellow-bg}{black-fg}', '{/black-fg}{/yellow-bg}'),
+    accent:  wrap('{magenta-fg}', '{/magenta-fg}'),
+    selected: wrap('{yellow-fg}', '{/yellow-fg}'),
+};
+
+export type ThemeKey = keyof typeof theme;

--- a/src/git/commands/gitLogDashboard.ts
+++ b/src/git/commands/gitLogDashboard.ts
@@ -10,6 +10,7 @@ import {
     createListDetailDashboard,
     modalConfirm,
     pickList,
+    theme,
 } from '@/UI/dashboard';
 import { browseFiles, runInherit } from '@/UI/dashboard/screen';
 import { interactiveCherryPick } from '@/git/commands/cherryPickFlow';
@@ -205,11 +206,11 @@ async function loadCommitFiles(hash: string): Promise<string[]> {
 }
 
 function formatCommitRow(c: Commit, width: number): string {
-    const hash = `{yellow-fg}${c.shortHash}{/yellow-fg}`;
-    const refs = c.refs ? ` {green-fg}(${truncate(c.refs, 24)}){/green-fg}` : '';
-    const date = `{cyan-fg}${pad(c.relDate, 14)}{/cyan-fg}`;
+    const hash = theme.warn(c.shortHash);
+    const refs = c.refs ? ` ${theme.success(`(${truncate(c.refs, 24)})`)}` : '';
+    const date = theme.date(pad(c.relDate, 14));
     const subjMax = Math.max(10, width - 8 - 14 - (c.refs ? 26 : 0) - 4);
-    const subject = `{white-fg}${escape(truncate(c.subject, subjMax))}{/white-fg}`;
+    const subject = theme.value(escape(truncate(c.subject, subjMax)));
 
     return `${hash} ${date} ${subject}${refs}`;
 }
@@ -230,15 +231,34 @@ function escape(s: string): string {
     return s.replace(/[{}]/g, (m) => (m === '{' ? '{open}' : '{close}'));
 }
 
+function colorizeStat(s: string): string {
+    return s.split('\n').map((line) => {
+        const summary = line.match(/^(\s*)(\d+ files? changed)(.*)$/);
+        if (summary) {
+            const rest = summary[3]
+                .replace(/(\d+) insertions?\(\+\)/g, (_m, n) => `${theme.success(n + ' insertions(+)')}`)
+                .replace(/(\d+) deletions?\(-\)/g, (_m, n) => `${theme.err(n + ' deletions(-)')}`);
+            return `${summary[1]}${theme.label(summary[2])}${rest}`;
+        }
+        const fileLine = line.match(/^(\s*)(\S.*?)(\s*\|\s*)(\d+|Bin[^+\-]*)(\s*)([+\-]*)\s*$/);
+        if (fileLine) {
+            const [, lead, file, sep, count, gap, bar] = fileLine;
+            const coloredBar = bar.replace(/[+\-]/g, (c) => c === '+' ? theme.success('+') : theme.err('-'));
+            return `${lead}${theme.path(file)}${theme.dim(sep)}${theme.count(count)}${gap}${coloredBar}`;
+        }
+        return line;
+    }).join('\n');
+}
+
 function renderDetails(c: Commit): string {
-    const refs = c.refs ? `{green-fg}${escape(c.refs)}{/green-fg}` : '{gray-fg}(no refs){/gray-fg}';
+    const refs = c.refs ? theme.success(escape(c.refs)) : theme.dim('(no refs)');
     const lines = [
-        `{yellow-fg}{bold}commit{/bold}{/yellow-fg} ${c.hash}`,
-        `{cyan-fg}author{/cyan-fg}  ${escape(c.author)} {gray-fg}<${escape(c.email)}>{/gray-fg}`,
-        `{cyan-fg}date{/cyan-fg}    ${escape(c.isoDate)}  {gray-fg}(${escape(c.relDate)}){/gray-fg}`,
-        `{cyan-fg}refs{/cyan-fg}    ${refs}`,
+        `${theme.warn('{bold}commit{/bold}')} ${theme.warn(c.hash)}`,
+        `${theme.label('author')}  ${theme.success(escape(c.author))} ${theme.dim(`<${escape(c.email)}>`)}`,
+        `${theme.label('date')}    ${theme.date(escape(c.isoDate))}  ${theme.dim(`(${escape(c.relDate)})`)}`,
+        `${theme.label('refs')}    ${refs}`,
         '',
-        `{white-fg}{bold}${escape(c.subject)}{/bold}{/white-fg}`,
+        `{bold}${theme.value(escape(c.subject))}{/bold}`,
     ];
     if (c.body) {
         lines.push('');
@@ -249,7 +269,7 @@ function renderDetails(c: Commit): string {
 }
 
 function renderGraph(raw: string, currentShort: string): { content: string; matchLine: number } {
-    if (!raw.trim()) return { content: '{gray-fg}(empty graph){/gray-fg}', matchLine: -1 };
+    if (!raw.trim()) return { content: theme.dim('(empty graph)'), matchLine: -1 };
     const railSwap = (s: string): string =>
         s
             .replace(/\*/g, '\u0001')
@@ -294,13 +314,13 @@ function renderGraph(raw: string, currentShort: string): { content: string; matc
             const age = fields[3] ?? '';
 
             const railsOut = colorRails(railSwap(rails));
-            const hashOut = `{yellow-fg}{bold}${escape(hash)}{/bold}{/yellow-fg}`;
+            const hashOut = theme.warn(`{bold}${escape(hash)}{/bold}`);
             const refsOut = refsRaw
-                ? ` {green-fg}${escape(refsRaw)}{/green-fg}`
+                ? ` ${theme.success(escape(refsRaw))}`
                 : '';
-            const subjOut = ` {white-fg}${escape(truncate(subject, 80))}{/white-fg}`;
+            const subjOut = ` ${theme.value(escape(truncate(subject, 80)))}`;
             const metaOut = author
-                ? ` {gray-fg}· ${escape(author)}, ${escape(age)}{/gray-fg}`
+                ? ` ${theme.dim(`· ${escape(author)}, ${escape(age)}`)}`
                 : '';
             const content = `${hashOut}${refsOut}${subjOut}${metaOut}`;
 
@@ -308,7 +328,7 @@ function renderGraph(raw: string, currentShort: string): { content: string; matc
                 if (matchLine < 0) matchLine = idx;
                 const stripped = `${hash}${refsRaw ? ' ' + refsRaw : ''} ${truncate(subject, 80)}${author ? ' · ' + author + ', ' + age : ''}`;
 
-                return `${railsOut}{yellow-bg}{black-fg}${escape(stripped)}{/black-fg}{/yellow-bg}`;
+                return `${railsOut}${theme.hl(escape(stripped))}`;
             }
 
             return `${railsOut}${content}`;
@@ -388,15 +408,15 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
     function headerContent(): string {
         const head: Commit | undefined = commits.length > 0 ? commits[0] : undefined;
         const headPart = head
-            ? `   {cyan-fg}HEAD{/cyan-fg} {yellow-fg}${head.shortHash}{/yellow-fg} {gray-fg}${escape(truncate(head.subject, 40))}{/gray-fg}`
+            ? `   ${theme.label('HEAD')} ${theme.warn(head.shortHash)} ${theme.dim(escape(truncate(head.subject, 40)))}`
             : '';
         const loadingPart = loading
-            ? `   {yellow-fg}\u25dc loading\u2026{/yellow-fg}`
+            ? `   ${theme.warn('\u25dc loading\u2026')}`
             : '';
-        return ` {magenta-fg}{bold}\u25c6 git log{/bold}{/magenta-fg}` +
-            `   {cyan-fg}branch{/cyan-fg} {yellow-fg}${escape(branch)}{/yellow-fg}` +
-            `   {cyan-fg}repo{/cyan-fg} {white-fg}${escape(topLevel)}{/white-fg}` +
-            `   {cyan-fg}commits{/cyan-fg} {yellow-fg}${commits.length}{/yellow-fg}` +
+        return ` ${theme.title('\u25c6 git log')}` +
+            `   ${theme.label('branch')} ${theme.warn(escape(branch))}` +
+            `   ${theme.label('repo')} ${theme.path(escape(topLevel))}` +
+            `   ${theme.label('commits')} ${theme.count(commits.length)}` +
             headPart +
             loadingPart;
     }
@@ -415,7 +435,7 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
             return out;
         }).catch((e: Error) => {
             graphPending.delete(short);
-            return { content: `{red-fg}Failed to load graph:{/red-fg} ${escape(e.message)}`, matchLine: -1 };
+            return { content: `${theme.err('Failed to load graph:')} ${escape(e.message)}`, matchLine: -1 };
         });
         graphPending.set(short, p);
         return p;
@@ -437,13 +457,13 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
         const existing = statPending.get(hash);
         if (existing) return existing;
         const p = loadStat(hash).then((out) => {
-            const formatted = escape(out);
+            const formatted = colorizeStat(escape(out));
             statCache.set(hash, formatted);
             statPending.delete(hash);
             return formatted;
         }).catch((e: Error) => {
             statPending.delete(hash);
-            return `{red-fg}Failed:{/red-fg} ${escape(e.message)}`;
+            return `${theme.err('Failed:')} ${escape(e.message)}`;
         });
         statPending.set(hash, p);
         return p;
@@ -476,7 +496,7 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
     async function browseCommitFiles(c: Commit, screen: blessed.Widgets.Screen, a: ListDetailDashboardApi<Commit>): Promise<void> {
         const files = await loadCommitFiles(c.hash);
         if (files.length === 0) {
-            a.flashHeader(' {green-fg}no files in commit{/green-fg}');
+            a.flashHeader(` ${theme.success('no files in commit')}`);
             return;
         }
         await browseFiles(screen, {
@@ -499,16 +519,16 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
 
     async function abortCherryPick(a: ListDetailDashboardApi<Commit>): Promise<void> {
         if (!(await isCherryPickInProgress())) {
-            a.flashHeader(' {green-fg}no cherry-pick in progress{/green-fg}');
+            a.flashHeader(` ${theme.success('no cherry-pick in progress')}`);
             return;
         }
         const ok = await modalConfirm(a.screen, 'Abort cherry-pick', 'Abort the in-progress cherry-pick and restore HEAD?');
         if (!ok) return;
         try {
             await bash.execCommand('git cherry-pick --abort');
-            a.flashHeader(' {green-fg}\u2713 cherry-pick aborted{/green-fg}');
+            a.flashHeader(` ${theme.success('\u2713 cherry-pick aborted')}`);
         } catch (e) {
-            a.flashHeader(` {red-fg}\u2717 abort failed: ${(e as Error).message.split('\n')[0]}{/red-fg}`);
+            a.flashHeader(` ${theme.err(`\u2717 abort failed: ${(e as Error).message.split('\n')[0]}`)}`);
         }
     }
 
@@ -544,7 +564,7 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
         loading = false;
         if (api) {
             api.refreshHeader();
-            api.flashHeader(` {red-fg}Failed to load commits: ${escape(e.message)}{/red-fg}`, 4000);
+            api.flashHeader(` ${theme.err(`Failed to load commits: ${escape(e.message)}`)}`, 4000);
         }
     });
 
@@ -556,15 +576,15 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
         listWidth: '40%',
         listTags: true,
         keymapText: () =>
-            `{cyan-fg}j/k{/cyan-fg} nav   {cyan-fg}[ ]{/cyan-fg} \u00b110   {cyan-fg}{ }{/cyan-fg} \u00b1100   ` +
-            `{cyan-fg}enter{/cyan-fg} files in commit   ` +
-            `{cyan-fg}d{/cyan-fg} full diff   ` +
-            `{cyan-fg}c{/cyan-fg} cherry-pick   ` +
-            `{cyan-fg}A{/cyan-fg} abort cherry-pick   ` +
-            `{cyan-fg}B{/cyan-fg} scope branch   ` +
-            `{cyan-fg}s{/cyan-fg} / {cyan-fg}/{/cyan-fg} search   ` +
-            `{cyan-fg}y{/cyan-fg} yank hash   ` +
-            `{cyan-fg}q{/cyan-fg} quit`,
+            `${theme.key('j/k')} nav   ${theme.key('[ ]')} \u00b110   ${theme.key('{ }')} \u00b1100   ` +
+            `${theme.key('enter')} files in commit   ` +
+            `${theme.key('d')} full diff   ` +
+            `${theme.key('c')} cherry-pick   ` +
+            `${theme.key('A')} abort cherry-pick   ` +
+            `${theme.key('B')} scope branch   ` +
+            `${theme.key('s')} / ${theme.key('/')} search   ` +
+            `${theme.key('y')} yank hash   ` +
+            `${theme.key('q')} quit`,
         initialRows: [],
         rowKey: (c) => c.hash,
         renderListItem: (c, _i, _sel) => {
@@ -592,7 +612,7 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
             {
                 label: 'files changed (this commit)',
                 focusName: 'files',
-                initialContent: '{gray-fg}Loading\u2026{/gray-fg}',
+                initialContent: theme.dim('Loading\u2026'),
                 paint: (c, ctx) => {
                     const cached = statCache.get(c.hash);
                     if (cached !== undefined) return cached;
@@ -600,7 +620,7 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
                         if (ctx.isStale()) return;
                         ctx.api.repaintDetails();
                     });
-                    return '{gray-fg}Loading\u2026{/gray-fg}';
+                    return theme.dim('Loading\u2026');
                 },
             },
             {
@@ -620,7 +640,7 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
                         if (ctx.isStale()) return;
                         ctx.api.repaintDetails();
                     });
-                    return '{gray-fg}Loading graph\u2026{/gray-fg}';
+                    return theme.dim('Loading graph\u2026');
                 },
             },
         ],
@@ -637,7 +657,7 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
                 handler: (c, a) => {
                     if (c === undefined) return;
                     copyHash(c);
-                    a.flashHeader(` {green-fg}\u2713 copied ${c.shortHash}{/green-fg}`);
+                    a.flashHeader(` ${theme.success(`\u2713 copied ${c.shortHash}`)}`);
                 },
             },
             {
@@ -700,8 +720,8 @@ export async function gitLogDashboard(opts: GitLogDashboardOptions = {}): Promis
             items,
             itemsUseTags: true,
             renderItem: (item) => item === ALL
-                ? '{magenta-fg}<all branches>{/magenta-fg}'
-                : `{cyan-fg}${item}{/cyan-fg}`,
+                ? theme.accent('<all branches>')
+                : theme.label(item),
             showDetailsPanel: false,
         });
         if (result.value !== null) {

--- a/src/git/commands/gitScout.ts
+++ b/src/git/commands/gitScout.ts
@@ -11,6 +11,7 @@ import {
     createDashboardScreen,
     createDashboardShell,
     escTag,
+    theme,
 } from '@/UI/dashboard';
 import { browseFiles, runInherit } from '@/UI/dashboard/screen';
 import type * as blessed from 'blessed';
@@ -146,42 +147,42 @@ function trunc(s: string, n: number): string {
 }
 
 function renderRepoRow(r: RepoInfo): string {
-    const icon = r.isDirty ? '{yellow-fg}◉{/yellow-fg}' : '{green-fg}●{/green-fg}';
-    const name = `{bold}${escTag(trunc(r.name, 24))}{/bold}`;
-    const branch = `{gray-fg}${escTag(trunc(r.branch, 22))}{/gray-fg}`;
+    const icon = r.isDirty ? theme.warn('◉') : theme.success('●');
+    const name = `{bold}${theme.value(escTag(trunc(r.name, 24)))}{/bold}`;
+    const branch = theme.dim(escTag(trunc(r.branch, 22)));
     const dirty = r.isDirty
-        ? ` {yellow-fg}[${r.modifiedCount}M ${r.untrackedCount}U]{/yellow-fg}`
-        : ' {green-fg}✓{/green-fg}';
+        ? ` ${theme.warn(`[${r.modifiedCount}M ${r.untrackedCount}U]`)}`
+        : ` ${theme.success('✓')}`;
     const sync = r.ahead > 0 || r.behind > 0
-        ? ` {cyan-fg}↑${r.ahead}↓${r.behind}{/cyan-fg}`
+        ? ` ${theme.label(`↑${r.ahead}↓${r.behind}`)}`
         : '';
-    const stash = r.stashCount > 0 ? ` {magenta-fg}⚑${r.stashCount}{/magenta-fg}` : '';
+    const stash = r.stashCount > 0 ? ` ${theme.accent(`⚑${r.stashCount}`)}` : '';
     return `${icon} ${name} ${branch}${dirty}${sync}${stash}`;
 }
 
 function renderRepoDetails(r: RepoInfo): string {
     const syncLine = r.ahead > 0 || r.behind > 0
-        ? `  remote:     {cyan-fg}↑${r.ahead}{/cyan-fg} ahead  {cyan-fg}↓${r.behind}{/cyan-fg} behind`
-        : '  remote:     {gray-fg}up to date{/gray-fg}';
+        ? `  ${theme.label('remote:    ')} ${theme.accent(`↑${r.ahead}`)} ahead  ${theme.accent(`↓${r.behind}`)} behind`
+        : `  ${theme.label('remote:    ')} ${theme.dim('up to date')}`;
     const stashLine = r.stashCount > 0
-        ? `  stashes:    {magenta-fg}${r.stashCount}{/magenta-fg}`
+        ? `  ${theme.label('stashes:   ')} ${theme.accent(String(r.stashCount))}`
         : '';
 
     return [
-        `{cyan-fg}name{/cyan-fg}       {bold}${escTag(r.name)}{/bold}`,
-        `{cyan-fg}path{/cyan-fg}       {white-fg}${escTag(r.fullPath)}{/white-fg}`,
-        `{cyan-fg}branch{/cyan-fg}     {white-fg}${escTag(r.branch)}{/white-fg}`,
+        `${theme.label('name      ')} {bold}${theme.value(escTag(r.name))}{/bold}`,
+        `${theme.label('path      ')} ${theme.path(escTag(r.fullPath))}`,
+        `${theme.label('branch    ')} ${theme.value(escTag(r.branch))}`,
         '',
-        `{cyan-fg}status{/cyan-fg}`,
-        `  workspace:  ${r.isDirty ? '{yellow-fg}dirty{/yellow-fg}' : '{green-fg}clean{/green-fg}'}`,
-        `  modified:   {yellow-fg}${r.modifiedCount}{/yellow-fg}`,
-        `  untracked:  {magenta-fg}${r.untrackedCount}{/magenta-fg}`,
+        theme.section('status'),
+        `  ${theme.label('workspace: ')} ${r.isDirty ? theme.warn('dirty') : theme.success('clean')}`,
+        `  ${theme.label('modified:  ')} ${theme.count(r.modifiedCount)}`,
+        `  ${theme.label('untracked: ')} ${theme.count(r.untrackedCount)}`,
         syncLine,
         ...(stashLine ? [stashLine] : []),
         '',
-        `{cyan-fg}last commit{/cyan-fg}`,
-        `  {yellow-fg}${escTag(r.lastCommitHash || '—')}{/yellow-fg}  {gray-fg}${escTag(r.lastCommitDate || '')}{/gray-fg}`,
-        `  ${escTag(r.lastCommitSubject || '(no commits)')}`,
+        theme.section('last commit'),
+        `  ${theme.warn(escTag(r.lastCommitHash || '—'))}  ${theme.date(escTag(r.lastCommitDate || ''))}`,
+        `  ${theme.value(escTag(r.lastCommitSubject || '(no commits)'))}`,
     ].join('\n');
 }
 
@@ -190,14 +191,14 @@ async function loadRecentLog(r: RepoInfo): Promise<string> {
         const { stdout } = await bash.execCommand(
             `git -C ${JSON.stringify(r.fullPath)} log --oneline --decorate -20`,
         );
-        if (!stdout.trim()) return '{gray-fg}(no commits){/gray-fg}';
+        if (!stdout.trim()) return theme.dim('(no commits)');
         return stdout.trim().split('\n').map((line) => {
             const m = line.match(/^([a-f0-9]+)\s+(.*)$/);
             if (!m) return escTag(line);
-            return `{yellow-fg}${m[1]}{/yellow-fg} ${escTag(m[2] ?? '')}`;
+            return `${theme.warn(m[1])} ${theme.value(escTag(m[2] ?? ''))}`;
         }).join('\n');
     } catch (e) {
-        return `{red-fg}Error:{/red-fg} ${escTag((e as Error).message)}`;
+        return `${theme.err('Error:')} ${escTag((e as Error).message)}`;
     }
 }
 
@@ -206,9 +207,9 @@ async function loadGitStatus(r: RepoInfo): Promise<string> {
         const { stdout } = await bash.execCommand(
             `git -C ${JSON.stringify(r.fullPath)} status`,
         );
-        return escTag(stdout.trim()) || '{gray-fg}(clean){/gray-fg}';
+        return escTag(stdout.trim()) || theme.success('(clean)');
     } catch (e) {
-        return `{red-fg}Error:{/red-fg} ${escTag((e as Error).message)}`;
+        return `${theme.err('Error:')} ${escTag((e as Error).message)}`;
     }
 }
 
@@ -285,17 +286,17 @@ export async function scout(): Promise<void> {
             { label: 'git status', focusName: 'status' },
         ],
         keymapText: () =>
-            `{cyan-fg}j/k{/cyan-fg} nav   ` +
-            `{cyan-fg}enter{/cyan-fg} nvim   ` +
-            `{cyan-fg}l{/cyan-fg} git log   ` +
-            `{cyan-fg}d{/cyan-fg} diff files   ` +
-            `{cyan-fg}f{/cyan-fg} fetch   ` +
-            `{cyan-fg}p{/cyan-fg} pull   ` +
-            `{cyan-fg}D{/cyan-fg} dirty filter   ` +
-            `{cyan-fg}r{/cyan-fg} refresh   ` +
-            `{cyan-fg}s{/cyan-fg}/{cyan-fg}/{/cyan-fg} search   ` +
-            `{cyan-fg}y{/cyan-fg} copy path   ` +
-            `{cyan-fg}q{/cyan-fg} quit`,
+            `${theme.key('j/k')} nav   ` +
+            `${theme.key('enter')} nvim   ` +
+            `${theme.key('l')} git log   ` +
+            `${theme.key('d')} diff files   ` +
+            `${theme.key('f')} fetch   ` +
+            `${theme.key('p')} pull   ` +
+            `${theme.key('D')} dirty filter   ` +
+            `${theme.key('r')} refresh   ` +
+            `${theme.key('s')}/${theme.key('/')} search   ` +
+            `${theme.key('y')} copy path   ` +
+            `${theme.key('q')} quit`,
     });
 
     const { header, list, ring } = shell;
@@ -307,13 +308,13 @@ export async function scout(): Promise<void> {
     function setHeader(): void {
         const dirtyCount = allRepos.filter((r) => r.isDirty).length;
         const syncCount = allRepos.filter((r) => r.ahead > 0 || r.behind > 0).length;
-        const filterTag = showDirtyOnly ? '  {yellow-fg}[dirty only]{/yellow-fg}' : '';
+        const filterTag = showDirtyOnly ? `  ${theme.warn('[dirty only]')}` : '';
         header.setContent(
-            ` {magenta-fg}{bold}◆ git scout{/bold}{/magenta-fg}` +
-            `   {cyan-fg}root{/cyan-fg} {white-fg}${escTag(root)}{/white-fg}` +
-            `   {cyan-fg}repos{/cyan-fg} {yellow-fg}${allRepos.length}{/yellow-fg}` +
-            `   {cyan-fg}dirty{/cyan-fg} {yellow-fg}${dirtyCount}{/yellow-fg}` +
-            `   {cyan-fg}out of sync{/cyan-fg} {cyan-fg}${syncCount}{/cyan-fg}` +
+            ` ${theme.title('◆ git scout')}` +
+            `   ${theme.label('root')} ${theme.path(escTag(root))}` +
+            `   ${theme.label('repos')} ${theme.count(allRepos.length)}` +
+            `   ${theme.label('dirty')} ${theme.count(dirtyCount)}` +
+            `   ${theme.label('out of sync')} ${theme.accent(String(syncCount))}` +
             filterTag,
         );
     }
@@ -339,7 +340,7 @@ export async function scout(): Promise<void> {
             list.select(0);
             void selectIndex(0);
         } else {
-            details.setContent('{gray-fg}no matches{/gray-fg}');
+            details.setContent(theme.dim('no matches'));
             logPanel.setContent('');
             statusPanel.setContent('');
         }
@@ -372,7 +373,7 @@ export async function scout(): Promise<void> {
             logPanel.setContent(cachedLog);
             logPanel.setScrollPerc(0);
         } else {
-            logPanel.setContent('{gray-fg}Loading…{/gray-fg}');
+            logPanel.setContent(theme.dim('Loading…'));
         }
 
         // Load status panel
@@ -381,7 +382,7 @@ export async function scout(): Promise<void> {
             statusPanel.setContent(cachedStatus);
             statusPanel.setScrollPerc(0);
         } else {
-            statusPanel.setContent('{gray-fg}Loading…{/gray-fg}');
+            statusPanel.setContent(theme.dim('Loading…'));
         }
 
         screen.render();

--- a/src/system/commands/diskUsageDashboard.ts
+++ b/src/system/commands/diskUsageDashboard.ts
@@ -7,7 +7,9 @@ import {
     createListDetailDashboard,
     modalConfirm,
     modalText,
+    highlightCode,
     sanitizeForBlessed,
+    theme,
 } from '@/UI/dashboard';
 import { runInherit } from '@/UI/dashboard/screen';
 
@@ -242,14 +244,14 @@ export async function openDiskUsageDashboard(): Promise<void> {
 
     function headerContent(): string {
         const sizeText = rootSize === null
-            ? '{gray-fg}scanning\u2026{/gray-fg}'
-            : `{yellow-fg}${formatBytes(rootSize)}{/yellow-fg}`;
+            ? theme.dim('scanning\u2026')
+            : theme.size(formatBytes(rootSize));
         const selCount = selected.size > 0
-            ? `   {magenta-fg}selected:{/magenta-fg} ${selected.size}`
+            ? `   ${theme.label('selected:')} ${theme.count(selected.size)}`
             : '';
-        return ` {magenta-fg}{bold}\u25c6 disk-usage{/bold}{/magenta-fg}   ` +
-            `{gray-fg}root:{/gray-fg} ${escapeTag(truncate(root, 80))}   ` +
-            `${sizeText}   {gray-fg}sort:{/gray-fg} ${sortLabel()}` +
+        return ` ${theme.title('\u25c6 disk-usage')}   ` +
+            `${theme.label('root:')} ${theme.path(escapeTag(truncate(root, 80)))}   ` +
+            `${sizeText}   ${theme.label('sort:')} ${theme.value(sortLabel())}` +
             `${selCount}`;
     }
 
@@ -339,17 +341,18 @@ rebuildAndPush(api?.selectedRow()?.id);
     function formatRow(r: Row): string {
         const indent = '  '.repeat(r.depth);
         const expandMarker = r.expandable
-            ? (r.isOpen ? '{cyan-fg}\u25be{/cyan-fg} ' : '{cyan-fg}\u25b8{/cyan-fg} ')
+            ? (r.isOpen ? `${theme.key('\u25be')} ` : `${theme.key('\u25b8')} `)
             : '  ';
-        const select = selected.has(r.id) ? '{magenta-fg}\u2713{/magenta-fg} ' : '  ';
+        const select = selected.has(r.id) ? `${theme.accent('\u2713')} ` : '  ';
         const sizeStr = r.entry.sizeBytes === null
-            ? '{gray-fg}     \u2026{/gray-fg}'
-            : `{yellow-fg}${formatBytes(r.entry.sizeBytes).padStart(10)}{/yellow-fg}`;
+            ? theme.dim('     \u2026')
+            : theme.size(formatBytes(r.entry.sizeBytes).padStart(10));
         const pctStr = r.parentTotal !== null && r.entry.sizeBytes !== null
-            ? `{gray-fg}${formatPct(r.entry.sizeBytes, r.parentTotal)}{/gray-fg}`
-            : '{gray-fg}     -{/gray-fg}';
+            ? theme.dim(formatPct(r.entry.sizeBytes, r.parentTotal))
+            : theme.dim('     -');
         const icon = r.entry.isSymlink ? '\ud83d\udd17' : (r.entry.isDir ? '\ud83d\udcc1' : '\ud83d\udcc4');
-        const name = escapeTag(r.entry.name) + (r.entry.isDir ? '/' : '');
+        const rawName = escapeTag(r.entry.name) + (r.entry.isDir ? '/' : '');
+        const name = r.entry.isDir ? theme.dir(rawName) : theme.value(rawName);
         return `${select}${sizeStr} ${pctStr}  ${indent}${expandMarker}${icon} ${name}`;
     }
 
@@ -362,14 +365,14 @@ rebuildAndPush(api?.selectedRow()?.id);
         const itemsText = e.itemCount === null ? '\u2026' : `${e.itemCount}`;
         const typeText = e.isSymlink ? 'symlink' : (e.isDir ? 'directory' : 'file');
         const errLine = e.sizeError
-            ? `\n {red-fg}scan error:{/red-fg} ${escapeTag(e.sizeError)}`
+            ? `\n ${theme.err('scan error:')} ${escapeTag(e.sizeError)}`
             : '';
-        return ` {cyan-fg}path:{/cyan-fg}    ${escapeTag(e.absPath)}\n` +
-            ` {cyan-fg}type:{/cyan-fg}    ${typeText}\n` +
-            ` {cyan-fg}size:{/cyan-fg}    {yellow-fg}${sizeText}{/yellow-fg}   {gray-fg}({/gray-fg}${pctText}{gray-fg} of parent){/gray-fg}\n` +
-            ` {cyan-fg}items:{/cyan-fg}   ${itemsText}\n` +
-            ` {cyan-fg}mode:{/cyan-fg}    ${formatMode(e.mode)}\n` +
-            ` {cyan-fg}mtime:{/cyan-fg}   ${formatMtime(e.mtimeMs)}` +
+        return ` ${theme.label('path:')}    ${theme.path(escapeTag(e.absPath))}\n` +
+            ` ${theme.label('type:')}    ${theme.value(typeText)}\n` +
+            ` ${theme.label('size:')}    ${theme.size(sizeText)}   ${theme.dim(`(${pctText} of parent)`)}\n` +
+            ` ${theme.label('items:')}   ${theme.count(itemsText)}\n` +
+            ` ${theme.label('mode:')}    ${theme.value(formatMode(e.mode))}\n` +
+            ` ${theme.label('mtime:')}   ${theme.date(formatMtime(e.mtimeMs))}` +
             errLine;
     }
 
@@ -387,25 +390,27 @@ rebuildAndPush(api?.selectedRow()?.id);
         // fullUnicode and duplicate glyphs on scroll).
         const lines = sorted.map((c) => {
             const sz = c.sizeBytes === null
-                ? '{gray-fg}     \u2026{/gray-fg}'
-                : `{yellow-fg}${formatBytes(c.sizeBytes).padStart(10)}{/yellow-fg}`;
+                ? theme.dim('     \u2026')
+                : theme.size(formatBytes(c.sizeBytes).padStart(10));
+            const rawName = escapeTag(sanitizeForBlessed(c.name)) + (c.isDir ? '/' : '');
             const icon = c.isSymlink
-                ? '{magenta-fg}L{/magenta-fg}'
-                : (c.isDir ? '{blue-fg}D{/blue-fg}' : '{green-fg}F{/green-fg}');
-            return ` ${sz}  ${icon} ${escapeTag(sanitizeForBlessed(c.name))}${c.isDir ? '/' : ''}`;
+                ? theme.link('L')
+                : (c.isDir ? theme.dir('D') : theme.file('F'));
+            const name = c.isSymlink ? theme.link(rawName) : (c.isDir ? theme.dir(rawName) : theme.value(rawName));
+            return ` ${sz}  ${icon} ${name}`;
         });
         const more = entries.length > sorted.length
-            ? `\n {gray-fg}\u2026and ${entries.length - sorted.length} more{/gray-fg}`
+            ? `\n ${theme.dim(`\u2026and ${entries.length - sorted.length} more`)}`
             : '';
-        return ` {gray-fg}children of{/gray-fg} ${escapeTag(sanitizeForBlessed(e.name))}/  {gray-fg}(${entries.length}){/gray-fg}\n\n` +
-            (lines.join('\n') || ' {gray-fg}empty{/gray-fg}') +
+        return ` ${theme.dim('children of')} ${theme.dir(escapeTag(sanitizeForBlessed(e.name)) + '/')}  ${theme.dim(`(${entries.length})`)}\n\n` +
+            (lines.join('\n') || ` ${theme.dim('empty')}`) +
             more;
     }
 
     async function paintFilePreviewContent(e: Entry): Promise<string> {
         const cap = 4096;
         if (e.sizeBytes !== null && e.sizeBytes > 200 * 1024) {
-            return ` {gray-fg}file too large to preview ({/gray-fg}${formatBytes(e.sizeBytes)}{gray-fg}){/gray-fg}`;
+            return ` ${theme.dim(`file too large to preview (${formatBytes(e.sizeBytes)})`)}`;
         }
         try {
             const fh = await fs.open(e.absPath, 'r');
@@ -413,15 +418,15 @@ rebuildAndPush(api?.selectedRow()?.id);
                 const buf = Buffer.alloc(cap);
                 const { bytesRead } = await fh.read(buf, 0, cap, 0);
                 let text = buf.subarray(0, bytesRead).toString('utf8');
-                if (/\u0000/.test(text)) return ' {gray-fg}binary file (no preview){/gray-fg}';
+                if (/\u0000/.test(text)) return ` ${theme.dim('binary file (no preview)')}`;
                 text = sanitizeForBlessed(text);
                 if (bytesRead === cap) text += '\n\u2026';
-                return escapeTag(text);
+                return escapeTag(highlightCode(text, e.absPath));
             } finally {
                 await fh.close();
             }
         } catch (err) {
-            return ` {red-fg}preview error:{/red-fg} ${escapeTag((err as Error).message)}`;
+            return ` ${theme.err('preview error:')} ${escapeTag((err as Error).message)}`;
         }
     }
 
@@ -430,18 +435,20 @@ rebuildAndPush(api?.selectedRow()?.id);
         const ranked = sortEntries(top, 'size-desc').slice(0, 10);
         const lines = ranked.map((e, i) => {
             const sz = e.sizeBytes === null
-                ? '{gray-fg}     \u2026{/gray-fg}'
-                : `{yellow-fg}${formatBytes(e.sizeBytes).padStart(10)}{/yellow-fg}`;
+                ? theme.dim('     \u2026')
+                : theme.size(formatBytes(e.sizeBytes).padStart(10));
+            const rawName = escapeTag(sanitizeForBlessed(e.name));
             const icon = e.isSymlink
-                ? '{magenta-fg}L{/magenta-fg}'
-                : (e.isDir ? '{blue-fg}D{/blue-fg}' : '{green-fg}F{/green-fg}');
-            return ` ${(`${i + 1}`).padStart(2)}. ${sz}  ${icon} ${escapeTag(sanitizeForBlessed(e.name))}`;
+                ? theme.link('L')
+                : (e.isDir ? theme.dir('D') : theme.file('F'));
+            const name = e.isSymlink ? theme.link(rawName) : (e.isDir ? theme.dir(rawName) : theme.value(rawName));
+            return ` ${theme.dim((`${i + 1}`).padStart(2) + '.')} ${sz}  ${icon} ${name}`;
         });
         const flightLine = scanInFlight > 0
-            ? `\n {gray-fg}scanning ${scanInFlight} dirs\u2026{/gray-fg}`
+            ? `\n ${theme.dim(`scanning ${scanInFlight} dirs\u2026`)}`
             : '';
-        return ` {gray-fg}top 10 in current root{/gray-fg}\n\n` +
-            (lines.join('\n') || ' {gray-fg}empty{/gray-fg}') +
+        return ` ${theme.section('top 10 in current root')}\n\n` +
+            (lines.join('\n') || ` ${theme.dim('empty')}`) +
             flightLine;
     }
 
@@ -514,9 +521,9 @@ rebuildAndPush(api?.selectedRow()?.id);
         await loadDir(root);
         rebuildAndPush();
         if (failed.length > 0) {
-            a.flashHeader(` {red-fg}deleted ${okCount}, failed ${failed.length}: ${escapeTag(failed[0])}{/red-fg}`);
+            a.flashHeader(` ${theme.err(`deleted ${okCount}, failed ${failed.length}: ${escapeTag(failed[0])}`)}`);
         } else {
-            a.flashHeader(` {green-fg}\u2713 deleted ${okCount} item(s) ({/green-fg}${formatBytes(totalBytes)}{green-fg}){/green-fg}`);
+            a.flashHeader(` ${theme.success(`\u2713 deleted ${okCount} item(s) (${formatBytes(totalBytes)})`)}`);
         }
     }
 
@@ -527,7 +534,7 @@ rebuildAndPush(api?.selectedRow()?.id);
         if (r.entry.isDir) {
             const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
             spawn(cmd, [target], { stdio: 'ignore', detached: true }).unref();
-            a.flashHeader(` {green-fg}\u2713 opened{/green-fg} ${escapeTag(target)}`);
+            a.flashHeader(` ${theme.success('\u2713 opened')} ${theme.path(escapeTag(target))}`);
         } else {
             await runInherit('nvim', [target], a.screen);
         }
@@ -544,12 +551,12 @@ rebuildAndPush(api?.selectedRow()?.id);
         try {
             const st = await fs.stat(expandedPath);
             if (!st.isDirectory()) {
-                a.flashHeader(` {red-fg}not a directory{/red-fg}`);
+                a.flashHeader(` ${theme.err('not a directory')}`);
                 return;
             }
             await setRoot(expandedPath);
         } catch (err) {
-            a.flashHeader(` {red-fg}${escapeTag((err as Error).message)}{/red-fg}`);
+            a.flashHeader(` ${theme.err(escapeTag((err as Error).message))}`);
         }
     }
 
@@ -564,13 +571,13 @@ rebuildAndPush(api?.selectedRow()?.id);
         listWidth: '50%',
         listTags: true,
         keymapText:
-            `{cyan-fg}j/k{/cyan-fg} nav  {cyan-fg}enter{/cyan-fg} descend  ` +
-            `{cyan-fg}-{/cyan-fg} up  {cyan-fg}e/l{/cyan-fg} expand  ` +
-            `{cyan-fg}space{/cyan-fg} select  {cyan-fg}X{/cyan-fg} delete  ` +
-            `{cyan-fg}o{/cyan-fg} open  {cyan-fg}s{/cyan-fg} sort  ` +
-            `{cyan-fg}/{/cyan-fg} filter  {cyan-fg}r{/cyan-fg} refresh  ` +
-            `{cyan-fg}R{/cyan-fg} new root  {cyan-fg}H{/cyan-fg} home  ` +
-            `{cyan-fg}y{/cyan-fg} yank  {cyan-fg}Tab{/cyan-fg} focus  {cyan-fg}q{/cyan-fg} quit`,
+            `${theme.key('j/k')} nav  ${theme.key('enter')} descend  ` +
+            `${theme.key('-')} up  ${theme.key('e/l')} expand  ` +
+            `${theme.key('space')} select  ${theme.key('X')} delete  ` +
+            `${theme.key('o')} open  ${theme.key('s')} sort  ` +
+            `${theme.key('/')} filter  ${theme.key('r')} refresh  ` +
+            `${theme.key('R')} new root  ${theme.key('H')} home  ` +
+            `${theme.key('y')} yank  ${theme.key('Tab')} focus  ${theme.key('q')} quit`,
         initialRows: rows,
         rowKey: (r) => r.id,
         renderListItem: (r) => formatRow(r),
@@ -640,7 +647,7 @@ rebuildAndPush(api?.selectedRow()?.id);
                 handler: (r, a) => {
                     if (r === undefined) return;
                     copyToClipboard(r.entry.absPath);
-                    a.flashHeader(` {green-fg}\u2713 copied{/green-fg} ${escapeTag(r.entry.absPath)}`);
+                    a.flashHeader(` ${theme.success('\u2713 copied')} ${theme.path(escapeTag(r.entry.absPath))}`);
                 },
             },
         ],

--- a/src/system/commands/scripts/scriptsDashboard.ts
+++ b/src/system/commands/scripts/scriptsDashboard.ts
@@ -7,8 +7,11 @@ import { filterGitKeep } from '@/utils/common';
 import {
     createListDetailDashboard,
     escTag,
+    highlightCode,
     modalConfirm,
     modalText,
+    sanitizeForBlessed,
+    theme,
 } from '@/UI/dashboard';
 import { runInherit } from '@/UI/dashboard/screen';
 import { makeExecutableIfNoPermissions } from '@/system/utils/fileUtils';
@@ -34,10 +37,10 @@ async function loadScripts(): Promise<ScriptEntry[]> {
 async function loadPreview(absPath: string): Promise<string> {
     try {
         const { stdout } = await execCommand(`head -n 100 ${JSON.stringify(absPath)} 2>/dev/null`);
-        if (!stdout.trim()) return '{gray-fg}(empty script){/gray-fg}';
-        return escTag(stdout);
+        if (!stdout.trim()) return theme.dim('(empty script)');
+        return escTag(highlightCode(sanitizeForBlessed(stdout), absPath));
     } catch {
-        return '{red-fg}(could not read script){/red-fg}';
+        return theme.err('(could not read script)');
     }
 }
 
@@ -51,21 +54,21 @@ async function loadMeta(entry: ScriptEntry): Promise<string> {
         const modified = lsOut.split(/\s+/).slice(5, 8).join(' ') || '?';
         const size = lsOut.split(/\s+/)[4] ?? '?';
         return (
-            `{cyan-fg}name    {/cyan-fg}${escTag(entry.name)}\n` +
-            `{cyan-fg}path    {/cyan-fg}${escTag(entry.absPath)}\n` +
-            `{cyan-fg}size    {/cyan-fg}${size} bytes\n` +
-            `{cyan-fg}lines   {/cyan-fg}${lineCount}\n` +
-            `{cyan-fg}modified{/cyan-fg}${modified}\n\n` +
-            `{white-fg}${escTag(lsOut)}{/white-fg}`
+            `${theme.label('name    ')}${theme.value(escTag(entry.name))}\n` +
+            `${theme.label('path    ')}${theme.path(escTag(entry.absPath))}\n` +
+            `${theme.label('size    ')}${theme.size(`${size} bytes`)}\n` +
+            `${theme.label('lines   ')}${theme.count(lineCount)}\n` +
+            `${theme.label('modified')} ${theme.date(modified)}\n\n` +
+            `${theme.dim(escTag(lsOut))}`
         );
     } catch {
-        return `{cyan-fg}name{/cyan-fg}  ${escTag(entry.name)}`;
+        return `${theme.label('name')}  ${theme.value(escTag(entry.name))}`;
     }
 }
 
 function renderRow(entry: ScriptEntry, isSelected: boolean): string {
-    const marker = isSelected ? '{yellow-fg}▶{/yellow-fg} ' : '  ';
-    return `${marker}{green-fg}📜{/green-fg} ${escTag(entry.name)}`;
+    const marker = isSelected ? `${theme.selected('▶')} ` : '  ';
+    return `${marker}${theme.success('📜')} ${theme.value(escTag(entry.name))}`;
 }
 
 // ─── Dashboard ────────────────────────────────────────────────────────────────
@@ -83,10 +86,7 @@ export async function openScriptsDashboard(): Promise<void> {
         listLabel: 'scripts',
         listFocusName: 'scripts',
         listWidth: '42%',
-        headerContent: () => {
-            const countTag = `{cyan-fg}scripts{/cyan-fg} {yellow-fg}${scripts.length}{/yellow-fg}`;
-            return ` ${countTag}`;
-        },
+        headerContent: () => ` ${theme.label('scripts')} ${theme.count(scripts.length)}`,
         filter: {
             label: 'filter',
             mode: 'live',
@@ -118,18 +118,18 @@ export async function openScriptsDashboard(): Promise<void> {
             {
                 label: 'output',
                 focusName: 'output',
-                initialContent: '{gray-fg}(no run yet — press enter to run){/gray-fg}',
+                initialContent: theme.dim('(no run yet — press enter to run)'),
                 // selection changes don't regenerate this panel; actions write into it
                 paint: () => null,
             },
         ],
         keymapText: () =>
-            `{cyan-fg}j/k{/cyan-fg} nav   {cyan-fg}/{/cyan-fg} filter   ` +
-            `{cyan-fg}enter{/cyan-fg} run   {cyan-fg}x{/cyan-fg} interactive   ` +
-            `{cyan-fg}e{/cyan-fg} edit   {cyan-fg}n{/cyan-fg} new   ` +
-            `{cyan-fg}D{/cyan-fg} delete   {cyan-fg}y{/cyan-fg} yank path   ` +
-            `{cyan-fg}r{/cyan-fg} reload   ` +
-            `{cyan-fg}Tab{/cyan-fg} focus   {cyan-fg}q{/cyan-fg} quit`,
+            `${theme.key('j/k')} nav   ${theme.key('/')} filter   ` +
+            `${theme.key('enter')} run   ${theme.key('x')} interactive   ` +
+            `${theme.key('e')} edit   ${theme.key('n')} new   ` +
+            `${theme.key('D')} delete   ${theme.key('y')} yank path   ` +
+            `${theme.key('r')} reload   ` +
+            `${theme.key('Tab')} focus   ${theme.key('q')} quit`,
         actions: [
             {
                 keys: 'enter',
@@ -137,20 +137,20 @@ export async function openScriptsDashboard(): Promise<void> {
                     if (!entry) return;
                     await makeExecutableIfNoPermissions(entry.absPath);
                     const outputPanel = api.shell.detailPanels[2];
-                    outputPanel.setContent(`{gray-fg}Running {/gray-fg}{yellow-fg}${escTag(entry.name)}{/yellow-fg}{gray-fg}…{/gray-fg}`);
+                    outputPanel.setContent(`${theme.dim('Running ')}${theme.warn(escTag(entry.name))}${theme.dim('…')}`);
                     outputPanel.focus();
                     api.screen.render();
                     try {
                         const { stdout, stderr } = await execCommand(`sh ${JSON.stringify(entry.absPath)} 2>&1`);
                         const combined = (stdout + stderr).trim();
                         outputPanel.setContent(
-                            `{cyan-fg}▶ ${escTag(entry.name)}{/cyan-fg}\n\n` +
-                            (combined ? escTag(combined) : '{gray-fg}(no output){/gray-fg}'),
+                            `${theme.title(`▶ ${escTag(entry.name)}`)}\n\n` +
+                            (combined ? escTag(combined) : theme.dim('(no output)')),
                         );
                         outputPanel.setScrollPerc(100);
                     } catch (err) {
                         outputPanel.setContent(
-                            `{red-fg}Error running ${escTag(entry.name)}:{/red-fg}\n\n` +
+                            `${theme.err(`Error running ${escTag(entry.name)}:`)}\n\n` +
                             escTag((err as Error).message),
                         );
                     }
@@ -163,7 +163,7 @@ export async function openScriptsDashboard(): Promise<void> {
                     if (!entry) return;
                     await makeExecutableIfNoPermissions(entry.absPath);
                     const outputPanel = api.shell.detailPanels[2];
-                    outputPanel.setContent('{gray-fg}(interactive run — output not captured){/gray-fg}');
+                    outputPanel.setContent(theme.dim('(interactive run — output not captured)'));
                     await runInherit('sh', [entry.absPath], api.screen);
                     api.screen.render();
                 },

--- a/src/system/commands/systemGrepDashboard.ts
+++ b/src/system/commands/systemGrepDashboard.ts
@@ -6,6 +6,7 @@ import {
     createListDetailDashboard,
     escTag,
     modalConfirm,
+    theme,
 } from '@/UI/dashboard';
 import { runInherit } from '@/UI/dashboard/screen';
 import {
@@ -24,14 +25,14 @@ import {
 // ─── Main dashboard ───────────────────────────────────────────────────────────
 
 const MODE_LABEL: Record<SearchMode, string> = {
-    files: '{green-fg}FILES{/green-fg}',
-    dirs: '{blue-fg}DIRS{/blue-fg}',
-    content: '{yellow-fg}CONTENT{/yellow-fg}',
+    files: theme.file('FILES'),
+    dirs: theme.dir('DIRS'),
+    content: theme.warn('CONTENT'),
 };
 
 function renderStatsContent(allResults: GrepResult[], isSearching: boolean): string {
     if (allResults.length === 0) {
-        return isSearching ? '{gray-fg}searching…{/gray-fg}' : '{gray-fg}no results{/gray-fg}';
+        return isSearching ? theme.warn('searching…') : theme.dim('no results');
     }
     const byExt = new Map<string, number>();
     const byDir = new Map<string, number>();
@@ -54,16 +55,16 @@ function renderStatsContent(allResults: GrepResult[], isSearching: boolean): str
     const extPad = topExt.reduce((m, [e]) => Math.max(m, e.length), 0);
     const dirPad = Math.min(topDirs.reduce((m, [d]) => Math.max(m, d.length), 0), 24);
 
-    let out = `{cyan-fg}total{/cyan-fg}    {yellow-fg}${allResults.length}{/yellow-fg}` +
-        `  {gray-fg}(${files} files, ${dirs} dirs){/gray-fg}`;
-    if (selected > 0) out += `\n{cyan-fg}selected{/cyan-fg} {yellow-fg}${selected}{/yellow-fg}`;
-    out += `\n\n{cyan-fg}by extension{/cyan-fg}\n`;
+    let out = `${theme.label('total   ')} ${theme.count(allResults.length)}` +
+        `  ${theme.dim(`(${files} files, ${dirs} dirs)`)}`;
+    if (selected > 0) out += `\n${theme.label('selected')} ${theme.count(selected)}`;
+    out += `\n\n${theme.section('by extension')}\n`;
     out += topExt
-        .map(([e, n]) => `  {green-fg}${escTag(e).padEnd(extPad)}{/green-fg}  ${n}`)
+        .map(([e, n]) => `  ${theme.file(escTag(e).padEnd(extPad))}  ${theme.count(n)}`)
         .join('\n');
-    out += `\n\n{cyan-fg}by top dir{/cyan-fg}\n`;
+    out += `\n\n${theme.section('by top dir')}\n`;
     out += topDirs
-        .map(([d, n]) => `  {magenta-fg}${escTag(d.slice(0, dirPad)).padEnd(dirPad)}{/magenta-fg}  ${n}`)
+        .map(([d, n]) => `  ${theme.path(escTag(d.slice(0, dirPad)).padEnd(dirPad))}  ${theme.count(n)}`)
         .join('\n');
 
     return out;
@@ -83,13 +84,13 @@ export async function openGrepDashboard(): Promise<void> {
     let activeSearch: StreamSearchHandle | null = null;
 
     function headerText(): string {
-        const q = lastQuery ? `  {cyan-fg}query{/cyan-fg} {white-fg}${escTag(lastQuery)}{/white-fg}` : '';
-        const count = allResults.length > 0 ? `  {cyan-fg}results{/cyan-fg} {yellow-fg}${displayed.length}{/yellow-fg}` : '';
-        const status = isSearching ? '  {yellow-fg}searching…{/yellow-fg}' : '';
+        const q = lastQuery ? `  ${theme.label('query')} ${theme.value(escTag(lastQuery))}` : '';
+        const count = allResults.length > 0 ? `  ${theme.label('results')} ${theme.count(displayed.length)}` : '';
+        const status = isSearching ? `  ${theme.warn('searching…')}` : '';
         const selCount = allResults.filter((r) => r.selected).length;
-        const selTag = selCount > 0 ? `  {yellow-fg}[${selCount} selected]{/yellow-fg}` : '';
-        return ` {magenta-fg}{bold}◆ grep{/bold}{/magenta-fg}` +
-            `  mode ${MODE_LABEL[mode]}` +
+        const selTag = selCount > 0 ? `  ${theme.selected(`[${selCount} selected]`)}` : '';
+        return ` ${theme.title('◆ grep')}` +
+            `  ${theme.dim('mode')} ${MODE_LABEL[mode]}` +
             q + count + selTag + status;
     }
 
@@ -180,7 +181,7 @@ export async function openGrepDashboard(): Promise<void> {
                         previewScroll.set(r.absPath, scrollPerc);
                         ctx.api.repaintDetails();
                     });
-                    return '{gray-fg}loading…{/gray-fg}';
+                    return theme.dim('loading…');
                 },
                 scrollPerc: (r) => previewScroll.get(r.absPath) ?? 0,
             },
@@ -195,27 +196,27 @@ export async function openGrepDashboard(): Promise<void> {
                         metaCache.set(r.absPath, v);
                         ctx.api.repaintDetails();
                     });
-                    return '{gray-fg}loading…{/gray-fg}';
+                    return theme.dim('loading…');
                 },
             },
             {
                 label: 'stats',
                 focusName: 'stats',
-                initialContent: '{gray-fg}no results{/gray-fg}',
+                initialContent: theme.dim('no results'),
                 paint: () => renderStatsContent(allResults, isSearching),
             },
         ],
         keymapText: () =>
-            `{cyan-fg}enter{/cyan-fg} search/nvim   ` +
-            `{cyan-fg}f{/cyan-fg} files   ` +
-            `{cyan-fg}d{/cyan-fg} dirs   ` +
-            `{cyan-fg}c{/cyan-fg} content   ` +
-            `{cyan-fg}x{/cyan-fg} delete   ` +
-            `{cyan-fg}space{/cyan-fg} select   ` +
-            `{cyan-fg}X{/cyan-fg} del selected   ` +
-            `{cyan-fg}y{/cyan-fg} copy path   ` +
-            `{cyan-fg}s{/cyan-fg}/{cyan-fg}/{/cyan-fg} search   ` +
-            `{cyan-fg}q{/cyan-fg} quit`,
+            `${theme.key('enter')} search/nvim   ` +
+            `${theme.key('f')} files   ` +
+            `${theme.key('d')} dirs   ` +
+            `${theme.key('c')} content   ` +
+            `${theme.key('x')} delete   ` +
+            `${theme.key('space')} select   ` +
+            `${theme.key('X')} del selected   ` +
+            `${theme.key('y')} copy path   ` +
+            `${theme.key('s')}/${theme.key('/')} search   ` +
+            `${theme.key('q')} quit`,
         actions: [
             {
                 keys: 'f',

--- a/src/system/commands/systemProcessManager.ts
+++ b/src/system/commands/systemProcessManager.ts
@@ -6,6 +6,7 @@ import {
     createDashboardScreen,
     createDashboardShell,
     modalConfirm,
+    theme,
 } from '@/UI/dashboard';
 
 interface ProcessInfo {
@@ -120,7 +121,9 @@ function renderBar(percent: number, width = 30): string {
     const num = Math.min(100, Math.max(0, percent));
     const filled = Math.round((num / 100) * width);
 
-    return `[${'█'.repeat(filled)}${'░'.repeat(width - filled)}]`;
+    const color = num >= 90 ? 'red-fg' : num >= 70 ? 'yellow-fg' : 'green-fg';
+
+    return `[{${color}}${'█'.repeat(filled)}{/${color}}{gray-fg}${'░'.repeat(width - filled)}{/gray-fg}]`;
 }
 
 
@@ -185,12 +188,12 @@ export async function openProcessManager(): Promise<void> {
         function renderListItems(): void {
             const items = displayed.map((p) => {
                 return (
-                    `{cyan-fg}${p.pid.toString().padStart(6)}{/cyan-fg} ` +
-                    `{gray-fg}${p.user.padEnd(10)}{/gray-fg} ` +
-                    `{yellow-fg}${p.cpu.padStart(5)}{/yellow-fg} ` +
-                    `{yellow-fg}${p.mem.padStart(5)}{/yellow-fg} ` +
-                    `{gray-fg}${p.started.padEnd(8)} ${p.time.padEnd(10)}{/gray-fg} ` +
-                    `${truncate(p.command, 60)}`
+                    `${theme.count(p.pid.toString().padStart(6))} ` +
+                    `${theme.dim(p.user.padEnd(10))} ` +
+                    `${theme.warn(p.cpu.padStart(5))} ` +
+                    `${theme.warn(p.mem.padStart(5))} ` +
+                    `${theme.date(p.started.padEnd(8) + ' ' + p.time.padEnd(10))} ` +
+                    `${theme.path(escapeTag(truncate(p.command, 60)))}`
                 );
             });
             list.setItems(items);
@@ -261,23 +264,24 @@ export async function openProcessManager(): Promise<void> {
             if (currentIdx !== i) return;
             const p = displayed[i];
             if (p === undefined) return;
+            const lab = (s: string): string => theme.label(s);
             const detailText =
-                `PID:            ${p.pid}\n` +
-                `Parent PID:     ${p.ppid}\n` +
-                `Process Group:  ${p.pgid}   (terminal fg pgid: ${p.tpgid})\n` +
-                `Session:        ${p.sess}\n` +
-                `User:           ${p.user} (uid ${p.uid}, gid ${p.gid})\n` +
-                `State:          ${p.state}\n` +
-                `TTY:            ${p.tty}\n` +
-                `Priority:       ${p.pri} (nice ${p.nice})\n` +
-                `CPU:            ${p.cpu}%\n` +
-                `Memory:         ${p.mem}%   RSS ${kbFmt(p.rss)}   VSZ ${kbFmt(p.vsz)}\n` +
-                `Started:        ${p.lstart}\n` +
-                `Elapsed Time:   ${p.etime}\n` +
-                `CPU Time:       ${p.time}\n` +
+                `${lab('PID:')}            ${theme.count(p.pid)}\n` +
+                `${lab('Parent PID:')}     ${theme.count(p.ppid)}\n` +
+                `${lab('Process Group:')}  ${theme.count(p.pgid)}   ${theme.dim('(terminal fg pgid: ' + p.tpgid + ')')}\n` +
+                `${lab('Session:')}        ${theme.count(p.sess)}\n` +
+                `${lab('User:')}           ${theme.value(p.user)} ${theme.dim('(uid ' + p.uid + ', gid ' + p.gid + ')')}\n` +
+                `${lab('State:')}          ${theme.value(p.state)}\n` +
+                `${lab('TTY:')}            ${theme.value(p.tty)}\n` +
+                `${lab('Priority:')}       ${theme.value(p.pri)} ${theme.dim('(nice ' + p.nice + ')')}\n` +
+                `${lab('CPU:')}            ${theme.warn(p.cpu + '%')}\n` +
+                `${lab('Memory:')}         ${theme.warn(p.mem + '%')}   ${theme.dim('RSS')} ${theme.size(kbFmt(p.rss))}   ${theme.dim('VSZ')} ${theme.size(kbFmt(p.vsz))}\n` +
+                `${lab('Started:')}        ${theme.date(escapeTag(p.lstart))}\n` +
+                `${lab('Elapsed Time:')}   ${theme.date(p.etime)}\n` +
+                `${lab('CPU Time:')}       ${theme.date(p.time)}\n` +
                 `\n` +
-                `Command:\n${p.command}`;
-            details.setContent(escapeTag(detailText));
+                `${lab('Command:')}\n${theme.path(escapeTag(p.command))}`;
+            details.setContent(detailText);
             details.setScrollPerc(0);
 
             const totalCpu = filtered.reduce((acc, x) => acc + (parseFloat(x.cpu) || 0), 0);
@@ -289,15 +293,15 @@ export async function openProcessManager(): Promise<void> {
             const memPct = parseFloat(p.mem) || 0;
             const sysMemPct = (used / total) * 100;
             const statsText =
-                `{cyan-fg}Process{/cyan-fg}\n` +
-                `CPU   ${renderBar(cpuPct)} ${cpuPct.toFixed(1)}%\n` +
-                `Mem   ${renderBar(memPct)} ${memPct.toFixed(1)}%\n` +
+                `${theme.section('Process')}\n` +
+                `${theme.label('CPU')}   ${renderBar(cpuPct)} ${theme.warn(cpuPct.toFixed(1) + '%')}\n` +
+                `${theme.label('Mem')}   ${renderBar(memPct)} ${theme.warn(memPct.toFixed(1) + '%')}\n` +
                 `\n` +
-                `{cyan-fg}System{/cyan-fg}\n` +
-                `Load avg:    ${load[0].toFixed(2)}  ${load[1].toFixed(2)}  ${load[2].toFixed(2)}   (${cores} cores)\n` +
-                `Memory   ${renderBar(sysMemPct)} ${formatBytes(used)} / ${formatBytes(total)} (${sysMemPct.toFixed(1)}%)\n` +
-                `Uptime:      ${formatUptime(os.uptime())}\n` +
-                `Processes:   ${filtered.length} shown / ${processes.length} total   sum CPU ${totalCpu.toFixed(1)}%   sum Mem ${totalMem.toFixed(1)}%`;
+                `${theme.section('System')}\n` +
+                `${theme.label('Load avg:')}    ${theme.count(load[0].toFixed(2))}  ${theme.count(load[1].toFixed(2))}  ${theme.count(load[2].toFixed(2))}   ${theme.dim('(' + cores + ' cores)')}\n` +
+                `${theme.label('Memory')}   ${renderBar(sysMemPct)} ${theme.size(formatBytes(used))} ${theme.dim('/')} ${theme.size(formatBytes(total))} ${theme.dim('(' + sysMemPct.toFixed(1) + '%)')}\n` +
+                `${theme.label('Uptime:')}      ${theme.date(formatUptime(os.uptime()))}\n` +
+                `${theme.label('Processes:')}   ${theme.count(filtered.length)} ${theme.dim('shown /')} ${theme.count(processes.length)} ${theme.dim('total')}   ${theme.dim('sum CPU')} ${theme.warn(totalCpu.toFixed(1) + '%')}   ${theme.dim('sum Mem')} ${theme.warn(totalMem.toFixed(1) + '%')}`;
             stats.setContent(statsText);
             stats.setScrollPerc(0);
             screen.render();

--- a/src/system/utils/grepUtils.ts
+++ b/src/system/utils/grepUtils.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { escTag, sanitizeForBlessed } from '@/UI/dashboard';
+import { escTag, highlightCode, sanitizeForBlessed, theme } from '@/UI/dashboard';
 import { execCommand } from '@/utils/bashHelper';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -256,18 +256,23 @@ export async function loadContentPreviewWithMatches(
         let firstMatchLine = -1;
         let matchCount = 0;
 
+        // blessed's fullUnicode: true tracks double-width cells via \x03
+        // markers; on scroll those markers desync and duplicate glyphs at
+        // wrong positions. Sanitize wide / non-printable chars BEFORE
+        // syntax-highlight + tag-escape so the preview renders at exactly
+        // one cell per char. Highlight the whole buffer for cross-line context
+        // (template strings, multi-line comments) then split back into lines.
+        const safeLines = shown.map((l) => sanitizeForBlessed(l));
+        const highlightedAll = highlightCode(safeLines.join('\n'), absPath);
+        const hlLines = highlightedAll.split('\n');
+
         const out = shown.map((line, i) => {
             const lineNo = i + 1;
-            // blessed's fullUnicode: true tracks double-width cells via \x03
-            // markers; on scroll those markers desync and duplicate glyphs at
-            // wrong positions. Sanitize wide / non-printable chars BEFORE
-            // tag-escape so the preview renders at exactly one cell per char.
-            const safe = sanitizeForBlessed(line);
-            const escaped = escTag(safe);
+            const hlLine = hlLines[i] ?? safeLines[i] ?? '';
+            const escaped = escTag(hlLine);
             const hasMatch = escQuery !== '' && line.includes(query);
             if (hasMatch) {
                 if (firstMatchLine === -1) firstMatchLine = lineNo;
-                // count occurrences in this line (literal substring count)
                 let from = 0;
                 let idx = line.indexOf(query, from);
                 while (idx !== -1) {
@@ -327,10 +332,12 @@ export async function loadPreview(
             }
         }
         const { stdout } = await execCommand(`head -n 120 ${JSON.stringify(result.absPath)} 2>/dev/null`);
+        if (!stdout) return '(binary or empty file)';
+        const safe = sanitizeForBlessed(stdout);
 
-        return sanitizeForBlessed(stdout) || '(binary or empty file)';
+        return escTag(highlightCode(safe, result.absPath));
     } catch {
-        return '(could not read file)';
+        return theme.err('(could not read file)');
     }
 }
 
@@ -345,32 +352,34 @@ export async function loadMeta(result: GrepResult): Promise<string> {
         if (result.type === 'file') {
             const { stdout: wcOut } = await execCommand(`wc -l ${JSON.stringify(result.absPath)} 2>/dev/null`).catch(() => ({ stdout: '?' }));
             const lineCount = wcOut.trim().split(/\s+/)[0] || '?';
-            extra = `\n{cyan-fg}lines  {/cyan-fg}${lineCount}`;
+            extra = `\n${theme.label('lines  ')}${theme.count(lineCount)}`;
             if (result.matchCount > 0) {
-                extra += `\n{cyan-fg}matches{/cyan-fg} {yellow-fg}${result.matchCount}{/yellow-fg}`;
+                extra += `\n${theme.label('matches')} ${theme.count(result.matchCount)}`;
             }
         }
 
         return (
-            `{cyan-fg}path   {/cyan-fg}${escTag(abs)}\n` +
-            `{cyan-fg}dir    {/cyan-fg}${escTag(dir)}\n` +
-            `{cyan-fg}size   {/cyan-fg}${size}` +
+            `${theme.label('path   ')}${theme.path(escTag(abs))}\n` +
+            `${theme.label('dir    ')}${theme.path(escTag(dir))}\n` +
+            `${theme.label('size   ')}${theme.size(size)}` +
             extra +
-            `\n\n{white-fg}${escTag(lsOut.trim())}{/white-fg}`
+            `\n\n${theme.dim(escTag(lsOut.trim()))}`
         );
     } catch {
-        return `{cyan-fg}path{/cyan-fg}  ${escTag(result.absPath)}`;
+        return `${theme.label('path')}  ${theme.path(escTag(result.absPath))}`;
     }
 }
 
 // ─── Row renderer ─────────────────────────────────────────────────────────────
 
 export function renderRow(r: GrepResult, mode: SearchMode): string {
-    const sel = r.selected ? '{yellow-fg}[x]{/yellow-fg} ' : '    ';
+    const sel = r.selected ? `${theme.selected('[x]')} ` : '    ';
     const icon = r.type === 'dir' ? '📁' : '📄';
-    const disp = escTag(r.displayPath.replace(/^\.\//u, ''));
+    const disp = r.type === 'dir'
+        ? theme.dir(escTag(r.displayPath.replace(/^\.\//u, '')))
+        : theme.path(escTag(r.displayPath.replace(/^\.\//u, '')));
     const countTag = mode === 'content' && r.matchCount > 0
-        ? `  {yellow-fg}(${r.matchCount}){/yellow-fg}`
+        ? `  ${theme.count(`(${r.matchCount})`)}`
         : '';
 
     return `${sel}${icon} ${disp}${countTag}`;

--- a/src/tmux/commands/manageSessionDashboard.ts
+++ b/src/tmux/commands/manageSessionDashboard.ts
@@ -14,6 +14,7 @@ import {
     createDashboardShell,
     attachVerticalNavigation,
     createListDetailDashboard,
+    theme,
 } from '@/UI/dashboard';
 
 interface FileEntry {
@@ -85,22 +86,22 @@ function summarize(sessions: TmuxSessions): { sessions: number; windows: number;
 
 
 function renderSummary(entry: FileEntry | undefined): string {
-    if (!entry) return '{gray-fg}(no save selected){/gray-fg}';
-    if (entry.parseError) return `{red-fg}parse error:{/red-fg}\n${escTag(entry.parseError)}`;
-    if (!entry.sessions) return '{gray-fg}(loading...){/gray-fg}';
+    if (!entry) return theme.dim('(no save selected)');
+    if (entry.parseError) return `${theme.err('parse error:')}\n${escTag(entry.parseError)}`;
+    if (!entry.sessions) return theme.dim('(loading...)');
     const s = summarize(entry.sessions);
     const lines: string[] = [];
-    lines.push(`{bold}${escTag(entry.name)}{/bold}`);
+    lines.push(`{bold}${theme.value(escTag(entry.name))}{/bold}`);
     lines.push('');
-    lines.push(`{cyan-fg}sessions:{/cyan-fg} ${s.sessions}   {cyan-fg}windows:{/cyan-fg} ${s.windows}   {cyan-fg}panes:{/cyan-fg} ${s.panes}`);
-    lines.push(`{cyan-fg}size:{/cyan-fg} ${fmtSize(entry.sizeBytes)}   {cyan-fg}saved:{/cyan-fg} ${fmtAge(entry.mtimeMs)} ago`);
+    lines.push(`${theme.label('sessions:')} ${theme.count(s.sessions)}   ${theme.label('windows:')} ${theme.count(s.windows)}   ${theme.label('panes:')} ${theme.count(s.panes)}`);
+    lines.push(`${theme.label('size:')} ${theme.size(fmtSize(entry.sizeBytes))}   ${theme.label('saved:')} ${theme.date(fmtAge(entry.mtimeMs) + ' ago')}`);
     lines.push('');
     for (const sessName of Object.keys(entry.sessions)) {
         const sess = entry.sessions[sessName];
         const path = sess.windows[0]?.currentPath ?? '';
         let panes = 0;
         for (const w of sess.windows) panes += w.panes.length;
-        lines.push(`  {magenta-fg}${escTag(sessName)}{/magenta-fg}  {gray-fg}w${sess.windows.length} p${panes}{/gray-fg}  ${escTag(path)}`);
+        lines.push(`  ${theme.accent(escTag(sessName))}  ${theme.dim(`w${sess.windows.length} p${panes}`)}  ${theme.path(escTag(path))}`);
     }
 
     return lines.join('\n');
@@ -111,12 +112,12 @@ function renderDetails(entry: FileEntry | undefined): string {
     const lines: string[] = [];
     for (const sessName of Object.keys(entry.sessions)) {
         const sess = entry.sessions[sessName];
-        lines.push(`{bold}{magenta-fg}${escTag(sessName)}{/magenta-fg}{/bold}`);
+        lines.push(`{bold}${theme.accent(escTag(sessName))}{/bold}`);
         for (const [i, w] of sess.windows.entries()) {
-            lines.push(`  {yellow-fg}#${i} ${escTag(w.windowName || '')}{/yellow-fg}  {gray-fg}${escTag(w.currentCommand || '')}{/gray-fg}`);
-            lines.push(`    {gray-fg}${escTag(w.currentPath)}{/gray-fg}`);
+            lines.push(`  ${theme.warn(`#${i} ${escTag(w.windowName || '')}`)}  ${theme.dim(escTag(w.currentCommand || ''))}`);
+            lines.push(`    ${theme.path(escTag(w.currentPath))}`);
             for (const [j, p] of w.panes.entries()) {
-                lines.push(`      {green-fg}pane ${j}{/green-fg}  ${escTag(p.currentCommand || '')}  {gray-fg}${escTag(p.currentPath)}{/gray-fg}`);
+                lines.push(`      ${theme.success(`pane ${j}`)}  ${theme.value(escTag(p.currentCommand || ''))}  ${theme.path(escTag(p.currentPath))}`);
             }
         }
         lines.push('');
@@ -137,21 +138,21 @@ function renderTreeRows(sessions: TmuxSessions): BuilderRow[] {
     const rows: BuilderRow[] = [];
     const names = Object.keys(sessions);
     if (names.length === 0) {
-        return [{ level: 'session', sessionName: '', label: '{gray-fg}(empty — press s to add a session){/gray-fg}' }];
+        return [{ level: 'session', sessionName: '', label: theme.dim('(empty — press s to add a session)') }];
     }
     for (const sname of names) {
         const sess = sessions[sname];
         rows.push({
             level: 'session',
             sessionName: sname,
-            label: `{bold}{magenta-fg}◆ ${escTag(sname)}{/magenta-fg}{/bold}  {gray-fg}(${sess.windows.length}w){/gray-fg}`,
+            label: `{bold}${theme.accent(`◆ ${escTag(sname)}`)}{/bold}  ${theme.dim(`(${sess.windows.length}w)`)}`,
         });
         for (const [wi, w] of sess.windows.entries()) {
             rows.push({
                 level: 'window',
                 sessionName: sname,
                 windowIdx: wi,
-                label: `  {yellow-fg}▸ #${wi} ${escTag(w.windowName || '(unnamed)')}{/yellow-fg}  {gray-fg}${escTag(w.currentPath)}{/gray-fg}`,
+                label: `  ${theme.warn(`▸ #${wi} ${escTag(w.windowName || '(unnamed)')}`)}  ${theme.path(escTag(w.currentPath))}`,
             });
             for (const [pi, p] of w.panes.entries()) {
                 rows.push({
@@ -159,7 +160,7 @@ function renderTreeRows(sessions: TmuxSessions): BuilderRow[] {
                     sessionName: sname,
                     windowIdx: wi,
                     paneIdx: pi,
-                    label: `      {green-fg}· pane ${pi}{/green-fg}  ${escTag(p.currentCommand || '(shell)')}  {gray-fg}${escTag(p.currentPath)}{/gray-fg}`,
+                    label: `      ${theme.success(`· pane ${pi}`)}  ${theme.value(escTag(p.currentCommand || '(shell)'))}  ${theme.path(escTag(p.currentPath))}`,
                 });
             }
         }
@@ -170,33 +171,33 @@ function renderTreeRows(sessions: TmuxSessions): BuilderRow[] {
 
 function renderNodeDetails(sessions: TmuxSessions, row: BuilderRow | undefined): string {
     if (!row?.sessionName) {
-        return '{gray-fg}Press {/gray-fg}{cyan-fg}s{/cyan-fg}{gray-fg} to add a new session.{/gray-fg}';
+        return `${theme.dim('Press ')}${theme.key('s')}${theme.dim(' to add a new session.')}`;
     }
     const sess = sessions[row.sessionName];
     if (!sess) return '';
     const lines: string[] = [];
     if (row.level === 'session') {
-        lines.push(`{bold}Session:{/bold} {magenta-fg}${escTag(row.sessionName)}{/magenta-fg}`);
-        lines.push(`{cyan-fg}windows:{/cyan-fg} ${sess.windows.length}`);
+        lines.push(`{bold}Session:{/bold} ${theme.accent(escTag(row.sessionName))}`);
+        lines.push(`${theme.label('windows:')} ${theme.count(sess.windows.length)}`);
         lines.push('');
-        lines.push('{cyan-fg}w{/cyan-fg} add window   {cyan-fg}e{/cyan-fg} rename   {cyan-fg}D{/cyan-fg} delete session');
+        lines.push(`${theme.key('w')} add window   ${theme.key('e')} rename   ${theme.key('D')} delete session`);
     } else if (row.level === 'window' && row.windowIdx !== undefined) {
         const w = sess.windows[row.windowIdx];
         if (!w) return '';
-        lines.push(`{bold}Window:{/bold} {yellow-fg}#${row.windowIdx} ${escTag(w.windowName || '(unnamed)')}{/yellow-fg}`);
-        lines.push(`{cyan-fg}cwd:{/cyan-fg} ${escTag(w.currentPath)}`);
-        lines.push(`{cyan-fg}cmd:{/cyan-fg} ${escTag(w.currentCommand || '(shell)')}`);
-        lines.push(`{cyan-fg}panes:{/cyan-fg} ${w.panes.length}`);
+        lines.push(`{bold}Window:{/bold} ${theme.warn(`#${row.windowIdx} ${escTag(w.windowName || '(unnamed)')}`)}`);
+        lines.push(`${theme.label('cwd:')} ${theme.path(escTag(w.currentPath))}`);
+        lines.push(`${theme.label('cmd:')} ${theme.value(escTag(w.currentCommand || '(shell)'))}`);
+        lines.push(`${theme.label('panes:')} ${theme.count(w.panes.length)}`);
         lines.push('');
-        lines.push('{cyan-fg}p{/cyan-fg} add pane   {cyan-fg}e{/cyan-fg} edit fields   {cyan-fg}D{/cyan-fg} delete window');
+        lines.push(`${theme.key('p')} add pane   ${theme.key('e')} edit fields   ${theme.key('D')} delete window`);
     } else if (row.level === 'pane' && row.windowIdx !== undefined && row.paneIdx !== undefined) {
         const p = sess.windows[row.windowIdx]?.panes[row.paneIdx];
         if (!p) return '';
-        lines.push(`{bold}Pane:{/bold} {green-fg}${row.paneIdx}{/green-fg} of window #${row.windowIdx}`);
-        lines.push(`{cyan-fg}cwd:{/cyan-fg} ${escTag(p.currentPath)}`);
-        lines.push(`{cyan-fg}cmd:{/cyan-fg} ${escTag(p.currentCommand || '(shell)')}`);
+        lines.push(`{bold}Pane:{/bold} ${theme.success(String(row.paneIdx))} of window #${row.windowIdx}`);
+        lines.push(`${theme.label('cwd:')} ${theme.path(escTag(p.currentPath))}`);
+        lines.push(`${theme.label('cmd:')} ${theme.value(escTag(p.currentCommand || '(shell)'))}`);
         lines.push('');
-        lines.push('{cyan-fg}e{/cyan-fg} edit fields   {cyan-fg}D{/cyan-fg} delete pane');
+        lines.push(`${theme.key('e')} edit fields   ${theme.key('D')} delete pane`);
     }
 
     return lines.join('\n');
@@ -230,10 +231,10 @@ async function buildNewSaveFlow(parentScreen: blessed.Widgets.Screen): Promise<T
                 { label: 'selected', focusName: 'selected', bottom: 3 },
             ],
             keymapText: () =>
-                `{cyan-fg}j/k{/cyan-fg} nav   {cyan-fg}[ ]{/cyan-fg} ±10   ` +
-                `{cyan-fg}s{/cyan-fg} +session   {cyan-fg}w{/cyan-fg} +window   {cyan-fg}p{/cyan-fg} +pane   ` +
-                `{cyan-fg}e{/cyan-fg} edit   {cyan-fg}D{/cyan-fg} delete   ` +
-                `{cyan-fg}enter{/cyan-fg} done   {cyan-fg}esc/q{/cyan-fg} cancel`,
+                `${theme.key('j/k')} nav   ${theme.key('[ ]')} ±10   ` +
+                `${theme.key('s')} +session   ${theme.key('w')} +window   ${theme.key('p')} +pane   ` +
+                `${theme.key('e')} edit   ${theme.key('D')} delete   ` +
+                `${theme.key('enter')} done   ${theme.key('esc/q')} cancel`,
         });
         const { header } = shell;
         const tree = shell.list;
@@ -256,8 +257,8 @@ async function buildNewSaveFlow(parentScreen: blessed.Widgets.Screen): Promise<T
                 return { s: Object.keys(sessions).length, w, p };
             })();
             header.setContent(
-                `{bold}{magenta-fg}building save{/magenta-fg}{/bold}  {gray-fg}|{/gray-fg}  ` +
-                `{cyan-fg}sessions:{/cyan-fg} ${totals.s}   {cyan-fg}windows:{/cyan-fg} ${totals.w}   {cyan-fg}panes:{/cyan-fg} ${totals.p}`,
+                `${theme.title('building save')}  ${theme.dim('|')}  ` +
+                `${theme.label('sessions:')} ${theme.count(totals.s)}   ${theme.label('windows:')} ${theme.count(totals.w)}   ${theme.label('panes:')} ${theme.count(totals.p)}`,
             );
             detail.setContent(renderNodeDetails(sessions, rows[selectedIdx]));
             parentScreen.render();
@@ -508,14 +509,14 @@ export async function manageSessions(): Promise<void> {
             const age = fmtAge(e.mtimeMs).padStart(4);
             const size = fmtSize(e.sizeBytes).padStart(6);
 
-            return `{cyan-fg}${age}{/cyan-fg}  {gray-fg}${size}{/gray-fg}  ${escTag(e.name)}`;
+            return `${theme.date(age)}  ${theme.size(size)}  ${theme.value(escTag(e.name))}`;
         },
         listLabel: 'saves',
         listFocusName: 'saves',
         listWidth: '50%',
         headerContent: () => {
             const total = entries.length;
-            return `{bold}{magenta-fg}tmux saves{/magenta-fg}{/bold}  {gray-fg}|{/gray-fg}  ${total} files`;
+            return `${theme.title('tmux saves')}  ${theme.dim('|')}  ${theme.count(total)} files`;
         },
         detailPanels: [
             {
@@ -536,13 +537,13 @@ export async function manageSessions(): Promise<void> {
             },
         ],
         keymapText: () =>
-            `{cyan-fg}j/k{/cyan-fg} nav   {cyan-fg}[ ]{/cyan-fg} ±10   {cyan-fg}{ }{/cyan-fg} ±100   ` +
-            `{cyan-fg}enter{/cyan-fg} load   ` +
-            `{cyan-fg}n{/cyan-fg} new save   ` +
-            `{cyan-fg}d{/cyan-fg} delete   ` +
-            `{cyan-fg}r{/cyan-fg} rename   ` +
-            `{cyan-fg}R{/cyan-fg} reload   ` +
-            `{cyan-fg}q{/cyan-fg} quit`,
+            `${theme.key('j/k')} nav   ${theme.key('[ ]')} ±10   ${theme.key('{ }')} ±100   ` +
+            `${theme.key('enter')} load   ` +
+            `${theme.key('n')} new save   ` +
+            `${theme.key('d')} delete   ` +
+            `${theme.key('r')} rename   ` +
+            `${theme.key('R')} reload   ` +
+            `${theme.key('q')} quit`,
         actions: [
             {
                 keys: 'enter',


### PR DESCRIPTION
Introduce src/UI/dashboard/theme.ts as the single source of semantic colors (label/value/path/date/size/count/err/...) and sweep all dashboards (gitLog, gitScout, manageSession, scripts, systemGrep, diskUsage, processManager) to use it. Adds richer color to data fields across the board: dates, sizes, paths, counts, status. Wires cli-highlight syntax coloring into file previews. Colorizes git log +/- diff stats green/red.