### PR TITLE
feat: investigate_web sub-agent for offloaded web research

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -146,7 +146,7 @@ graph TB
 | Documentation index | [`docs/agent/README.md`](docs/agent/README.md) |
 | Providers, model catalog, backend add/remove lifecycle | [`docs/agent/providers.md`](docs/agent/providers.md) |
 | Turn workflow, keymaps, tool-approval UX, diff review | [`docs/agent/workflow-and-keymaps.md`](docs/agent/workflow-and-keymaps.md) |
-| File-context tools, BYOK bash/web tools, MCP config, sub-agents (`investigate`) | [`docs/agent/tools-and-mcp.md`](docs/agent/tools-and-mcp.md) |
+| File-context tools, BYOK bash/web tools, MCP config, sub-agents (`investigate`, `investigate_web`, `execute`) | [`docs/agent/tools-and-mcp.md`](docs/agent/tools-and-mcp.md) |
 | Persistent memory, memory tools, indexing behavior | [`docs/agent/memory-and-indexing.md`](docs/agent/memory-and-indexing.md) |
 | Documentation crawling (`kra memory`) | [`docs/agent/docs-crawling.md`](docs/agent/docs-crawling.md) |
 

--- a/__tests__/AI/AIAgent/memory/researchChunks.test.ts
+++ b/__tests__/AI/AIAgent/memory/researchChunks.test.ts
@@ -1,0 +1,209 @@
+import {
+    insertResearchChunks,
+    searchResearchChunks,
+    deleteByResearchIds,
+    deleteResearchChunksOlderThan,
+} from '@/AI/AIAgent/shared/memory/researchChunks';
+import { getResearchChunksTable } from '@/AI/AIAgent/shared/memory/db';
+import type { ResearchChunkRow } from '@/AI/AIAgent/shared/memory/types';
+
+jest.mock('@/AI/AIAgent/shared/memory/db', () => ({
+    getResearchChunksTable: jest.fn(),
+}));
+
+const mockedGetTable = jest.mocked(getResearchChunksTable);
+
+interface FakeTable {
+    add: jest.Mock;
+    delete: jest.Mock;
+    search: jest.Mock;
+    _whereSpy: jest.Mock;
+}
+
+function makeTable(searchRows: Record<string, unknown>[] = []): FakeTable {
+    const whereSpy = jest.fn();
+    const search = jest.fn(() => ({
+        where: (filter: string) => {
+            whereSpy(filter);
+            return {
+                limit: jest.fn(() => ({ toArray: jest.fn(async () => searchRows) })),
+            };
+        },
+    }));
+
+    return {
+        add: jest.fn(async () => undefined),
+        delete: jest.fn(async () => undefined),
+        search,
+        _whereSpy: whereSpy,
+    };
+}
+
+function row(overrides: Partial<ResearchChunkRow> = {}): ResearchChunkRow {
+    return {
+        id: 'cid',
+        researchId: 'rid',
+        url: 'https://example.com/a',
+        title: 'A',
+        sectionPath: 'S',
+        chunkIndex: 0,
+        content: 'body',
+        fetchedAt: 1_000,
+        vector: [0.1, 0.2, 0.3],
+        ...overrides,
+    };
+}
+
+describe('researchChunks.insertResearchChunks', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('is a no-op for an empty batch (does not touch the table)', async () => {
+        await insertResearchChunks([]);
+        expect(mockedGetTable).not.toHaveBeenCalled();
+    });
+
+    it('seeds via the first row and adds the remainder', async () => {
+        const table = makeTable();
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: true });
+
+        const rows = [row({ id: 'a' }), row({ id: 'b' }), row({ id: 'c' })];
+        await insertResearchChunks(rows);
+
+        expect(mockedGetTable).toHaveBeenCalledWith(rows[0], undefined);
+        expect(table.add).toHaveBeenCalledTimes(1);
+        expect(table.add.mock.calls[0]?.[0]).toHaveLength(2);
+    });
+
+    it('does not call add when only one row is provided (the seed insert covers it)', async () => {
+        const table = makeTable();
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: true });
+
+        await insertResearchChunks([row()]);
+        expect(table.add).not.toHaveBeenCalled();
+    });
+
+    it('throws when the table is unavailable after the seed insert', async () => {
+        mockedGetTable.mockResolvedValueOnce({ table: null, justCreated: false });
+        await expect(insertResearchChunks([row()])).rejects.toThrow(/research_chunks table unavailable/);
+    });
+});
+
+describe('researchChunks.searchResearchChunks', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('returns [] when the table does not exist yet', async () => {
+        mockedGetTable.mockResolvedValueOnce({ table: null, justCreated: false });
+        const out = await searchResearchChunks({ researchId: 'rid', vector: [0, 0, 0] });
+        expect(out).toEqual([]);
+    });
+
+    it('applies a researchId filter and (when ttlMs is set) a fetchedAt cutoff', async () => {
+        const table = makeTable([
+            { ...row({ id: '1' }), _distance: 0 },
+        ]);
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: false });
+
+        const before = Date.now();
+        await searchResearchChunks({ researchId: 'rid-1', vector: [0.1], k: 4, ttlMs: 60_000 });
+        const after = Date.now();
+
+        expect(table._whereSpy).toHaveBeenCalledTimes(1);
+        const filter = table._whereSpy.mock.calls[0]?.[0] as string;
+        expect(filter).toContain("researchId = 'rid-1'");
+        expect(filter).toMatch(/fetchedAt > \d+/);
+        const cutoff = Number(filter.match(/fetchedAt > (\d+)/)?.[1]);
+        expect(cutoff).toBeGreaterThanOrEqual(before - 60_000 - 5);
+        expect(cutoff).toBeLessThanOrEqual(after - 60_000 + 5);
+    });
+
+    it("escapes single quotes in researchId so the filter can't be broken", async () => {
+        const table = makeTable();
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: false });
+
+        await searchResearchChunks({ researchId: "rid'; DROP TABLE--", vector: [0] });
+        const filter = table._whereSpy.mock.calls[0]?.[0] as string;
+        expect(filter).toContain("researchId = 'rid''; DROP TABLE--'");
+    });
+
+    it('omits the TTL clause when ttlMs is undefined', async () => {
+        const table = makeTable();
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: false });
+
+        await searchResearchChunks({ researchId: 'rid', vector: [0] });
+        const filter = table._whereSpy.mock.calls[0]?.[0] as string;
+        expect(filter).not.toContain('fetchedAt');
+    });
+
+    it('maps `_distance` to a 1/(1+d) score, sorts descending and applies k', async () => {
+        const table = makeTable([
+            { ...row({ id: 'far' }), _distance: 9 },
+            { ...row({ id: 'mid' }), _distance: 1 },
+            { ...row({ id: 'near' }), _distance: 0 },
+        ]);
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: false });
+
+        const hits = await searchResearchChunks({ researchId: 'rid', vector: [0.1], k: 2 });
+        expect(hits).toHaveLength(2);
+        expect(hits[0]?.score).toBeGreaterThan(hits[1]?.score ?? Infinity);
+        expect(hits[0]?.score).toBeCloseTo(1, 6);
+    });
+
+    it('returns [] when the underlying search throws', async () => {
+        const table = makeTable();
+        table.search.mockImplementationOnce(() => ({
+            where: () => ({ limit: () => ({ toArray: async () => { throw new Error('boom'); } }) }),
+        }));
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: false });
+
+        const out = await searchResearchChunks({ researchId: 'rid', vector: [0.1] });
+        expect(out).toEqual([]);
+    });
+});
+
+describe('researchChunks.deleteByResearchIds', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('is a no-op for an empty list', async () => {
+        await deleteByResearchIds([]);
+        expect(mockedGetTable).not.toHaveBeenCalled();
+    });
+
+    it('quotes and joins the ids in an IN clause and tolerates delete errors', async () => {
+        const table = makeTable();
+        table.delete.mockRejectedValueOnce(new Error('best-effort'));
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: false });
+
+        await expect(deleteByResearchIds(["a", "b'c"])).resolves.toBeUndefined();
+        expect(table.delete).toHaveBeenCalledWith("researchId IN ('a', 'b''c')");
+    });
+
+    it('is a no-op when the table does not exist', async () => {
+        mockedGetTable.mockResolvedValueOnce({ table: null, justCreated: false });
+        await expect(deleteByResearchIds(['a'])).resolves.toBeUndefined();
+    });
+});
+
+describe('researchChunks.deleteResearchChunksOlderThan', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('issues a fetchedAt < cutoff predicate', async () => {
+        const table = makeTable();
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: false });
+
+        await deleteResearchChunksOlderThan(12_345);
+        expect(table.delete).toHaveBeenCalledWith('fetchedAt < 12345');
+    });
+
+    it('swallows delete errors', async () => {
+        const table = makeTable();
+        table.delete.mockRejectedValueOnce(new Error('boom'));
+        mockedGetTable.mockResolvedValueOnce({ table: table as never, justCreated: false });
+
+        await expect(deleteResearchChunksOlderThan(1)).resolves.toBeUndefined();
+    });
+
+    it('is a no-op when the table does not exist', async () => {
+        mockedGetTable.mockResolvedValueOnce({ table: null, justCreated: false });
+        await expect(deleteResearchChunksOlderThan(1)).resolves.toBeUndefined();
+    });
+});

--- a/__tests__/AI/AIAgent/subAgents/investigateWebTool.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/investigateWebTool.test.ts
@@ -1,0 +1,186 @@
+import {
+    coerceWebResult,
+    validateWebEvidence,
+    type WebEvidenceItem,
+} from '@/AI/AIAgent/shared/subAgents/investigateWebTool';
+import { embedOne } from '@/AI/AIAgent/shared/memory/embedder';
+import { searchResearchChunks } from '@/AI/AIAgent/shared/memory/researchChunks';
+import type { WebResearchToolStats } from '@/AI/AIAgent/shared/subAgents/webResearchTools';
+
+jest.mock('@/AI/AIAgent/shared/memory/embedder', () => ({
+    embedOne: jest.fn(async () => [0.1, 0.2, 0.3]),
+}));
+jest.mock('@/AI/AIAgent/shared/memory/researchChunks', () => ({
+    searchResearchChunks: jest.fn(),
+}));
+
+const mockedEmbedOne = jest.mocked(embedOne);
+const mockedSearch = jest.mocked(searchResearchChunks);
+
+const baseStats: WebResearchToolStats = {
+    searches: 1,
+    scrapes: 1,
+    pagesFetched: 2,
+    pagesFailed: 0,
+    chunksIndexed: 5,
+};
+
+describe('investigateWebTool.coerceWebResult', () => {
+    it('parses a complete result and projects stats', () => {
+        const parsed = coerceWebResult(
+            {
+                summary: 'X works because Y',
+                evidence: [
+                    {
+                        url: 'https://docs.example/foo',
+                        title: 'Foo',
+                        section: 'API',
+                        excerpt: 'foo() is idempotent',
+                        why_relevant: 'states the property under test',
+                    },
+                ],
+                confidence: 'high',
+                suggested_next: 'check bar',
+                partial: true,
+            },
+            baseStats,
+        );
+
+        expect(parsed.summary).toBe('X works because Y');
+        expect(parsed.evidence).toHaveLength(1);
+        expect(parsed.evidence[0]?.url).toBe('https://docs.example/foo');
+        expect(parsed.evidence[0]?.title).toBe('Foo');
+        expect(parsed.confidence).toBe('high');
+        expect(parsed.suggested_next).toBe('check bar');
+        expect(parsed.partial).toBe(true);
+        expect(parsed.pages_fetched).toBe(2);
+        expect(parsed.scrapes).toBe(1);
+        expect(parsed.chunks_indexed).toBe(5);
+    });
+
+    it('drops malformed evidence entries (missing required fields)', () => {
+        const parsed = coerceWebResult(
+            {
+                summary: '',
+                evidence: [
+                    { url: 'https://a', excerpt: 'x', why_relevant: 'y' },
+                    { url: 'https://b' }, // missing excerpt + why_relevant
+                    'garbage',
+                    { excerpt: 'x', why_relevant: 'y' }, // missing url
+                    { url: 'https://c', excerpt: 'z', why_relevant: 'w' },
+                ],
+            },
+            baseStats,
+        );
+
+        expect(parsed.evidence.map((e) => e.url)).toEqual(['https://a', 'https://c']);
+    });
+
+    it('falls back to a sensible default for missing/invalid confidence', () => {
+        const missing = coerceWebResult({ summary: '', evidence: [] }, baseStats).confidence;
+        const invalid = coerceWebResult(
+            { summary: '', evidence: [], confidence: 'mystery' },
+            baseStats,
+        ).confidence;
+
+        expect(['high', 'medium', 'low']).toContain(missing);
+        expect(missing).toBe(invalid);
+    });
+});
+
+describe('investigateWebTool.validateWebEvidence', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedEmbedOne.mockResolvedValue([0.1, 0.2, 0.3]);
+    });
+
+    function evidence(overrides: Partial<WebEvidenceItem> = {}): WebEvidenceItem {
+        return {
+            url: 'https://docs.example/foo',
+            excerpt: 'foo() is idempotent',
+            why_relevant: 'states the property',
+            ...overrides,
+        };
+    }
+
+    it('keeps evidence whose excerpt is contained in a same-URL hit', async () => {
+        mockedSearch.mockResolvedValueOnce([
+            {
+                url: 'https://docs.example/foo',
+                title: 'Foo',
+                sectionPath: 'API',
+                chunkIndex: 0,
+                content: 'Notes: foo() is idempotent and safe to retry.',
+                fetchedAt: Date.now(),
+                score: 0.9,
+            },
+        ]);
+
+        const validated = await validateWebEvidence([evidence()], 'rid', 60_000);
+
+        expect(validated).toHaveLength(1);
+        expect(validated[0]?.why_relevant).toBe('states the property');
+    });
+
+    it('flags evidence not present in any indexed chunk', async () => {
+        mockedSearch.mockResolvedValueOnce([
+            {
+                url: 'https://docs.example/foo',
+                title: 'Foo',
+                sectionPath: 'API',
+                chunkIndex: 0,
+                content: 'Completely unrelated text about other things.',
+                fetchedAt: Date.now(),
+                score: 0.4,
+            },
+        ]);
+
+        const validated = await validateWebEvidence([evidence()], 'rid', 60_000);
+        expect(validated[0]?.why_relevant).toMatch(/^\[unverified: excerpt not found/);
+    });
+
+    it('falls back to all hits when there are no same-URL matches', async () => {
+        mockedSearch.mockResolvedValueOnce([
+            {
+                url: 'https://other.example/page',
+                title: 'Other',
+                sectionPath: '',
+                chunkIndex: 0,
+                content: 'Quoting docs: foo() is idempotent. Source: docs.example.',
+                fetchedAt: Date.now(),
+                score: 0.7,
+            },
+        ]);
+
+        const validated = await validateWebEvidence([evidence()], 'rid', 60_000);
+        expect(validated[0]?.why_relevant).toBe('states the property');
+    });
+
+    it('tolerates whitespace / case differences when matching', async () => {
+        mockedSearch.mockResolvedValueOnce([
+            {
+                url: 'https://docs.example/foo',
+                title: 'Foo',
+                sectionPath: '',
+                chunkIndex: 0,
+                content: 'FOO()    is\nidempotent.',
+                fetchedAt: Date.now(),
+                score: 0.8,
+            },
+        ]);
+
+        const validated = await validateWebEvidence(
+            [evidence({ excerpt: 'foo() is idempotent' })],
+            'rid',
+            60_000,
+        );
+        expect(validated[0]?.why_relevant).toBe('states the property');
+    });
+
+    it('flags items when the search throws', async () => {
+        mockedSearch.mockRejectedValueOnce(new Error('table missing'));
+
+        const validated = await validateWebEvidence([evidence()], 'rid', 60_000);
+        expect(validated[0]?.why_relevant).toMatch(/^\[unverified: validation error: table missing/);
+    });
+});

--- a/__tests__/AI/AIAgent/subAgents/settings.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/settings.test.ts
@@ -1,4 +1,5 @@
-import { mergeExecutor, mergeInvestigator } from '@/AI/AIAgent/shared/subAgents/settings';
+import { mergeExecutor, mergeInvestigator, mergeTruncation } from '@/AI/AIAgent/shared/subAgents/settings';
+import type { AgentTruncationSettings } from '@/AI/AIAgent/shared/subAgents/types';
 
 describe('mergeExecutor', () => {
     it('returns defaults when raw is undefined', () => {
@@ -70,7 +71,8 @@ describe('mergeInvestigator', () => {
     it('returns defaults when raw is undefined', () => {
         const merged = mergeInvestigator(undefined);
 
-        expect(merged.enabled).toBe(false);
+        expect(merged.code).toBe(false);
+        expect(merged.web).toBe(false);
         expect(merged.maxEvidenceItems).toBe(8);
         expect(merged.maxExcerptLines).toBe(20);
         expect(merged.validateExcerpts).toBe(true);
@@ -90,10 +92,67 @@ describe('mergeInvestigator', () => {
     });
 
     it('respects partial overrides', () => {
-        const merged = mergeInvestigator({ enabled: true, validateExcerpts: false });
+        const merged = mergeInvestigator({ code: true, web: true, validateExcerpts: false });
 
-        expect(merged.enabled).toBe(true);
+        expect(merged.code).toBe(true);
+        expect(merged.web).toBe(true);
         expect(merged.validateExcerpts).toBe(false);
         expect(merged.maxEvidenceItems).toBe(8);
+    });
+
+    it('treats `code` and `web` independently', () => {
+        const onlyCode = mergeInvestigator({ code: true });
+        const onlyWeb = mergeInvestigator({ web: true });
+
+        expect(onlyCode.code).toBe(true);
+        expect(onlyCode.web).toBe(false);
+        expect(onlyWeb.code).toBe(false);
+        expect(onlyWeb.web).toBe(true);
+    });
+});
+
+describe('mergeTruncation', () => {
+    const defaults: AgentTruncationSettings = {
+        defaultHead: 4000,
+        defaultTail: 4000,
+        bashHead: 2000,
+        bashTail: 6000,
+        neverTruncate: ['semantic_search'],
+    };
+
+    it('returns a clone of defaults when raw is missing', () => {
+        const merged = mergeTruncation(undefined, defaults);
+        expect(merged).toEqual(defaults);
+        expect(merged.neverTruncate).not.toBe(defaults.neverTruncate);
+    });
+
+    it('overrides only the specified fields', () => {
+        const merged = mergeTruncation({ defaultHead: 1000, bashTail: 9999 }, defaults);
+        expect(merged.defaultHead).toBe(1000);
+        expect(merged.defaultTail).toBe(defaults.defaultTail);
+        expect(merged.bashHead).toBe(defaults.bashHead);
+        expect(merged.bashTail).toBe(9999);
+    });
+
+    it('clamps negative values to 0 and rejects non-numeric values', () => {
+        const merged = mergeTruncation(
+            { defaultHead: -50, defaultTail: 'nope' as unknown as number },
+            defaults,
+        );
+        expect(merged.defaultHead).toBe(0);
+        expect(merged.defaultTail).toBe(defaults.defaultTail);
+    });
+
+    it('replaces neverTruncate when provided and filters non-strings', () => {
+        const merged = mergeTruncation(
+            { neverTruncate: ['recall', '', 42 as unknown as string, 'docs_search'] },
+            defaults,
+        );
+        expect(merged.neverTruncate).toEqual(['recall', 'docs_search']);
+    });
+
+    it('falls back to defaults when neverTruncate is omitted', () => {
+        const merged = mergeTruncation({ defaultHead: 100 }, defaults);
+        expect(merged.neverTruncate).toEqual(defaults.neverTruncate);
     });
 });

--- a/__tests__/AI/AIAgent/subAgents/singleFlight.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/singleFlight.test.ts
@@ -37,7 +37,8 @@ const investigatorRuntime: InvestigatorRuntime = {
     client: fakeClient,
     model: 'm',
     settings: {
-        enabled: true,
+        code: true,
+        web: false,
         maxEvidenceItems: 8,
         maxExcerptLines: 20,
         validateExcerpts: false,

--- a/__tests__/AI/AIAgent/subAgents/webResearchTools.test.ts
+++ b/__tests__/AI/AIAgent/subAgents/webResearchTools.test.ts
@@ -1,0 +1,283 @@
+import { createWebResearchTools } from '@/AI/AIAgent/shared/subAgents/webResearchTools';
+import {
+    fetchPageMarkdown,
+    searchPagesStructured,
+} from '@/AI/shared/utils/webTools';
+import { embedMany, embedOne } from '@/AI/AIAgent/shared/memory/embedder';
+import {
+    insertResearchChunks,
+    searchResearchChunks,
+} from '@/AI/AIAgent/shared/memory/researchChunks';
+import { chunkMarkdown } from '@/AI/AIAgent/shared/docs/chunker';
+import type { LocalTool } from '@/AI/AIAgent/shared/types/agentTypes';
+import type { WebInvestigatorSettings } from '@/AI/AIAgent/shared/subAgents/types';
+
+jest.mock('@/AI/shared/utils/webTools', () => ({
+    fetchPageMarkdown: jest.fn(),
+    searchPagesStructured: jest.fn(),
+}));
+jest.mock('@/AI/AIAgent/shared/memory/embedder', () => ({
+    embedMany: jest.fn(),
+    embedOne: jest.fn(),
+}));
+jest.mock('@/AI/AIAgent/shared/memory/researchChunks', () => ({
+    insertResearchChunks: jest.fn(),
+    searchResearchChunks: jest.fn(),
+}));
+jest.mock('@/AI/AIAgent/shared/docs/chunker', () => ({
+    chunkMarkdown: jest.fn(),
+}));
+
+const mockedFetch = jest.mocked(fetchPageMarkdown);
+const mockedSearchPages = jest.mocked(searchPagesStructured);
+const mockedEmbedMany = jest.mocked(embedMany);
+const mockedEmbedOne = jest.mocked(embedOne);
+const mockedInsert = jest.mocked(insertResearchChunks);
+const mockedSearchChunks = jest.mocked(searchResearchChunks);
+const mockedChunk = jest.mocked(chunkMarkdown);
+
+const SETTINGS: WebInvestigatorSettings = {
+    useInvestigatorRuntime: true,
+    maxSearches: 2,
+    maxScrapes: 2,
+    urlsPerScrape: 5,
+    maxToolCalls: 30,
+    maxEvidenceItems: 4,
+    maxExcerptLines: 20,
+    ttlMinutes: 60,
+    validateExcerpts: true,
+    toolWhitelist: [],
+};
+
+function findTool(tools: LocalTool[], name: string): LocalTool {
+    const t = tools.find((tool) => tool.name === name);
+    if (!t) throw new Error(`tool ${name} missing from factory`);
+
+    return t;
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('webResearchTools.web_search', () => {
+    it('delegates to searchPagesStructured and tracks quota', async () => {
+        mockedSearchPages.mockResolvedValueOnce({
+            results: [{ title: 'A', url: 'https://a', snippet: 'snip' }],
+        });
+
+        const factory = createWebResearchTools('rid', SETTINGS);
+        const tool = findTool(factory.tools, 'web_search');
+        const out = JSON.parse(await tool.handler({ query: 'foo', max_results: 3 }) as string);
+
+        expect(mockedSearchPages).toHaveBeenCalledWith('foo', 3);
+        expect(out.results).toHaveLength(1);
+        expect(out.quota.web_search.used).toBe(1);
+        expect(factory.stats().searches).toBe(1);
+    });
+
+    it('refuses once the per-investigation quota is exhausted', async () => {
+        mockedSearchPages.mockResolvedValue({ results: [] });
+
+        const factory = createWebResearchTools('rid', SETTINGS);
+        const tool = findTool(factory.tools, 'web_search');
+        await tool.handler({ query: 'q1' });
+        await tool.handler({ query: 'q2' });
+        const out = JSON.parse(await tool.handler({ query: 'q3' }) as string);
+
+        expect(out.error).toMatch(/web_search quota exhausted/);
+        expect(mockedSearchPages).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('webResearchTools.web_scrape_and_index', () => {
+    function setupSuccessfulScrape() {
+        mockedFetch.mockImplementation(async (url: string) => ({
+            page: {
+                url,
+                title: `T-${url}`,
+                body: `# ${url}\n\nbody for ${url}`,
+                contentType: 'text/markdown',
+                via: 'direct',
+                fetchedAt: 12_345,
+                status: 200,
+            },
+        }));
+        mockedChunk.mockImplementation((body: string) => [
+            { sectionPath: 'Intro', content: `${body} chunk1`, contentForEmbedding: '', tokenEstimate: 10 } as never,
+            { sectionPath: 'Details', content: `${body} chunk2`, contentForEmbedding: '', tokenEstimate: 10 } as never,
+        ]);
+        mockedEmbedMany.mockImplementation(async (texts: string[]) =>
+            texts.map(() => [0.1, 0.2, 0.3]),
+        );
+        mockedEmbedOne.mockResolvedValue([0.1, 0.2, 0.3]);
+        mockedInsert.mockResolvedValue(undefined);
+        mockedSearchChunks.mockResolvedValue([
+            {
+                url: 'https://a',
+                title: 'T-https://a',
+                sectionPath: 'Intro',
+                chunkIndex: 0,
+                content: 'hit content',
+                fetchedAt: 12_345,
+                score: 0.9,
+            },
+        ]);
+    }
+
+    it('fetches, chunks, embeds, indexes and runs per-query searches', async () => {
+        setupSuccessfulScrape();
+
+        const factory = createWebResearchTools('rid-xyz', SETTINGS);
+        const tool = findTool(factory.tools, 'web_scrape_and_index');
+        const raw = await tool.handler({
+            urls: ['https://a', 'https://b'],
+            queries: ['what is foo?', 'why is foo idempotent?'],
+        }) as string;
+        const out = JSON.parse(raw);
+
+        expect(out.scraped).toBe(2);
+        expect(out.failed).toEqual([]);
+        expect(out.chunks_indexed).toBe(4); // 2 urls × 2 chunks
+        expect(out.results).toHaveLength(2);
+        expect(out.results[0].query).toBe('what is foo?');
+        expect(out.results[0].hits[0].url).toBe('https://a');
+
+        expect(mockedFetch).toHaveBeenCalledTimes(2);
+        expect(mockedEmbedMany).toHaveBeenCalledTimes(1);
+        // breadcrumb prefix is reconstructed from sectionPath
+        const embeddedTexts = mockedEmbedMany.mock.calls[0]?.[0] as string[];
+        expect(embeddedTexts[0]).toMatch(/^# Intro\n\n/);
+        // every inserted row carries the researchId
+        const insertedRows = mockedInsert.mock.calls[0]?.[0] ?? [];
+        expect(insertedRows.every((r) => r.researchId === 'rid-xyz')).toBe(true);
+        expect(insertedRows[0]?.fetchedAt).toBe(12_345);
+
+        const stats = factory.stats();
+        expect(stats.scrapes).toBe(1);
+        expect(stats.pagesFetched).toBe(2);
+        expect(stats.pagesFailed).toBe(0);
+        expect(stats.chunksIndexed).toBe(4);
+    });
+
+    it('reports failures without aborting the rest of the batch', async () => {
+        mockedFetch.mockImplementation(async (url: string) => {
+            if (url === 'https://bad') return { error: 'HTTP 500' };
+
+            return {
+                page: {
+                    url,
+                    title: 't',
+                    body: 'body',
+                    contentType: 'text/markdown',
+                    via: 'direct',
+                    fetchedAt: 1,
+                    status: 200,
+                },
+            };
+        });
+        mockedChunk.mockReturnValue([
+            { sectionPath: '', content: 'c', contentForEmbedding: '', tokenEstimate: 1 } as never,
+        ]);
+        mockedEmbedMany.mockResolvedValue([[0, 0, 0]]);
+        mockedEmbedOne.mockResolvedValue([0, 0, 0]);
+        mockedSearchChunks.mockResolvedValue([]);
+
+        const factory = createWebResearchTools('rid', SETTINGS);
+        const tool = findTool(factory.tools, 'web_scrape_and_index');
+        const out = JSON.parse(await tool.handler({
+            urls: ['https://ok', 'https://bad'],
+            queries: ['q'],
+        }) as string);
+
+        expect(out.scraped).toBe(1);
+        expect(out.failed).toEqual([{ url: 'https://bad', error: 'HTTP 500' }]);
+        expect(out.chunks_indexed).toBe(1);
+        expect(factory.stats().pagesFailed).toBe(1);
+    });
+
+    it('truncates the URL list to settings.urlsPerScrape', async () => {
+        setupSuccessfulScrape();
+        const factory = createWebResearchTools('rid', { ...SETTINGS, urlsPerScrape: 2 });
+        const tool = findTool(factory.tools, 'web_scrape_and_index');
+        const urls = ['https://a', 'https://b', 'https://c', 'https://d'];
+
+        await tool.handler({ urls, queries: ['q'] });
+        expect(mockedFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('errors early when no URLs or queries are provided', async () => {
+        const factory = createWebResearchTools('rid', SETTINGS);
+        const tool = findTool(factory.tools, 'web_scrape_and_index');
+
+        const noUrls = JSON.parse(await tool.handler({ urls: [], queries: ['q'] }) as string);
+        expect(noUrls.error).toMatch(/No URLs/);
+
+        // Still consumes one quota slot — call again with valid urls but no queries.
+        const noQueries = JSON.parse(await tool.handler({ urls: ['https://a'], queries: [] }) as string);
+        expect(noQueries.error).toMatch(/No queries/);
+    });
+
+    it('refuses once the scrape quota is exhausted', async () => {
+        setupSuccessfulScrape();
+        const factory = createWebResearchTools('rid', { ...SETTINGS, maxScrapes: 1 });
+        const tool = findTool(factory.tools, 'web_scrape_and_index');
+
+        await tool.handler({ urls: ['https://a'], queries: ['q'] });
+        const out = JSON.parse(await tool.handler({ urls: ['https://b'], queries: ['q'] }) as string);
+        expect(out.error).toMatch(/quota exhausted/);
+    });
+});
+
+describe('webResearchTools.research_query', () => {
+    it('vector-searches scoped to the investigation researchId + ttl', async () => {
+        mockedEmbedOne.mockResolvedValue([0.1, 0.2, 0.3]);
+        mockedSearchChunks.mockResolvedValue([
+            {
+                url: 'https://a',
+                title: 'A',
+                sectionPath: 'Intro',
+                chunkIndex: 0,
+                content: 'snippet',
+                fetchedAt: 1,
+                score: 0.5,
+            },
+        ]);
+
+        const factory = createWebResearchTools('rid', SETTINGS);
+        const tool = findTool(factory.tools, 'research_query');
+        const out = JSON.parse(await tool.handler({ query: 'sub-q', k: 3 }) as string);
+
+        expect(mockedEmbedOne).toHaveBeenCalledWith('sub-q');
+        expect(mockedSearchChunks).toHaveBeenCalledWith(
+            expect.objectContaining({
+                researchId: 'rid',
+                k: 3,
+                ttlMs: SETTINGS.ttlMinutes * 60_000,
+            }),
+        );
+        expect(out.hits).toHaveLength(1);
+        expect(out.hits[0].score).toBe(0.5);
+    });
+
+    it('rejects an empty query', async () => {
+        const factory = createWebResearchTools('rid', SETTINGS);
+        const tool = findTool(factory.tools, 'research_query');
+        const out = JSON.parse(await tool.handler({ query: '' }) as string);
+        expect(out.error).toMatch(/Missing required argument/);
+        expect(mockedEmbedOne).not.toHaveBeenCalled();
+    });
+
+    it('caps k at maxEvidenceItems * 2', async () => {
+        mockedEmbedOne.mockResolvedValue([0]);
+        mockedSearchChunks.mockResolvedValue([]);
+
+        const factory = createWebResearchTools('rid', { ...SETTINGS, maxEvidenceItems: 3 });
+        const tool = findTool(factory.tools, 'research_query');
+        await tool.handler({ query: 'q', k: 999 });
+
+        expect(mockedSearchChunks).toHaveBeenCalledWith(
+            expect.objectContaining({ k: 6 }),
+        );
+    });
+});

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -18,7 +18,7 @@ kra ai agent
 |---|---|
 | [`providers.md`](./providers.md) | Provider architecture, Copilot/BYOK behavior, backend add/remove lifecycle, model catalog |
 | [`workflow-and-keymaps.md`](./workflow-and-keymaps.md) | Turn lifecycle, keymaps, tool approval UX, diff editor behavior, session diff history |
-| [`tools-and-mcp.md`](./tools-and-mcp.md) | File-context tools, bash/web tools, MCP configuration, sub-agent tools (`investigate`, `execute`) |
+| [`tools-and-mcp.md`](./tools-and-mcp.md) | File-context tools, bash/web tools, MCP configuration, sub-agent tools (`investigate`, `investigate_web`, `execute`) |
 | [`memory-and-indexing.md`](./memory-and-indexing.md) | `kra-memory` store, tools, picker UX, indexing behavior and settings |
 | [`copilot-operations.md`](./copilot-operations.md) | Copilot-only skills and quota monitoring |
 

--- a/docs/agent/tools-and-mcp.md
+++ b/docs/agent/tools-and-mcp.md
@@ -50,7 +50,7 @@ Because BYOK has no SDK tools, Kra injects these MCP servers for BYOK sessions:
 
 - Executes command in session working dir
 - 120s timeout, 10MB stdout/stderr cap
-- Long output is head/tail truncated
+- Long output is head/tail truncated (caps configurable per profile in `[ai.agent.truncation]` / `[ai.agent.subAgentTruncation]`)
 - Emits git status before/after for history tracking
 
 ### `kra-web` (`web_fetch`, `web_search`)
@@ -89,14 +89,15 @@ Provider behavior differences:
 ## Sub-agent tools
 
 Opt-in helpers that let a smaller, cheaper model do bulk work while the
-orchestrator focuses on reasoning. Toggle in `settings.toml` (`[ai.agent.executor]`,
-`[ai.agent.investigator]`); when enabled, the start flow prompts for a separate
-provider + model right after the orchestrator picker. Sub-agents work for both
-BYOK and Copilot orchestrators — mix and match freely.
+orchestrator focuses on reasoning. Toggle in `settings.toml`
+(`[ai.agent.executor]`, `[ai.agent.investigator]`, `[ai.agent.investigatorWeb]`);
+when enabled, the start flow prompts for a separate provider + model right after
+the orchestrator picker. Sub-agents work for both BYOK and Copilot
+orchestrators — mix and match freely.
 
 ### `investigate` (investigator sub-agent)
 
-Registered on the orchestrator only when `[ai.agent.investigator].enabled = true`.
+Registered on the orchestrator only when `[ai.agent.investigator].code = true`.
 Delegates a research question to a smaller model that returns a curated,
 evidence-backed synthesis instead of raw file dumps.
 
@@ -186,4 +187,86 @@ When the orchestrator should skip it:
 
 - One-line trivial edits.
 - Tasks that need orchestrator-grade reasoning at every step.
+
+### `investigate_web` (web research sub-agent)
+
+Registered on the orchestrator only when `[ai.agent.investigator].web = true`.
+The `code` and `web` switches are independent; if both are on, the web
+investigator piggy-backs on the code investigator's runtime by default
+(`useInvestigatorRuntime = true` under `[ai.agent.investigatorWeb]`). Delegates a research
+question whose answer lives **outside** this repo (library/SDK behaviour, vendor
+docs, RFCs, current ecosystem state) to a sub-agent that searches, scrapes, and
+returns curated `{summary, evidence, confidence}` excerpts.
+
+| Field | Purpose |
+|---|---|
+| `questions` | Array of related sub-questions for this investigation. **One call per scope** — if multiple questions share the same library, vendor, or docs source, list them ALL in this array so the sub-agent answers them from one round of fetches. Split into separate calls only when topics are genuinely unrelated. |
+| `hint` | Optional steering shared by all questions: known canonical URLs, version, prior findings, user context. |
+
+Returns:
+
+```json
+{
+  "summary": "…",
+  "evidence": [
+    { "url": "https://…", "title": "…", "section": "…", "excerpt": "…", "why_relevant": "…" }
+  ],
+  "confidence": "high|medium|low",
+  "suggested_next": "…",
+  "partial": false,
+  "pages_fetched": 4,
+  "pages_failed": 0,
+  "chunks_indexed": 37,
+  "searches": 2,
+  "scrapes": 1
+}
+```
+
+Sub-agent toolset (4 tools):
+
+- `web_search(query, max_results?)` — pure search; returns `[{title, url, snippet}]`.
+  Quota: `maxSearches`.
+- `web_scrape_and_index({urls, queries, k?})` — fetches the URLs in parallel,
+  chunks them with the markdown chunker, embeds with the local BGE model,
+  inserts rows into a per-investigation LanceDB table, then runs vector search
+  per query and returns merged hits. Quota: `maxScrapes`; URLs capped at
+  `urlsPerScrape`.
+- `research_query({query, k?})` — vector search over the chunks already
+  indexed during this investigation (no new fetching). For drilling into pages
+  the agent already scraped.
+- `submit_result(…)` — finalize.
+
+Behavior notes:
+
+- Runtime sharing: when `useInvestigatorRuntime = true` (default) and the
+  investigator is enabled, the web investigator reuses the code investigator's
+  resolved provider + model. Set it to `false` to be prompted for a separate
+  model on startup.
+- The orchestrator never sees raw page bodies — only retrieved excerpts. URL
+  filtering is coarse (titles / snippets); fine relevance is vector retrieval.
+- Each call mints a fresh `researchId` (UUID); chunks are tagged with it so
+  concurrent investigations never cross-contaminate.
+- TTL eviction (default 60 min, `ttlMinutes`) plus `SIGINT`/`SIGTERM`/`exit`
+  cleanup hooks ensure the LanceDB table doesn't grow unbounded.
+- When `validateExcerpts = true` (default) every excerpt is checked against the
+  indexed chunks before being returned; unverified snippets are flagged in
+  `why_relevant`.
+- Only one `investigate_web` runs at a time; concurrent calls are rejected.
+- `maxEvidenceItems`, `maxExcerptLines`, and `maxToolCalls` cap the size of
+  the returned envelope and the sub-agent loop.
+- Sub-agent output streams into the chat file under a 🌐 `[INVESTIGATOR-WEB]`
+  header.
+
+When the orchestrator should call it:
+
+- Library / SDK behaviour the user is asking about that isn't documented in
+  this repo's `docs_search` corpus.
+- Vendor / RFC / standards questions where authoritative pages live online.
+- Current ecosystem state (API changes, deprecations, recent releases).
+
+When the orchestrator should skip it:
+
+- Anything answerable from this repo's code or its indexed `docs_search`
+  corpus — use `investigate` instead.
+- Single-fact lookups where one `web_fetch` would do.
 

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -50,13 +50,62 @@ maxToolCalls = 60             # hard cap on tool calls before the executor is fo
 #                  "search", "lsp_query", "bash"]
 
 [ai.agent.investigator]
-enabled = false               # master switch; off by default
+# Two independent switches — either or both may be enabled. The runtime picker
+# (BYOK) prompts once and the same provider+model is reused for both.
+code = false                  # `investigate` sub-agent for repo code questions
+web  = false                  # `investigate_web` sub-agent for live web research
 maxEvidenceItems = 8          # cap on evidence array returned to orchestrator
 maxExcerptLines = 20          # cap on lines per excerpt
 validateExcerpts = true       # reject hallucinated snippets at the tool layer
-# Restrict the toolset the investigator is allowed to call (defaults shown):
+# Restrict the toolset the code investigator is allowed to call (defaults shown):
 # toolWhitelist = ["semantic_search", "search", "get_outline", "read_lines",
 #                  "lsp_query", "docs_search", "recall"]
+
+# Tool-result truncation — caps on the number of characters of a tool's output
+# the model gets to see. Anything longer than head + tail gets the middle
+# replaced with an omission marker. Set head/tail to 0 to disable that bucket.
+#
+# Two profiles. The orchestrator profile applies to tool calls the orchestrator
+# itself makes; the sub-agent profile applies to tool calls inside an
+# `investigate` / `investigate_web` / `execute` sub-agent. Sub-agents typically
+# need to digest larger payloads, so their defaults are looser.
+#
+# Tools whose name contains any substring in `neverTruncate` bypass truncation
+# entirely. Defaults cover the structured discovery tools whose middle slice
+# is just as load-bearing as the head/tail — truncating them forces the model
+# to fall back to bash to recover the omitted hits.
+[ai.agent.truncation]
+defaultHead = 4000
+defaultTail = 4000
+bashHead    = 2000
+bashTail    = 6000
+neverTruncate = ["semantic_search", "docs_search", "recall", "get_outline"]
+
+[ai.agent.subAgentTruncation]
+defaultHead = 8000
+defaultTail = 8000
+bashHead    = 4000
+bashTail    = 12000
+neverTruncate = ["semantic_search", "docs_search", "recall", "get_outline"]
+
+# Web Investigator – tuning knobs for `investigate_web`. Turn it on/off via
+# `[ai.agent.investigator].web` above. The sub-agent searches the web, scrapes
+# selected URLs server-side, indexes them into a TTL-evicted vector table, and
+# returns a curated `{summary, evidence, confidence}` synthesis. The LLM never
+# sees raw page bodies — only retrieved excerpts.
+[ai.agent.investigatorWeb]
+useInvestigatorRuntime = true # if true reuse the code investigator's provider+model;
+                              # if false you'll be prompted to pick a separate one on startup
+maxSearches = 5               # hard cap on web_search calls per investigation
+maxScrapes = 5                # hard cap on web_scrape_and_index calls per investigation
+urlsPerScrape = 30            # per-call cap on URLs in one scrape batch
+maxToolCalls = 30             # hard cap on total tool calls before the agent is forced to submit
+maxEvidenceItems = 8          # cap on evidence array returned to orchestrator
+maxExcerptLines = 20          # cap on lines per excerpt
+ttlMinutes = 60               # how long indexed page chunks survive before TTL eviction
+validateExcerpts = true       # reject hallucinated snippets at the tool layer
+# Restrict the toolset the web investigator is allowed to call (defaults shown):
+# toolWhitelist = ["web_search", "web_scrape_and_index", "research_query"]
 
 # ─── Quota dashboard (`kra ai quota-agent`) ──────────────────────────────────
 # Per-provider toggles for which sections the quota dashboard renders, and

--- a/src/AI/AIAgent/commands/startAgentChat.ts
+++ b/src/AI/AIAgent/commands/startAgentChat.ts
@@ -23,6 +23,7 @@ import type { AgentClient } from '@/AI/AIAgent/shared/types/agentTypes';
 import type {
     ExecutorRuntime,
     InvestigatorRuntime,
+    WebInvestigatorRuntime,
 } from '@/AI/AIAgent/shared/subAgents/types';
 
 export async function startAgentChat(): Promise<void> {
@@ -31,12 +32,13 @@ export async function startAgentChat(): Promise<void> {
     let orchestrator: Awaited<ReturnType<typeof pickAgentRuntime>> | null = null;
     let executor: ExecutorRuntime | undefined;
     let investigator: InvestigatorRuntime | undefined;
+    let investigatorWeb: WebInvestigatorRuntime | undefined;
 
     try {
         orchestrator = await pickAgentRuntime('orchestrator');
         allClients.push(orchestrator.client);
 
-        if (subAgentSettings.investigator.enabled) {
+        if (subAgentSettings.investigator.code) {
             const picked = await pickAgentRuntime('investigator');
             allClients.push(picked.client);
             investigator = {
@@ -45,6 +47,30 @@ export async function startAgentChat(): Promise<void> {
                 ...(picked.contextWindow !== undefined ? { contextWindow: picked.contextWindow } : {}),
                 settings: subAgentSettings.investigator,
             };
+        }
+
+        if (subAgentSettings.investigator.web) {
+            // Web investigator's runtime usually piggy-backs on the code
+            // investigator (same cheap model). When `useInvestigatorRuntime`
+            // is off OR the code investigator is somehow absent, fall through
+            // to a dedicated picker so the user can select a different model.
+            if (subAgentSettings.investigatorWeb.useInvestigatorRuntime && investigator) {
+                investigatorWeb = {
+                    client: investigator.client,
+                    model: investigator.model,
+                    ...(investigator.contextWindow !== undefined ? { contextWindow: investigator.contextWindow } : {}),
+                    settings: subAgentSettings.investigatorWeb,
+                };
+            } else {
+                const picked = await pickAgentRuntime('investigator');
+                allClients.push(picked.client);
+                investigatorWeb = {
+                    client: picked.client,
+                    model: picked.model,
+                    ...(picked.contextWindow !== undefined ? { contextWindow: picked.contextWindow } : {}),
+                    settings: subAgentSettings.investigatorWeb,
+                };
+            }
         }
 
         if (subAgentSettings.executor.enabled) {
@@ -84,6 +110,9 @@ export async function startAgentChat(): Promise<void> {
                 : {}),
             ...(executor ? { executor } : {}),
             ...(investigator ? { investigator } : {}),
+            ...(investigatorWeb ? { investigatorWeb } : {}),
+            truncation: subAgentSettings.truncation,
+            subAgentTruncation: subAgentSettings.subAgentTruncation,
         });
     } catch (error) {
         for (const c of allClients) {

--- a/src/AI/AIAgent/providers/claude/claudeClient.ts
+++ b/src/AI/AIAgent/providers/claude/claudeClient.ts
@@ -44,6 +44,7 @@ import { TURN_REMINDER } from '@/AI/AIAgent/shared/main/turnReminder';
 import { createExecutableToolBridge, disconnectPool } from '@/AI/AIAgent/mcp/executableToolBridge';
 import { buildMcpClientPool, type McpClientPool } from '@/AI/AIAgent/providers/byok/mcpClientPool';
 import { ClaudeSessionBridge } from '@/AI/AIAgent/providers/claude/claudeSessionBridge';
+import { matchesSubAgentWhitelist } from '@/AI/AIAgent/shared/subAgents/whitelist';
 
 export interface ClaudeModelInfo {
     id: string;
@@ -97,6 +98,30 @@ export class ClaudeClient implements AgentClient {
 
         const permissionMode = decidePermissionMode(options);
 
+        // For sub-agents on Claude, the SDK's `allowedTools` is just an
+        // auto-approve permission list — it does NOT hide non-listed tools
+        // from the model's context. To actually scope a sub-agent down to
+        // its whitelist we have to enumerate every MCP tool name the SDK
+        // would expose (`mcp__<server>__<tool>`) and add the non-whitelisted
+        // ones to `disallowedTools`, which IS a context-level filter per the
+        // SDK contract ("removed from the model's context and cannot be used").
+        // Built-in tools are already disabled below via `tools: []`. Local
+        // tools live under the synthetic `kra-local` server and are inherently
+        // scoped to whatever the sub-agent factory passed in, so we never
+        // disallow them.
+        let subAgentExtraDisallowed: string[] = [];
+        if (isSubAgent && options.allowedTools && options.allowedTools.length > 0) {
+            subAgentExtraDisallowed = await computeClaudeSubAgentDisallowedTools(
+                options.mcpServers,
+                options.workingDirectory,
+                new Set(options.allowedTools),
+            );
+        }
+        const finalDisallowed = [
+            ...(options.excludedTools ?? []),
+            ...subAgentExtraDisallowed,
+        ];
+
         const sdkOptions: ClaudeSdkOptions = {
             cwd: options.workingDirectory,
             model: options.model,
@@ -108,8 +133,8 @@ export class ClaudeClient implements AgentClient {
             tools: [],
             permissionMode,
             ...(this.executablePath ? { pathToClaudeCodeExecutable: this.executablePath } : {}),
-            ...(options.excludedTools && options.excludedTools.length > 0
-                ? { disallowedTools: options.excludedTools }
+            ...(finalDisallowed.length > 0
+                ? { disallowedTools: finalDisallowed }
                 : {}),
             ...(options.allowedTools && options.allowedTools.length > 0
                 ? { allowedTools: options.allowedTools }
@@ -380,6 +405,52 @@ function buildSystemPrompt(
 
     return { systemPrompt: message.content };
 }
+
+/**
+ * Probes the configured MCP servers and returns the list of fully-qualified
+ * Claude tool names (`mcp__<server>__<tool>`) that are NOT in the sub-agent's
+ * whitelist. Pass the result as part of `disallowedTools` so the model never
+ * sees those tools in its inventory.
+ *
+ * Mirrors the pattern used by `decideCopilotExcludedTools` so the two
+ * providers offer the same scoping guarantee for sub-agents. The probe spins
+ * each MCP server up briefly and tears it down again — the actual session
+ * spawns its own pool, so this overhead is per-sub-agent-invocation only.
+ */
+async function computeClaudeSubAgentDisallowedTools(
+    servers: Record<string, MCPServerConfig>,
+    workingDirectory: string,
+    allowedSet: Set<string>,
+): Promise<string[]> {
+    let probePool: McpClientPool | undefined;
+    const disallowed: string[] = [];
+
+    try {
+        probePool = await buildMcpClientPool({
+            servers,
+            workingDirectory,
+        });
+
+        for (const tool of probePool.tools.values()) {
+            const fqName = `mcp__${tool.server}__${tool.originalName}`;
+            if (!matchesSubAgentWhitelist(tool.namespacedName, allowedSet)) {
+                disallowed.push(fqName);
+            }
+        }
+    } catch {
+        // If we can't enumerate, return what we have so far. The runtime
+        // pre-tool-use hook still gates execution on the whitelist, so
+        // failures here only affect what the model SEES — not what it can
+        // actually run.
+    } finally {
+        if (probePool) {
+            await probePool.disconnect();
+        }
+    }
+
+    return disallowed;
+}
+
 
 function buildLocalToolsMcpServer(
     localTools: LocalTool[] | undefined

--- a/src/AI/AIAgent/providers/copilot/copilotClient.ts
+++ b/src/AI/AIAgent/providers/copilot/copilotClient.ts
@@ -97,12 +97,26 @@ export class CopilotClientWrapper implements AgentClient {
 
         const onPermissionRequest = (): { kind: 'approved' } => ({ kind: 'approved' as const });
 
-        // When the caller asked for a positive tool inventory filter, translate
-        // it into Copilot's `excludedTools` knob. Copilot accepts bare MCP tool
-        // names there, so we enumerate the configured MCP servers, drop the
-        // ones our whitelist matches, and merge the rest with whatever
-        // `excludedTools` the caller already supplied.
-        const mergedExcluded = await decideCopilotExcludedTools(options);
+        // For sub-agents, force a strict positive whitelist via the SDK's
+        // `availableTools` knob. Per the SDK docs it "takes precedence over
+        // excludedTools" and means ONLY listed tools are exposed to the
+        // model — hiding ALL built-in Copilot tools (read_bash, write_bash,
+        // stop_bash, list_bash, and any future additions) without us having
+        // to enumerate every name we want to block. Local tools must be
+        // listed by name to remain callable.
+        let availableToolsForSdk: string[] | undefined;
+        let mergedExcluded: string[] = options.excludedTools ?? [];
+
+        if (isSubAgent && options.allowedTools && options.allowedTools.length > 0) {
+            availableToolsForSdk = Array.from(new Set([
+                ...options.allowedTools,
+                ...(options.localTools?.map((t) => t.name) ?? []),
+            ]));
+        } else {
+            // Orchestrator path: keep the existing enumerate-and-exclude
+            // behaviour so any user-supplied excludes are honoured.
+            mergedExcluded = await decideCopilotExcludedTools(options);
+        }
 
         const sdkSession = await this.inner.createSession({
             clientName: 'copilot-cli',
@@ -113,7 +127,8 @@ export class CopilotClientWrapper implements AgentClient {
             enableConfigDiscovery: !isSubAgent,
             ...(isSubAgent ? {} : { skillDirectories: [skillsDir] }),
             mcpServers: options.mcpServers,
-            ...(mergedExcluded.length > 0 ? { excludedTools: mergedExcluded } : {}),
+            ...(availableToolsForSdk ? { availableTools: availableToolsForSdk } : {}),
+            ...(mergedExcluded.length > 0 && !availableToolsForSdk ? { excludedTools: mergedExcluded } : {}),
             ...(options.localTools && options.localTools.length > 0 ? { tools: options.localTools } : {}),
             onPermissionRequest,
             infiniteSessions: {

--- a/src/AI/AIAgent/shared/main/agentConversation.ts
+++ b/src/AI/AIAgent/shared/main/agentConversation.ts
@@ -14,7 +14,28 @@ import type {
     LocalTool,
 } from '@/AI/AIAgent/shared/types/agentTypes';
 import { createInvestigateTool } from '@/AI/AIAgent/shared/subAgents/investigateTool';
+import { createInvestigateWebTool } from '@/AI/AIAgent/shared/subAgents/investigateWebTool';
 import { createExecuteTool } from '@/AI/AIAgent/shared/subAgents/executeTool';
+import { deleteByResearchIds } from '@/AI/AIAgent/shared/memory/researchChunks';
+import type { AgentTruncationSettings } from '@/AI/AIAgent/shared/subAgents/types';
+
+// Fallback truncation profiles used when callers don't pass settings (e.g. tests).
+// The real defaults live in `subAgents/settings.ts`; these mirror them so the
+// behaviour is identical when settings.toml is absent.
+const ORCHESTRATOR_TRUNCATION_FALLBACK: AgentTruncationSettings = {
+    defaultHead: 4000,
+    defaultTail: 4000,
+    bashHead: 2000,
+    bashTail: 6000,
+    neverTruncate: ['semantic_search', 'docs_search', 'recall', 'get_outline'],
+};
+const SUB_AGENT_TRUNCATION_FALLBACK: AgentTruncationSettings = {
+    defaultHead: 8000,
+    defaultTail: 8000,
+    bashHead: 4000,
+    bashTail: 12000,
+    neverTruncate: ['semantic_search', 'docs_search', 'recall', 'get_outline'],
+};
 import { createOrchestratorTranscript } from '@/AI/AIAgent/shared/main/orchestratorTranscript';
 
 import { handleAgentUserInput, handlePreToolUse } from '@/AI/AIAgent/shared/utils/agentToolHook';
@@ -176,10 +197,30 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
         }
     };
 
+    // Truncation caps for tool results. Two profiles — the orchestrator's own
+    // tool results vs. those handed back to a sub-agent (investigator/executor/
+    // investigator_web). Sub-agents typically need to digest larger payloads,
+    // so the sub-agent profile defaults are looser. Both come from settings.toml.
+    const orchestratorTruncation = options.truncation ?? ORCHESTRATOR_TRUNCATION_FALLBACK;
+    const subAgentTruncation = options.subAgentTruncation ?? SUB_AGENT_TRUNCATION_FALLBACK;
+
     const orchestratorOnPostToolUse = async (input: AgentPostToolUseHookInput): Promise<AgentPostToolUseHookOutput> => {
         const isBashLike = ['bash', 'shell', 'execute', 'run_terminal', 'computer'].some(
             (fragment) => input.toolName.toLowerCase().includes(fragment)
         );
+
+        // Sub-agents reach this hook via `bridge.parentOnPostToolUse`, which
+        // tags the input with `agentLabel`. Branch on that to apply the right
+        // profile so each context can have its own caps.
+        const profile = input.agentLabel ? subAgentTruncation : orchestratorTruncation;
+
+        // Structured discovery tools return information-dense JSON whose
+        // middle slice is just as load-bearing as the head/tail. Truncating
+        // it forces the model to fall back to bash to recover the omitted
+        // hits, which defeats the point of having those tools.
+        if (profile.neverTruncate.some((name: string) => input.toolName.toLowerCase().includes(name))) {
+            return {};
+        }
 
         if (isBashLike && stateRef.current?.pendingBashSnapshot) {
             const snapshot = stateRef.current.pendingBashSnapshot;
@@ -188,8 +229,9 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
             await stateRef.current.history.bashSnapshotAfter(snapshot).catch(() => { /* non-fatal */ });
         }
 
-        const HEAD_CHARS = isBashLike ? 2000 : 4000;
-        const TAIL_CHARS = isBashLike ? 6000 : 4000;
+        const HEAD_CHARS = isBashLike ? profile.bashHead : profile.defaultHead;
+        const TAIL_CHARS = isBashLike ? profile.bashTail : profile.defaultTail;
+        if (HEAD_CHARS === 0 && TAIL_CHARS === 0) return {};
         const text = input.toolResult.textResultForLlm;
         if (text.length <= HEAD_CHARS + TAIL_CHARS) return {};
         const omitted = text.length - HEAD_CHARS - TAIL_CHARS;
@@ -227,6 +269,49 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
                 parentOnPostToolUse: orchestratorOnPostToolUse,
             },
         }));
+    }
+
+    // Track in-flight `investigate_web` research_ids so SIGINT/exit can purge
+    // their rows from the shared LanceDB table even when TTL hasn't kicked in.
+    const activeResearchIds = new Set<string>();
+
+    if (options.investigatorWeb) {
+        orchestratorLocalTools.push(createInvestigateWebTool({
+            runtime: options.investigatorWeb,
+            mcpServers: mergedMcpServers,
+            workingDirectory: cwd,
+            chatBridge: {
+                getParentState: () => {
+                    if (!stateRef.current) {
+                        throw new Error('Web investigator invoked before orchestrator state was ready');
+                    }
+
+                    return stateRef.current;
+                },
+                agentLabel: 'INVESTIGATOR-WEB',
+                headerEmoji: '🌐',
+                parentOnPreToolUse: orchestratorOnPreToolUse,
+                parentOnPostToolUse: orchestratorOnPostToolUse,
+            },
+            onResearchActive: (researchId, active) => {
+                if (active) activeResearchIds.add(researchId);
+                else activeResearchIds.delete(researchId);
+            },
+        }));
+
+        // Best-effort cleanup on shutdown. SIGINT fires for Ctrl-C; `exit`
+        // covers normal termination. SIGKILL leaves rows for the next
+        // `investigate_web` start (and ultimately the TTL purge) to clean up.
+        const purgeActive = (): void => {
+            if (activeResearchIds.size === 0) return;
+            const ids = Array.from(activeResearchIds);
+            activeResearchIds.clear();
+            // Fire-and-forget; we can't reliably await on `exit`.
+            void deleteByResearchIds(ids).catch(() => undefined);
+        };
+        process.once('SIGINT', purgeActive);
+        process.once('SIGTERM', purgeActive);
+        process.once('exit', purgeActive);
     }
 
     if (options.executor) {
@@ -275,6 +360,7 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
             content: buildOrchestratorSystemMessage({
                 selectedRepos,
                 investigateEnabled: !!options.investigator,
+                investigateWebEnabled: !!options.investigatorWeb,
                 executeEnabled: !!options.executor,
                 isCopilot: options.provider === 'copilot',
             }),
@@ -414,6 +500,7 @@ export async function converseAgent(options: AgentConversationOptions): Promise<
 
 interface OrchestratorSystemMessageOpts {
     investigateEnabled: boolean;
+    investigateWebEnabled?: boolean;
     executeEnabled: boolean;
     isCopilot?: boolean;
     selectedRepos?: { root: string; alias: string; repoKey: string }[];
@@ -492,6 +579,13 @@ function buildDelegationBlock(opts: OrchestratorSystemMessageOpts): string {
         lines.push('- `investigate` — LOCATION/FLOW questions only ("where is X?", "how does Y flow?"). NOT for diagnosis, root-cause, bug-hunting, or design judgement — those are YOUR job. Use it to gather information about how a system works; reason about the issue yourself. Pass known context via `hint`.');
     }
 
+    if (opts.investigateWebEnabled === true) {
+        lines.push('- `investigate_web` — web research. For questions whose answer lives outside this repo: library/SDK behaviour, current ecosystem state, vendor docs, RFCs, recent developments. Sub-agent searches, scrapes authoritative pages, and returns curated `{summary, evidence, confidence}` excerpts. NOT for repository code questions — use `investigate` for those. Pass known steering (canonical URLs, version, user context) via `hint`.');
+        lines.push('  - **The `questions` parameter is an array — use it.** List ALL related sub-questions in the same `questions[]` on ONE call. "Related" = same library, vendor, docs source, or topic. The sub-agent answers them all from one round of fetches.');
+        lines.push('  - **Before calling, check yourself:** "Does this call\'s scope overlap with one I already made (or am about to make) this turn?" If yes → STOP, add the new questions to the existing call\'s array (or merge before issuing). Splitting wastes a full search + fetch + index + synthesis cycle and fragments context.');
+        lines.push('  - Separate calls are ONLY appropriate when topics are genuinely unrelated (different library, different vendor, no shared docs source). When in doubt, bundle.');
+    }
+
     if (opts.executeEnabled) {
         const transcriptNote = opts.investigateEnabled
             ? 'a transcript of your prior `investigate` calls, file reads, and reasoning since the last execute'
@@ -506,12 +600,12 @@ function buildDelegationBlock(opts: OrchestratorSystemMessageOpts): string {
     lines.push('');
     lines.push('Do it yourself only for: a single trivial edit, or work needing orchestrator-grade reasoning at every step.');
 
-    if (opts.investigateEnabled && opts.executeEnabled) {
-        lines.push('Only ONE investigate and ONE execute can run at a time.');
-    } else if (opts.investigateEnabled) {
-        lines.push('Only ONE investigate can run at a time.');
-    } else {
-        lines.push('Only ONE execute can run at a time.');
+    const concurrencyParts: string[] = [];
+    if (opts.investigateEnabled) concurrencyParts.push('ONE investigate');
+    if (opts.investigateWebEnabled === true) concurrencyParts.push('ONE investigate_web');
+    if (opts.executeEnabled) concurrencyParts.push('ONE execute');
+    if (concurrencyParts.length > 0) {
+        lines.push(`Only ${concurrencyParts.join(' and ')} can run at a time.`);
     }
 
     lines.push('</delegation>');
@@ -599,6 +693,22 @@ ${discoveryRule}
 - \`edit_memory\` to refine in place (re-embeds on title/body change) instead of creating duplicates.
 </long_term_memory>`;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/src/AI/AIAgent/shared/memory/db.ts
+++ b/src/AI/AIAgent/shared/memory/db.ts
@@ -16,7 +16,7 @@
 import path from 'path';
 import { connect, type Connection, type Table } from '@lancedb/lancedb';
 import { ensureContentFtsIndex } from './hybridSearch';
-import type { CodeChunkRow, MemoryRow } from './types';
+import type { CodeChunkRow, MemoryRow, ResearchChunkRow } from './types';
 import type { DocChunkRow } from '../docs/types';
 import { _resetRepoStorageCacheForTest, resolveRepoStorage, repoStorageDirForKey } from './repoKey';
 import { kraDocsLanceRoot, kraDocsRoot } from '@/filePaths';
@@ -31,6 +31,7 @@ let docsDbCache: Connection | null = null;
 const memoryFindingsTableCache: Map<string, Table> = new Map();
 const memoryRevisitsTableCache: Map<string, Table> = new Map();
 const codeChunksTableCache: Map<string, Table> = new Map();
+const researchChunksTableCache: Map<string, Table> = new Map();
 const codeFtsEnsuredKeys: Set<string> = new Set();
 const docFtsEnsuredKeys: Set<string> = new Set();
 const DOC_FTS_KEY = 'doc_chunks';
@@ -39,6 +40,7 @@ const legacyDropAttemptedKeys: Set<string> = new Set();
 
 const CODE_CHUNKS_TABLE = 'code_chunks';
 const DOC_CHUNKS_TABLE = 'doc_chunks';
+const RESEARCH_CHUNKS_TABLE = 'research_chunks';
 const LEGACY_MEMORY_TABLE = 'memory';
 
 async function memoryRoot(repoKey?: string): Promise<string> {
@@ -172,6 +174,7 @@ export function _resetCachesForTest(): void {
     memoryFindingsTableCache.clear();
     memoryRevisitsTableCache.clear();
     codeChunksTableCache.clear();
+    researchChunksTableCache.clear();
     codeFtsEnsuredKeys.clear();
     docFtsEnsuredKeys.clear();
     docChunksTableCache = null;
@@ -266,6 +269,60 @@ export async function countCodeChunks(repoKey?: string): Promise<number> {
     } catch {
         return 0;
     }
+}
+
+export interface GetResearchChunksTableResult {
+    table: Table | null;
+    justCreated: boolean;
+}
+
+/**
+ * Returns the research_chunks table. Pass a seed row when about to write so the
+ * table can be created on first use; pass `null` for read-only callers and
+ * handle `table === null`. Per-repo, mirroring `getCodeChunksTable`.
+ */
+export async function getResearchChunksTable(
+    seedRow: ResearchChunkRow | null,
+    repoKey?: string,
+): Promise<GetResearchChunksTableResult> {
+    const key = await resolveRepoKey(repoKey);
+    const cached = researchChunksTableCache.get(key);
+    if (cached) {
+        return { table: cached, justCreated: false };
+    }
+
+    const next = mutex.then(async (): Promise<GetResearchChunksTableResult> => {
+        const cachedInner = researchChunksTableCache.get(key);
+        if (cachedInner) {
+            return { table: cachedInner, justCreated: false };
+        }
+
+        const db = await getDb(key);
+        const tableNames = await db.tableNames();
+
+        if (tableNames.includes(RESEARCH_CHUNKS_TABLE)) {
+            const t = await db.openTable(RESEARCH_CHUNKS_TABLE);
+            researchChunksTableCache.set(key, t);
+
+            return { table: t, justCreated: false };
+        }
+
+        if (!seedRow) {
+            return { table: null, justCreated: false };
+        }
+
+        const t = await db.createTable(
+            RESEARCH_CHUNKS_TABLE,
+            [seedRow as unknown as Record<string, unknown>],
+        );
+        researchChunksTableCache.set(key, t);
+
+        return { table: t, justCreated: true };
+    });
+
+    mutex = next.catch(() => undefined);
+
+    return next;
 }
 
 export interface GetDocChunksTableResult {

--- a/src/AI/AIAgent/shared/memory/researchChunks.ts
+++ b/src/AI/AIAgent/shared/memory/researchChunks.ts
@@ -1,0 +1,150 @@
+/**
+ * Helpers for the `research_chunks` LanceDB table — the per-investigation
+ * vector store used by the `investigate_web` sub-agent.
+ *
+ * Lifecycle:
+ *   1. `investigate_web` mints a fresh `researchId` (UUID) and, on its first
+ *      `web_scrape_and_index` call, inserts chunks tagged with that id.
+ *   2. `research_query` and the post-scrape semantic search filter by
+ *      `researchId` and a TTL window (default 60 min) so concurrent
+ *      investigations never cross-contaminate and stale rows are ignored.
+ *   3. Cleanup is hybrid: lazy TTL purge on every new investigation start,
+ *      explicit delete-by-researchId on SIGINT/exit, and an upper-bound TTL
+ *      filter on every query as defence-in-depth.
+ */
+
+import { getResearchChunksTable } from './db';
+import type { ResearchChunkRow } from './types';
+
+export interface ResearchHit {
+    url: string;
+    title: string;
+    sectionPath: string;
+    chunkIndex: number;
+    content: string;
+    score: number;
+    fetchedAt: number;
+}
+
+function escapeSqlLiteral(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
+/**
+ * Insert a batch of chunks into the research_chunks table. Creates the table
+ * on first use (using the first row as the seed schema). No-op for empty
+ * batches. Errors propagate so callers can surface them.
+ */
+export async function insertResearchChunks(
+    rows: ResearchChunkRow[],
+    repoKey?: string,
+): Promise<void> {
+    if (rows.length === 0) return;
+
+    const { table } = await getResearchChunksTable(rows[0], repoKey);
+    if (!table) {
+        throw new Error('research_chunks table unavailable after seed insert');
+    }
+
+    if (rows.length === 1) {
+        return;
+    }
+
+    await table.add(rows.slice(1) as unknown as Record<string, unknown>[]);
+}
+
+export interface SearchResearchChunksInput {
+    researchId: string;
+    vector: number[];
+    k?: number;
+    ttlMs?: number;
+    repoKey?: string;
+}
+
+/**
+ * Vector search scoped to a single `researchId`, with a TTL filter.
+ *
+ * `ttlMs` is applied as `fetchedAt > now() - ttlMs`. When the table doesn't
+ * exist yet (e.g. first-ever query for a research id), returns an empty
+ * array rather than throwing.
+ */
+export async function searchResearchChunks(
+    input: SearchResearchChunksInput,
+): Promise<ResearchHit[]> {
+    const { researchId, vector, k = 8, ttlMs, repoKey } = input;
+    const { table } = await getResearchChunksTable(null, repoKey);
+    if (!table) return [];
+
+    const cutoff = ttlMs !== undefined ? Date.now() - ttlMs : 0;
+    const filter = `researchId = '${escapeSqlLiteral(researchId)}'`
+        + (cutoff > 0 ? ` AND fetchedAt > ${cutoff}` : '');
+
+    const fetchK = Math.min(Math.max(k * 4, 20), 200);
+
+    let raw: Record<string, unknown>[];
+    try {
+        raw = await table.search(vector).where(filter).limit(fetchK).toArray();
+    } catch {
+        return [];
+    }
+
+    return raw
+        .map((row): ResearchHit => {
+            const r = row as unknown as ResearchChunkRow & { _distance?: number };
+            const distance = typeof r._distance === 'number' ? r._distance : 1;
+
+            return {
+                url: r.url,
+                title: r.title,
+                sectionPath: r.sectionPath,
+                chunkIndex: r.chunkIndex,
+                content: r.content,
+                fetchedAt: r.fetchedAt,
+                score: 1 / (1 + Math.max(0, distance)),
+            };
+        })
+        .sort((a, b) => b.score - a.score)
+        .slice(0, k);
+}
+
+/**
+ * Delete all rows for the given researchIds. Used by the SIGINT/exit cleanup
+ * hook so an interrupted investigation doesn't leak rows past its session.
+ * No-op if the table doesn't exist or the list is empty.
+ */
+export async function deleteByResearchIds(
+    researchIds: string[],
+    repoKey?: string,
+): Promise<void> {
+    if (researchIds.length === 0) return;
+    const { table } = await getResearchChunksTable(null, repoKey);
+    if (!table) return;
+
+    const list = researchIds
+        .map((id) => `'${escapeSqlLiteral(id)}'`)
+        .join(', ');
+    try {
+        await table.delete(`researchId IN (${list})`);
+    } catch {
+        // Best-effort cleanup; never let a delete error mask the real flow.
+    }
+}
+
+/**
+ * Purge rows older than the cutoff. Called at the start of every new
+ * `investigate_web` invocation so disk usage stays bounded. No-op if the
+ * table doesn't exist.
+ */
+export async function deleteResearchChunksOlderThan(
+    cutoffMs: number,
+    repoKey?: string,
+): Promise<void> {
+    const { table } = await getResearchChunksTable(null, repoKey);
+    if (!table) return;
+
+    try {
+        await table.delete(`fetchedAt < ${cutoffMs}`);
+    } catch {
+        // Same as above — best-effort.
+    }
+}

--- a/src/AI/AIAgent/shared/memory/types.ts
+++ b/src/AI/AIAgent/shared/memory/types.ts
@@ -157,6 +157,25 @@ export interface CodeChunkRow {
     vector: number[];
 }
 
+/**
+ * Row stored in the LanceDB `research_chunks` table.
+ *
+ * One row per chunk of a fetched web page indexed during an `investigate_web`
+ * sub-agent run. Tagged with `researchId` so concurrent investigations don't
+ * cross-contaminate, and with `fetchedAt` for TTL-based eviction.
+ */
+export interface ResearchChunkRow {
+    id: string;
+    researchId: string;
+    url: string;
+    title: string;
+    sectionPath: string;
+    chunkIndex: number;
+    content: string;
+    fetchedAt: number;
+    vector: number[];
+}
+
 export interface SemanticOutlineEntry {
     name: string;
     kind: string;

--- a/src/AI/AIAgent/shared/subAgents/investigateWebTool.ts
+++ b/src/AI/AIAgent/shared/subAgents/investigateWebTool.ts
@@ -1,0 +1,457 @@
+/**
+ * `investigate_web` — orchestrator-facing autonomous web research tool.
+ *
+ * Mirrors `createInvestigateTool` but for the web. Each call:
+ *   1. Mints a fresh `researchId` (UUID) so concurrent investigations stay
+ *      isolated in the shared `research_chunks` LanceDB table.
+ *   2. Lazily purges TTL-expired rows from previous investigations.
+ *   3. Builds a `webResearchTools` factory bound to that `researchId`.
+ *   4. Runs the sub-agent with `{ web_search, web_scrape_and_index,
+ *      research_query, submit_result }` and a custom system prompt.
+ *   5. Optionally validates each evidence excerpt against the indexed chunks.
+ *   6. Cleans up the `researchId`'s rows on successful completion.
+ *
+ * Like `investigate`, only ONE concurrent investigation is allowed (per
+ * factory) so the user retains full control.
+ */
+
+import { randomUUID } from 'crypto';
+import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
+import type { LocalTool } from '@/AI/AIAgent/shared/types/agentTypes';
+import type { WebInvestigatorRuntime } from '@/AI/AIAgent/shared/subAgents/types';
+import {
+    runSubAgentTask,
+    type SubAgentChatBridge,
+} from '@/AI/AIAgent/shared/subAgents/session';
+import {
+    createWebResearchTools,
+    type WebResearchToolStats,
+} from '@/AI/AIAgent/shared/subAgents/webResearchTools';
+import {
+    deleteByResearchIds,
+    deleteResearchChunksOlderThan,
+    searchResearchChunks,
+} from '@/AI/AIAgent/shared/memory/researchChunks';
+import { embedOne } from '@/AI/AIAgent/shared/memory/embedder';
+
+export interface CreateInvestigateWebToolOptions {
+    runtime: WebInvestigatorRuntime;
+    /**
+     * MCP servers exposed to the sub-agent. The web research tools are
+     * `LocalTool`s so they don't need an MCP entry — pass `{}` if no MCP
+     * tooling is needed (typical).
+     */
+    mcpServers: Record<string, MCPServerConfig>;
+    workingDirectory: string;
+    /**
+     * Optional bridge into the orchestrator's chat / approval modal. When set,
+     * web-investigator tool calls flow through the same approval modal as
+     * orchestrator tool calls (tagged `[INVESTIGATOR-WEB]`).
+     */
+    chatBridge?: SubAgentChatBridge;
+    /**
+     * Repo key override for the LanceDB row scoping. Defaults to the value
+     * resolved from `WORKING_DIR` / cwd by the memory layer.
+     */
+    repoKey?: string;
+    /**
+     * Hook invoked when an investigation starts/finishes — used by the
+     * cleanup-on-exit handler in `agentConversation.ts` to track which
+     * `researchId`s should be purged on SIGINT.
+     */
+    onResearchActive?: (researchId: string, active: boolean) => void;
+}
+
+export interface WebEvidenceItem {
+    url: string;
+    title?: string;
+    section?: string;
+    excerpt: string;
+    why_relevant: string;
+}
+
+export interface WebInvestigationResult {
+    summary: string;
+    evidence: WebEvidenceItem[];
+    confidence: 'high' | 'medium' | 'low';
+    suggested_next?: string;
+    /** True when the agent submitted before exhausting all relevant material. */
+    partial?: boolean;
+    pages_fetched: number;
+    pages_failed: number;
+    chunks_indexed: number;
+    searches: number;
+    scrapes: number;
+}
+
+interface InvestigateWebArgs {
+    questions: string[];
+    hint?: string;
+}
+
+const INVESTIGATE_WEB_PARAMETERS: Record<string, unknown> = {
+    type: 'object',
+    properties: {
+        questions: {
+            type: 'array',
+            minItems: 1,
+            items: { type: 'string' },
+            description: 'ALL related research sub-questions for this investigation, as an array of strings. **One call per scope** — if multiple questions share the same library, vendor, docs source, or topic, list them ALL here so the sub-agent answers them from a single round of fetches. DO NOT issue a second `investigate_web` call for a question that overlaps in scope with one already in this array (or one you just made). Split into separate calls only when topics are genuinely unrelated (different library, different vendor, no shared docs source).',
+        },
+        hint: {
+            type: 'string',
+            description: 'Optional steering shared by all questions: known authoritative sources, prior findings, version pins, user context. The web investigator only sees `questions` + `hint` — be generous.',
+        },
+    },
+    required: ['questions'],
+    additionalProperties: false,
+};
+
+export function createInvestigateWebTool(opts: CreateInvestigateWebToolOptions): LocalTool {
+    const { runtime, mcpServers, workingDirectory } = opts;
+    const { settings } = runtime;
+
+    let activeRun: Promise<string> | null = null;
+
+    return {
+        name: 'investigate_web',
+        serverLabel: 'kra-subagent',
+        description: [
+            'Autonomous web research tool. Spawns a sub-agent that searches the web and',
+            'returns a curated {summary, evidence, confidence}. Use for questions whose answer lives outside this',
+            'repo: library/SDK behaviour, current ecosystem state, RFCs, vendor docs, recent',
+            'developments. NOT for repository code questions — use `investigate` for those.',
+            '',
+            '**Bundle related sub-questions into the `questions` array — ONE call per scope.**',
+            'If two questions would be answered from the same docs / vendor / library, they MUST',
+            'go in the same `questions` array on a single call. Issuing a second `investigate_web`',
+            'for an overlapping scope re-runs the entire search + fetch + index + synthesis pipeline',
+            'and fragments context the sub-agent needs.',
+            '',
+            'You never see raw page bodies; only short excerpts the sub-agent picked. Pass any',
+            'known steering (canonical doc URLs, version, user context) via `hint`. May be called',
+            'at any point in the turn. Only ONE web investigation runs at a time.',
+        ].join(' '),
+        parameters: INVESTIGATE_WEB_PARAMETERS,
+        handler: async (rawArgs) => {
+            if (activeRun) {
+                return [
+                    'investigate_web: another web investigation is already running. Only one is',
+                    'allowed at a time so the user retains full control. Wait for it to finish',
+                    'and then issue your next investigate_web call.',
+                ].join(' ');
+            }
+
+            const args = rawArgs as unknown as InvestigateWebArgs;
+            const researchId = randomUUID();
+            opts.onResearchActive?.(researchId, true);
+
+            const run = (async (): Promise<string> => {
+                // Lazy TTL cleanup — runs once per investigation start so disk
+                // usage stays bounded even if the SIGINT hook never fired.
+                const ttlMs = settings.ttlMinutes * 60_000;
+                await deleteResearchChunksOlderThan(Date.now() - ttlMs, opts.repoKey);
+
+                const factory = createWebResearchTools(researchId, settings, opts.repoKey);
+
+                const systemPrompt = buildWebInvestigatorSystemPrompt(settings);
+                const taskPrompt = buildWebInvestigatorTaskPrompt(args);
+
+                const { result, events } = await runSubAgentTask({
+                    runtime,
+                    mcpServers,
+                    workingDirectory,
+                    systemPrompt,
+                    taskPrompt,
+                    toolWhitelist: settings.toolWhitelist,
+                    additionalLocalTools: factory.tools,
+                    resultSchema: buildWebResultSchema(settings.maxEvidenceItems),
+                    ...(runtime.contextWindow !== undefined ? { contextWindow: runtime.contextWindow } : {}),
+                    ...(opts.chatBridge ? { chatBridge: opts.chatBridge } : {}),
+                });
+
+                const stats = factory.stats();
+
+                if (!result) {
+                    return JSON.stringify({
+                        summary: 'Web investigator did not call submit_result.',
+                        evidence: [],
+                        confidence: 'low' as const,
+                        partial: true,
+                        pages_fetched: stats.pagesFetched,
+                        pages_failed: stats.pagesFailed,
+                        chunks_indexed: stats.chunksIndexed,
+                        searches: stats.searches,
+                        scrapes: stats.scrapes,
+                        note: `Captured event count: ${events.length}.`,
+                    }, null, 2);
+                }
+
+                const parsed = coerceWebResult(result, stats);
+
+                if (settings.validateExcerpts) {
+                    parsed.evidence = await validateWebEvidence(
+                        parsed.evidence,
+                        researchId,
+                        ttlMs,
+                        opts.repoKey,
+                    );
+                }
+
+                if (parsed.evidence.length > settings.maxEvidenceItems) {
+                    parsed.evidence = parsed.evidence.slice(0, settings.maxEvidenceItems);
+                }
+
+                return JSON.stringify(parsed, null, 2);
+            })();
+
+            activeRun = run;
+
+            try {
+                return await run;
+            } finally {
+                activeRun = null;
+                // Best-effort row cleanup — TTL is the safety net.
+                try {
+                    await deleteByResearchIds([researchId], opts.repoKey);
+                } catch {
+                    // Already swallowed inside helper; redundant guard for safety.
+                }
+                opts.onResearchActive?.(researchId, false);
+            }
+        },
+    };
+}
+
+function buildWebInvestigatorSystemPrompt(settings: WebInvestigatorRuntime['settings']): string {
+    return [
+        'You are a web research sub-agent. Answer ONE research question with concrete,',
+        'evidence-backed findings drawn from the live web. You do NOT modify code. You',
+        'do NOT diagnose repository bugs — your scope is external information: library',
+        'behaviour, vendor documentation, ecosystem state, recent developments, RFCs.',
+        '',
+        'You are a small fast model. Bias toward authoritative sources (official docs,',
+        'GitHub READMEs, vendor blogs) over content farms. Stop as soon as you can',
+        'answer confidently. Do not exhaustively crawl the web.',
+        '',
+        'Tools (call in roughly this order):',
+        `  1. web_search(query, max_results?) — up to ${settings.maxSearches} calls. Returns`,
+        '     {title, url, snippet}. CHEAP. Use it to triage which URLs are worth scraping.',
+        '     Prefer specific, jargon-rich queries (the language of the docs you want).',
+        `  2. web_scrape_and_index({urls, queries, k?}) — up to ${settings.maxScrapes} calls,`,
+        `     up to ${settings.urlsPerScrape} URLs per call. Server fetches all URLs in parallel,`,
+        '     chunks them, embeds them into your private vector index, then runs vector search',
+        '     for each of your supplied queries and returns the most relevant excerpts. You',
+        '     never see raw page bodies — only the curated hits. Pass 1–4 focused sub-questions',
+        '     in `queries` so the search is sharp.',
+        '  3. research_query({query, k?}) — vector search against the chunks YOU already',
+        '     indexed. Use it to dig deeper into pages without re-fetching them.',
+        '  4. submit_result(...) — call ONCE when you have enough evidence. Then briefly',
+        '     acknowledge and stop. Do NOT call any tool after submit_result.',
+        '',
+        'Workflow:',
+        '  - Start with web_search to find candidate URLs. Read titles and snippets carefully',
+        '    — they are often enough to discard low-quality sources before scraping.',
+        '  - Batch scrapes: pass MANY urls + a few queries to one web_scrape_and_index call,',
+        '    rather than scraping URLs one by one.',
+        '  - If hits look thin or off-topic, refine with another web_search → scrape cycle.',
+        '  - Use research_query to revisit indexed material from a new angle.',
+        '',
+        'Quality:',
+        `  - Cap each evidence excerpt at ${settings.maxExcerptLines} lines.`,
+        `  - Cap total evidence at ${settings.maxEvidenceItems} items. Prefer fewer high-signal excerpts.`,
+        '  - Every excerpt MUST be copied verbatim from a chunk you retrieved (the tool layer',
+        '    will reject hallucinated excerpts).',
+        '  - Always include the source URL. Include the section heading when available.',
+        '  - `confidence` ∈ {high, medium, low} — honest. If sources are thin, contradictory, or',
+        '    out-of-date, return `low` and say so in the summary.',
+        '  - `summary` is 2–6 sentences answering the question, citing the evidence.',
+        '',
+        'If you exhaust your search/scrape budget without enough evidence, submit anyway with',
+        'whatever you have and `confidence: "low"` — partial findings are better than none.',
+    ].join('\n');
+}
+
+function buildWebInvestigatorTaskPrompt(args: InvestigateWebArgs): string {
+    const lines: string[] = [];
+
+    if (args.questions.length === 1) {
+        lines.push(`Research question: ${args.questions[0]}`);
+    } else {
+        lines.push(`Research questions (${args.questions.length}) — answer ALL of them in your final synthesis:`);
+        for (let i = 0; i < args.questions.length; i++) {
+            lines.push(`  ${i + 1}. ${args.questions[i]}`);
+        }
+        lines.push('');
+        lines.push('Plan one search/fetch strategy that covers every question above. The summary you submit must address each one explicitly.');
+    }
+
+    if (args.hint) {
+        lines.push('', `Hint from caller: ${args.hint}`);
+    }
+
+    lines.push('', 'Investigate, then call submit_result with your structured findings.');
+
+    return lines.join('\n');
+}
+
+function buildWebResultSchema(maxEvidenceItems: number): Record<string, unknown> {
+    return {
+        type: 'object',
+        properties: {
+            summary: {
+                type: 'string',
+                description: 'A 2–6 sentence answer to the research question, citing the evidence.',
+            },
+            evidence: {
+                type: 'array',
+                maxItems: maxEvidenceItems,
+                items: {
+                    type: 'object',
+                    properties: {
+                        url: {
+                            type: 'string',
+                            description: 'Source page URL.',
+                        },
+                        title: {
+                            type: 'string',
+                            description: 'Optional source page title.',
+                        },
+                        section: {
+                            type: 'string',
+                            description: 'Optional section heading / breadcrumb the excerpt came from.',
+                        },
+                        excerpt: {
+                            type: 'string',
+                            description: 'Verbatim excerpt copied from a retrieved chunk.',
+                        },
+                        why_relevant: {
+                            type: 'string',
+                            description: '1–2 sentences explaining why this snippet matters.',
+                        },
+                    },
+                    required: ['url', 'excerpt', 'why_relevant'],
+                    additionalProperties: false,
+                },
+            },
+            confidence: {
+                type: 'string',
+                enum: ['high', 'medium', 'low'],
+            },
+            suggested_next: {
+                type: 'string',
+                description: 'Optional: what the orchestrator should do or look at next.',
+            },
+            partial: {
+                type: 'boolean',
+                description: 'Set to true if the budget was exhausted before fully answering.',
+            },
+        },
+        required: ['summary', 'evidence', 'confidence'],
+        additionalProperties: false,
+    };
+}
+
+export function coerceWebResult(
+    raw: Record<string, unknown>,
+    stats: WebResearchToolStats,
+): WebInvestigationResult {
+    const summary = typeof raw['summary'] === 'string' ? raw['summary'] : '';
+    const confidence: 'high' | 'medium' | 'low' =
+        raw['confidence'] === 'high' || raw['confidence'] === 'medium' || raw['confidence'] === 'low'
+            ? raw['confidence']
+            : 'low';
+
+    const evidence: WebEvidenceItem[] = Array.isArray(raw['evidence'])
+        ? (raw['evidence'] as unknown[]).flatMap((e) => {
+            if (!e || typeof e !== 'object') return [];
+            const obj = e as Record<string, unknown>;
+            const url = typeof obj['url'] === 'string' ? obj['url'] : '';
+            const excerpt = typeof obj['excerpt'] === 'string' ? obj['excerpt'] : '';
+            const whyRelevant = typeof obj['why_relevant'] === 'string' ? obj['why_relevant'] : '';
+            if (!url || !excerpt) return [];
+
+            const title = typeof obj['title'] === 'string' ? obj['title'] : undefined;
+            const section = typeof obj['section'] === 'string' ? obj['section'] : undefined;
+
+            const item: WebEvidenceItem = { url, excerpt, why_relevant: whyRelevant };
+            if (title !== undefined) item.title = title;
+            if (section !== undefined) item.section = section;
+
+            return [item];
+        })
+        : [];
+
+    const result: WebInvestigationResult = {
+        summary,
+        evidence,
+        confidence,
+        pages_fetched: stats.pagesFetched,
+        pages_failed: stats.pagesFailed,
+        chunks_indexed: stats.chunksIndexed,
+        searches: stats.searches,
+        scrapes: stats.scrapes,
+    };
+
+    if (typeof raw['suggested_next'] === 'string') {
+        result.suggested_next = raw['suggested_next'];
+    }
+    if (raw['partial'] === true) {
+        result.partial = true;
+    }
+
+    return result;
+}
+
+function normaliseForCompare(s: string): string {
+    return s.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/**
+ * Verify each evidence excerpt by retrieving chunks from the same URL and
+ * checking that the excerpt is a substring (after whitespace normalisation)
+ * of at least one indexed chunk. Failures are kept in the result but tagged.
+ */
+export async function validateWebEvidence(
+    evidence: WebEvidenceItem[],
+    researchId: string,
+    ttlMs: number,
+    repoKey?: string,
+): Promise<WebEvidenceItem[]> {
+    if (evidence.length === 0) return evidence;
+
+    const validated: WebEvidenceItem[] = [];
+    for (const item of evidence) {
+        try {
+            const vector = await embedOne(item.excerpt);
+            const hits = await searchResearchChunks({
+                researchId,
+                vector,
+                k: 8,
+                ttlMs,
+                ...(repoKey !== undefined ? { repoKey } : {}),
+            });
+
+            const needle = normaliseForCompare(item.excerpt);
+            const sameUrlHits = hits.filter((h) => h.url === item.url);
+            const candidates = sameUrlHits.length > 0 ? sameUrlHits : hits;
+            const matched = candidates.some((h) => normaliseForCompare(h.content).includes(needle));
+
+            if (matched) {
+                validated.push(item);
+            } else {
+                validated.push({
+                    ...item,
+                    why_relevant: `[unverified: excerpt not found in indexed chunks for ${item.url}] ${item.why_relevant}`,
+                });
+            }
+        } catch (e) {
+            validated.push({
+                ...item,
+                why_relevant: `[unverified: validation error: ${e instanceof Error ? e.message : String(e)}] ${item.why_relevant}`,
+            });
+        }
+    }
+
+    return validated;
+}

--- a/src/AI/AIAgent/shared/subAgents/session.ts
+++ b/src/AI/AIAgent/shared/subAgents/session.ts
@@ -76,6 +76,15 @@ export interface SubAgentRunOptions {
     toolWhitelist: string[];
     /** JSON Schema for the `submit_result` tool's arguments. */
     resultSchema: Record<string, unknown>;
+    /**
+     * Optional extra local tools the sub-agent may call (in addition to the
+     * built-in `submit_result`). Names are merged into `allowedTools`. Use this
+     * for callers that need to expose specialised in-process tools — for
+     * example, the `investigate_web` sub-agent ships its `web_search`,
+     * `web_scrape_and_index` and `research_query` tools as `LocalTool`s tagged
+     * with the current `researchId` so they don't have to be wired through MCP.
+     */
+    additionalLocalTools?: LocalTool[];
     /** Optional event sink for streaming progress to the caller. */
     onEvent?: (e: SubAgentEvent) => void;
     /** Optional context window override for compaction. */
@@ -235,13 +244,18 @@ export async function runSubAgentTask(opts: SubAgentRunOptions): Promise<SubAgen
             model: opts.runtime.model,
             workingDirectory: opts.workingDirectory,
             mcpServers: opts.mcpServers,
-            localTools: [submitTool],
+            localTools: [submitTool, ...(opts.additionalLocalTools ?? [])],
             systemMessage: { mode: 'replace', content: opts.systemPrompt },
             ...(opts.contextWindow !== undefined ? { contextWindow: opts.contextWindow } : {}),
             excludedTools: [
                 'str_replace_editor', 'write_file', 'read_file', 'edit', 'view',
                 'grep', 'glob', 'create', 'apply_patch', 'task',
                 'bash', 'shell', 'run_in_terminal', 'execute', 'report_intent',
+                // Sub-agents don't get raw web access. The web investigator
+                // routes everything through `web_scrape_and_index` so pages
+                // are chunked + indexed and the LLM only sees retrieved
+                // excerpts. Other sub-agents have no business fetching pages.
+                'web_fetch',
             ],
             ...(opts.initialMessages ? { initialMessages: opts.initialMessages } : {}),
             allowedTools: [...opts.toolWhitelist, 'submit_result'],

--- a/src/AI/AIAgent/shared/subAgents/settings.ts
+++ b/src/AI/AIAgent/shared/subAgents/settings.ts
@@ -13,30 +13,65 @@ import fs from 'fs/promises';
 import * as toml from 'smol-toml';
 import { settingsFilePath } from '@/filePaths';
 import type {
+    AgentTruncationSettings,
     ExecutorSettings,
     InvestigatorSettings,
     SubAgentSettings,
+    WebInvestigatorSettings,
 } from './types';
 
 const DEFAULT_EXECUTOR_TOOLS = [
+    // reading
     'read_lines',
     'get_outline',
-    'anchor_edit',
-    'create_file',
+    'read_function',
     'search',
     'lsp_query',
+    'semantic_search',
+    'recall',
+    'docs_search',
+    // writing
+    'anchor_edit',
+    'create_file',
     'bash',
 ];
 
 const DEFAULT_INVESTIGATOR_TOOLS = [
+    // all reading operations + bash; no write tools
     'semantic_search',
     'search',
     'get_outline',
     'read_lines',
+    'read_function',
     'lsp_query',
     'docs_search',
     'recall',
+    'bash',
 ];
+
+const DEFAULT_WEB_INVESTIGATOR_TOOLS = [
+    'web_search',
+    'web_scrape_and_index',
+    'research_query',
+];
+
+const DEFAULT_NEVER_TRUNCATE = ['semantic_search', 'docs_search', 'recall', 'get_outline'];
+
+const ORCHESTRATOR_TRUNCATION_DEFAULTS: AgentTruncationSettings = {
+    defaultHead: 4000,
+    defaultTail: 4000,
+    bashHead: 2000,
+    bashTail: 6000,
+    neverTruncate: DEFAULT_NEVER_TRUNCATE,
+};
+
+const SUB_AGENT_TRUNCATION_DEFAULTS: AgentTruncationSettings = {
+    defaultHead: 8000,
+    defaultTail: 8000,
+    bashHead: 4000,
+    bashTail: 12000,
+    neverTruncate: DEFAULT_NEVER_TRUNCATE,
+};
 
 const EXECUTOR_DEFAULTS: ExecutorSettings = {
     enabled: false,
@@ -49,11 +84,25 @@ const EXECUTOR_DEFAULTS: ExecutorSettings = {
 };
 
 const INVESTIGATOR_DEFAULTS: InvestigatorSettings = {
-    enabled: false,
+    code: false,
+    web: false,
     maxEvidenceItems: 8,
     maxExcerptLines: 20,
     validateExcerpts: true,
     toolWhitelist: DEFAULT_INVESTIGATOR_TOOLS,
+};
+
+const WEB_INVESTIGATOR_DEFAULTS: WebInvestigatorSettings = {
+    useInvestigatorRuntime: true,
+    maxSearches: 5,
+    maxScrapes: 5,
+    urlsPerScrape: 30,
+    maxToolCalls: 30,
+    maxEvidenceItems: 8,
+    maxExcerptLines: 20,
+    ttlMinutes: 60,
+    validateExcerpts: true,
+    toolWhitelist: DEFAULT_WEB_INVESTIGATOR_TOOLS,
 };
 
 interface RawExecutor {
@@ -67,16 +116,43 @@ interface RawExecutor {
 }
 
 interface RawInvestigator {
-    enabled?: boolean;
+    /** Enables the code-investigator (`investigate`). */
+    code?: boolean;
+    /** Enables the web-investigator (`investigate_web`). */
+    web?: boolean;
     maxEvidenceItems?: number;
     maxExcerptLines?: number;
     validateExcerpts?: boolean;
     toolWhitelist?: string[];
 }
 
+interface RawWebInvestigator {
+    useInvestigatorRuntime?: boolean;
+    maxSearches?: number;
+    maxScrapes?: number;
+    urlsPerScrape?: number;
+    maxToolCalls?: number;
+    maxEvidenceItems?: number;
+    maxExcerptLines?: number;
+    ttlMinutes?: number;
+    validateExcerpts?: boolean;
+    toolWhitelist?: string[];
+}
+
+interface RawTruncation {
+    defaultHead?: number;
+    defaultTail?: number;
+    bashHead?: number;
+    bashTail?: number;
+    neverTruncate?: string[];
+}
+
 interface RawAgent {
     executor?: RawExecutor;
     investigator?: RawInvestigator;
+    investigatorWeb?: RawWebInvestigator;
+    truncation?: RawTruncation;
+    subAgentTruncation?: RawTruncation;
 }
 
 export async function loadSubAgentSettings(): Promise<SubAgentSettings> {
@@ -93,9 +169,15 @@ export async function loadSubAgentSettings(): Promise<SubAgentSettings> {
         // settings.toml not present yet — fall back to defaults.
     }
 
+    const investigator = mergeInvestigator(raw.investigator);
+    const investigatorWeb = mergeWebInvestigator(raw.investigatorWeb);
+
     return {
         executor: mergeExecutor(raw.executor),
-        investigator: mergeInvestigator(raw.investigator),
+        investigator,
+        investigatorWeb,
+        truncation: mergeTruncation(raw.truncation, ORCHESTRATOR_TRUNCATION_DEFAULTS),
+        subAgentTruncation: mergeTruncation(raw.subAgentTruncation, SUB_AGENT_TRUNCATION_DEFAULTS),
     };
 }
 
@@ -121,11 +203,53 @@ export function mergeExecutor(raw: RawExecutor | undefined): ExecutorSettings {
     };
 }
 
+export function mergeWebInvestigator(
+    raw: RawWebInvestigator | undefined,
+): WebInvestigatorSettings {
+    if (!raw || typeof raw !== 'object') return { ...WEB_INVESTIGATOR_DEFAULTS };
+
+    return {
+        useInvestigatorRuntime: typeof raw.useInvestigatorRuntime === 'boolean'
+            ? raw.useInvestigatorRuntime
+            : WEB_INVESTIGATOR_DEFAULTS.useInvestigatorRuntime,
+        maxSearches: clampInt(raw.maxSearches, 1, 50, WEB_INVESTIGATOR_DEFAULTS.maxSearches),
+        maxScrapes: clampInt(raw.maxScrapes, 1, 50, WEB_INVESTIGATOR_DEFAULTS.maxScrapes),
+        urlsPerScrape: clampInt(
+            raw.urlsPerScrape,
+            1,
+            200,
+            WEB_INVESTIGATOR_DEFAULTS.urlsPerScrape,
+        ),
+        maxToolCalls: clampInt(raw.maxToolCalls, 1, 500, WEB_INVESTIGATOR_DEFAULTS.maxToolCalls),
+        maxEvidenceItems: clampInt(
+            raw.maxEvidenceItems,
+            1,
+            50,
+            WEB_INVESTIGATOR_DEFAULTS.maxEvidenceItems,
+        ),
+        maxExcerptLines: clampInt(
+            raw.maxExcerptLines,
+            1,
+            200,
+            WEB_INVESTIGATOR_DEFAULTS.maxExcerptLines,
+        ),
+        ttlMinutes: clampInt(raw.ttlMinutes, 1, 24 * 60, WEB_INVESTIGATOR_DEFAULTS.ttlMinutes),
+        validateExcerpts: typeof raw.validateExcerpts === 'boolean'
+            ? raw.validateExcerpts
+            : WEB_INVESTIGATOR_DEFAULTS.validateExcerpts,
+        toolWhitelist: normaliseStringList(
+            raw.toolWhitelist,
+            WEB_INVESTIGATOR_DEFAULTS.toolWhitelist,
+        ),
+    };
+}
+
 export function mergeInvestigator(raw: RawInvestigator | undefined): InvestigatorSettings {
     if (!raw || typeof raw !== 'object') return { ...INVESTIGATOR_DEFAULTS };
 
     return {
-        enabled: typeof raw.enabled === 'boolean' ? raw.enabled : INVESTIGATOR_DEFAULTS.enabled,
+        code: typeof raw.code === 'boolean' ? raw.code : INVESTIGATOR_DEFAULTS.code,
+        web: typeof raw.web === 'boolean' ? raw.web : INVESTIGATOR_DEFAULTS.web,
         maxEvidenceItems: clampInt(
             raw.maxEvidenceItems,
             1,
@@ -142,6 +266,23 @@ export function mergeInvestigator(raw: RawInvestigator | undefined): Investigato
             ? raw.validateExcerpts
             : INVESTIGATOR_DEFAULTS.validateExcerpts,
         toolWhitelist: normaliseStringList(raw.toolWhitelist, INVESTIGATOR_DEFAULTS.toolWhitelist),
+    };
+}
+
+export function mergeTruncation(
+    raw: RawTruncation | undefined,
+    defaults: AgentTruncationSettings,
+): AgentTruncationSettings {
+    if (!raw || typeof raw !== 'object') return { ...defaults, neverTruncate: [...defaults.neverTruncate] };
+
+    return {
+        defaultHead: clampInt(raw.defaultHead, 0, 1_000_000, defaults.defaultHead),
+        defaultTail: clampInt(raw.defaultTail, 0, 1_000_000, defaults.defaultTail),
+        bashHead: clampInt(raw.bashHead, 0, 1_000_000, defaults.bashHead),
+        bashTail: clampInt(raw.bashTail, 0, 1_000_000, defaults.bashTail),
+        neverTruncate: Array.isArray(raw.neverTruncate)
+            ? raw.neverTruncate.filter((x): x is string => typeof x === 'string' && x.length > 0)
+            : [...defaults.neverTruncate],
     };
 }
 

--- a/src/AI/AIAgent/shared/subAgents/types.ts
+++ b/src/AI/AIAgent/shared/subAgents/types.ts
@@ -30,16 +30,75 @@ export interface ExecutorSettings {
 }
 
 export interface InvestigatorSettings {
-    enabled: boolean;
+    /** Enables the code-investigator (`investigate`) sub-agent. */
+    code: boolean;
+    /** Enables the web-investigator (`investigate_web`) sub-agent. */
+    web: boolean;
     maxEvidenceItems: number;
     maxExcerptLines: number;
     validateExcerpts: boolean;
     toolWhitelist: string[];
 }
 
+/**
+ * Tuning knobs for the `investigate_web` autonomous web-research sub-agent.
+ * The on/off switch lives on `InvestigatorSettings.web`; this block only
+ * configures behaviour when that switch is on.
+ *
+ * Quotas are upper bounds; the sub-agent is also bound by `maxToolCalls`.
+ */
+export interface WebInvestigatorSettings {
+    /**
+     * If true AND the code-side investigator is enabled, the web investigator
+     * reuses its resolved runtime (client + model) instead of prompting for a
+     * separate provider/model on startup. Mirrors `executor.useInvestigatorRuntime`.
+     */
+    useInvestigatorRuntime: boolean;
+    /** Hard cap on `web_search` calls per investigation. */
+    maxSearches: number;
+    /** Hard cap on `web_scrape_and_index` calls per investigation. */
+    maxScrapes: number;
+    /** Per-call cap on URLs passed to `web_scrape_and_index`. */
+    urlsPerScrape: number;
+    /** Hard cap on total tool calls before the agent is forced to submit. */
+    maxToolCalls: number;
+    maxEvidenceItems: number;
+    maxExcerptLines: number;
+    /** Time-to-live for indexed research_chunks rows, in minutes. */
+    ttlMinutes: number;
+    /** Whether to reject submitted evidence whose excerpts can't be located. */
+    validateExcerpts: boolean;
+    toolWhitelist: string[];
+}
+
+/**
+ * Caps on tool-result text handed back to a model. Anything longer than
+ * `defaultHead + defaultTail` (or `bashHead + bashTail` for bash-like tools)
+ * gets the middle replaced with an omission marker. Set the head/tail to 0
+ * to disable truncation entirely for that bucket. Tool names matching any
+ * substring in `neverTruncate` bypass the cap completely.
+ */
+export interface AgentTruncationSettings {
+    defaultHead: number;
+    defaultTail: number;
+    bashHead: number;
+    bashTail: number;
+    /** Substrings; a tool name containing any of these is never truncated. */
+    neverTruncate: string[];
+}
+
 export interface SubAgentSettings {
     executor: ExecutorSettings;
     investigator: InvestigatorSettings;
+    investigatorWeb: WebInvestigatorSettings;
+    /** Truncation applied to tool results returned to the orchestrator. */
+    truncation: AgentTruncationSettings;
+    /**
+     * Truncation applied to tool results returned to a sub-agent
+     * (investigator / executor / investigator_web). Sub-agents typically need
+     * to digest larger payloads, so defaults are looser than the orchestrator.
+     */
+    subAgentTruncation: AgentTruncationSettings;
 }
 
 export interface SubAgentRuntime {
@@ -54,4 +113,8 @@ export interface ExecutorRuntime extends SubAgentRuntime {
 
 export interface InvestigatorRuntime extends SubAgentRuntime {
     settings: InvestigatorSettings;
+}
+
+export interface WebInvestigatorRuntime extends SubAgentRuntime {
+    settings: WebInvestigatorSettings;
 }

--- a/src/AI/AIAgent/shared/subAgents/webResearchTools.ts
+++ b/src/AI/AIAgent/shared/subAgents/webResearchTools.ts
@@ -1,0 +1,359 @@
+/**
+ * Local-tool factory for the `investigate_web` sub-agent.
+ *
+ * Builds three `LocalTool`s scoped to a single investigation, identified by a
+ * fresh `researchId` UUID minted by `createInvestigateWebTool` per call:
+ *
+ *   - `web_search`            — pure search, returns `[{title, url, snippet}]`.
+ *   - `web_scrape_and_index`  — fetches URLs in parallel, chunks them with the
+ *                               existing markdown chunker, embeds via
+ *                               `embedMany`, inserts rows tagged with this
+ *                               investigation's `researchId`, then runs vector
+ *                               search per query and returns merged hits.
+ *   - `research_query`        — vector search scoped to this investigation +
+ *                               TTL filter (no new fetching).
+ *
+ * The model never sees raw page bodies; only retrieved excerpts. URL filtering
+ * is coarse (titles / snippets); fine-grained relevance is the vector search.
+ *
+ * Per-investigation quotas (searches, scrapes) live in the closure so they're
+ * reset for each new `investigate_web` invocation.
+ */
+
+import { randomUUID } from 'crypto';
+import {
+    fetchPageMarkdown,
+    searchPagesStructured,
+    type FetchedPage,
+} from '@/AI/shared/utils/webTools';
+import { chunkMarkdown } from '@/AI/AIAgent/shared/docs/chunker';
+import { embedMany, embedOne } from '@/AI/AIAgent/shared/memory/embedder';
+import {
+    insertResearchChunks,
+    searchResearchChunks,
+    type ResearchHit,
+} from '@/AI/AIAgent/shared/memory/researchChunks';
+import type { ResearchChunkRow } from '@/AI/AIAgent/shared/memory/types';
+import type { LocalTool } from '@/AI/AIAgent/shared/types/agentTypes';
+import type { WebInvestigatorSettings } from './types';
+
+export interface WebResearchToolStats {
+    searches: number;
+    scrapes: number;
+    pagesFetched: number;
+    pagesFailed: number;
+    chunksIndexed: number;
+}
+
+export interface WebResearchToolFactory {
+    tools: LocalTool[];
+    stats: () => WebResearchToolStats;
+}
+
+/**
+ * Build the 3 web-research `LocalTool`s for one investigation.
+ *
+ * `researchId` is the UUID minted for this `investigate_web` call. All chunks
+ * indexed during the call are tagged with it, so concurrent investigations
+ * don't see each other's data.
+ */
+export function createWebResearchTools(
+    researchId: string,
+    settings: WebInvestigatorSettings,
+    repoKey?: string,
+): WebResearchToolFactory {
+    const stats: WebResearchToolStats = {
+        searches: 0,
+        scrapes: 0,
+        pagesFetched: 0,
+        pagesFailed: 0,
+        chunksIndexed: 0,
+    };
+    const ttlMs = settings.ttlMinutes * 60_000;
+
+    const webSearch: LocalTool = {
+        name: 'web_search',
+        serverLabel: 'kra-investigate-web',
+        description:
+            'Search the web for sources relevant to your research question. '
+            + 'Returns up to ~10 results as `{title, url, snippet}`. Use the '
+            + 'titles and snippets to triage which URLs to scrape — this call '
+            + 'does NOT fetch page bodies. Cheap; spend it freely to refine.',
+        parameters: {
+            type: 'object',
+            properties: {
+                query: { type: 'string', description: 'Search query.' },
+                max_results: {
+                    type: 'number',
+                    description: 'Max results to return (default 8, hard cap 15).',
+                },
+            },
+            required: ['query'],
+            additionalProperties: false,
+        },
+        handler: async (rawArgs) => {
+            if (stats.searches >= settings.maxSearches) {
+                return JSON.stringify({
+                    error: 'web_search quota exhausted',
+                    quota: { used: stats.searches, max: settings.maxSearches },
+                });
+            }
+            stats.searches += 1;
+
+            const args = rawArgs as { query?: unknown; max_results?: unknown };
+            const query = typeof args.query === 'string' ? args.query : '';
+            const maxResults = typeof args.max_results === 'number'
+                ? Math.max(1, Math.min(15, Math.floor(args.max_results)))
+                : 8;
+
+            const { results, error } = await searchPagesStructured(query, maxResults);
+
+            return JSON.stringify({
+                query,
+                results,
+                ...(error ? { error } : {}),
+                quota: {
+                    web_search: { used: stats.searches, max: settings.maxSearches },
+                    web_scrape_and_index: { used: stats.scrapes, max: settings.maxScrapes },
+                },
+            });
+        },
+    };
+
+    const webScrapeAndIndex: LocalTool = {
+        name: 'web_scrape_and_index',
+        serverLabel: 'kra-investigate-web',
+        description:
+            'Fetch a batch of URLs in parallel, chunk + embed them into a '
+            + 'private vector index for this investigation, then run vector '
+            + 'search using each of the supplied queries and return the most '
+            + 'relevant excerpts. The model never sees raw page bodies — only '
+            + 'the curated hits returned here. Spend `web_search` first to '
+            + 'pick which URLs are worth scraping.',
+        parameters: {
+            type: 'object',
+            properties: {
+                urls: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description:
+                        `URLs to fetch (max ${settings.urlsPerScrape} per call).`,
+                },
+                queries: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description:
+                        'Queries to run against the freshly-indexed chunks. '
+                        + 'Use 1–4 focused sub-questions; one excerpt list is '
+                        + 'returned per query.',
+                },
+                k: {
+                    type: 'number',
+                    description: `Hits per query (default 5, hard cap ${settings.maxEvidenceItems * 2}).`,
+                },
+            },
+            required: ['urls', 'queries'],
+            additionalProperties: false,
+        },
+        handler: async (rawArgs) => {
+            if (stats.scrapes >= settings.maxScrapes) {
+                return JSON.stringify({
+                    error: 'web_scrape_and_index quota exhausted',
+                    quota: { used: stats.scrapes, max: settings.maxScrapes },
+                });
+            }
+            stats.scrapes += 1;
+
+            const args = rawArgs as {
+                urls?: unknown;
+                queries?: unknown;
+                k?: unknown;
+            };
+
+            const urls = Array.isArray(args.urls)
+                ? (args.urls.filter((u): u is string => typeof u === 'string'))
+                    .slice(0, settings.urlsPerScrape)
+                : [];
+            const queries = Array.isArray(args.queries)
+                ? args.queries.filter((q): q is string => typeof q === 'string' && q.length > 0)
+                : [];
+            const kCap = settings.maxEvidenceItems * 2;
+            const k = typeof args.k === 'number'
+                ? Math.max(1, Math.min(kCap, Math.floor(args.k)))
+                : 5;
+
+            if (urls.length === 0) {
+                return JSON.stringify({ error: 'No URLs provided to scrape.' });
+            }
+            if (queries.length === 0) {
+                return JSON.stringify({ error: 'No queries provided to search the indexed chunks.' });
+            }
+
+            // Parallel fetch; per-URL failures collected, never block the batch.
+            const fetched = await Promise.all(urls.map(async (url) => {
+                try {
+                    const r = await fetchPageMarkdown(url);
+
+                    return r.page
+                        ? { ok: true as const, page: r.page }
+                        : { ok: false as const, url, error: r.error ?? 'unknown error' };
+                } catch (e) {
+                    return {
+                        ok: false as const,
+                        url,
+                        error: e instanceof Error ? e.message : String(e),
+                    };
+                }
+            }));
+
+            const successes = fetched.filter((f): f is { ok: true; page: FetchedPage } => f.ok);
+            const failures = fetched.filter((f): f is { ok: false; url: string; error: string } => !f.ok);
+            stats.pagesFetched += successes.length;
+            stats.pagesFailed += failures.length;
+
+            // Chunk every successful page; track which page each chunk came from.
+            const rowsToInsert: ResearchChunkRow[] = [];
+            for (const { page } of successes) {
+                const chunks = chunkMarkdown(page.body, { pageTitle: page.title });
+                chunks.forEach((c, idx) => {
+                    rowsToInsert.push({
+                        id: randomUUID(),
+                        researchId,
+                        url: page.url,
+                        title: page.title,
+                        sectionPath: c.sectionPath,
+                        chunkIndex: idx,
+                        content: c.content,
+                        fetchedAt: page.fetchedAt,
+                        // vector filled in next step
+                        vector: [],
+                    });
+                });
+            }
+
+            if (rowsToInsert.length > 0) {
+                const vectors = await embedMany(
+                    rowsToInsert.map((_, i) => {
+                        // Mirror chunkMarkdown's contentForEmbedding shape so the
+                        // breadcrumb is part of the indexed text. We didn't keep
+                        // the chunk objects around so reconstruct from row fields.
+                        const row = rowsToInsert[i];
+                        const breadcrumb = row.sectionPath ? `# ${row.sectionPath}\n\n` : '';
+
+                        return breadcrumb + row.content;
+                    }),
+                );
+                rowsToInsert.forEach((row, i) => {
+                    row.vector = vectors[i];
+                });
+
+                try {
+                    await insertResearchChunks(rowsToInsert, repoKey);
+                    stats.chunksIndexed += rowsToInsert.length;
+                } catch (e) {
+                    return JSON.stringify({
+                        error: 'Failed to index chunks',
+                        detail: e instanceof Error ? e.message : String(e),
+                        scraped: successes.length,
+                        failed: failures.map((f) => ({ url: f.url, error: f.error })),
+                    });
+                }
+            }
+
+            // Vector search for each requested query.
+            const results = await Promise.all(queries.map(async (q) => {
+                const vector = await embedOne(q);
+                const hits = await searchResearchChunks({
+                    researchId,
+                    vector,
+                    k,
+                    ttlMs,
+                    ...(repoKey !== undefined ? { repoKey } : {}),
+                });
+
+                return {
+                    query: q,
+                    hits: hits.map(formatHit),
+                };
+            }));
+
+            return JSON.stringify({
+                scraped: successes.length,
+                failed: failures.map((f) => ({ url: f.url, error: f.error })),
+                chunks_indexed: rowsToInsert.length,
+                results,
+                quota: {
+                    web_search: { used: stats.searches, max: settings.maxSearches },
+                    web_scrape_and_index: { used: stats.scrapes, max: settings.maxScrapes },
+                },
+            });
+        },
+    };
+
+    const researchQuery: LocalTool = {
+        name: 'research_query',
+        serverLabel: 'kra-investigate-web',
+        description:
+            'Vector-search the chunks already indexed during this '
+            + 'investigation. Use this to dig into pages you already scraped '
+            + 'with `web_scrape_and_index` without re-fetching them. Returns '
+            + 'top-k excerpts with `{url, title, sectionPath, excerpt, score}`.',
+        parameters: {
+            type: 'object',
+            properties: {
+                query: { type: 'string', description: 'Sub-question to retrieve excerpts for.' },
+                k: {
+                    type: 'number',
+                    description: `Hits to return (default 5, hard cap ${settings.maxEvidenceItems * 2}).`,
+                },
+            },
+            required: ['query'],
+            additionalProperties: false,
+        },
+        handler: async (rawArgs) => {
+            const args = rawArgs as { query?: unknown; k?: unknown };
+            const query = typeof args.query === 'string' ? args.query : '';
+            if (!query) return JSON.stringify({ error: 'Missing required argument: query' });
+            const kCap = settings.maxEvidenceItems * 2;
+            const k = typeof args.k === 'number'
+                ? Math.max(1, Math.min(kCap, Math.floor(args.k)))
+                : 5;
+
+            const vector = await embedOne(query);
+            const hits = await searchResearchChunks({
+                researchId,
+                vector,
+                k,
+                ttlMs,
+                ...(repoKey !== undefined ? { repoKey } : {}),
+            });
+
+            return JSON.stringify({
+                query,
+                hits: hits.map(formatHit),
+                indexed_chunks_total: stats.chunksIndexed,
+            });
+        },
+    };
+
+    return {
+        tools: [webSearch, webScrapeAndIndex, researchQuery],
+        stats: () => ({ ...stats }),
+    };
+}
+
+function formatHit(hit: ResearchHit): {
+    url: string;
+    title: string;
+    sectionPath: string;
+    excerpt: string;
+    score: number;
+} {
+    return {
+        url: hit.url,
+        title: hit.title,
+        sectionPath: hit.sectionPath,
+        excerpt: hit.content,
+        score: Number(hit.score.toFixed(4)),
+    };
+}

--- a/src/AI/AIAgent/shared/types/agentTypes.ts
+++ b/src/AI/AIAgent/shared/types/agentTypes.ts
@@ -264,6 +264,11 @@ export interface AgentConversationOptions {
     dynamicParams?: Record<string, unknown>;
     executor?: import('@/AI/AIAgent/shared/subAgents/types').ExecutorRuntime;
     investigator?: import('@/AI/AIAgent/shared/subAgents/types').InvestigatorRuntime;
+    investigatorWeb?: import('@/AI/AIAgent/shared/subAgents/types').WebInvestigatorRuntime;
+    /** Truncation caps for tool results returned to the orchestrator. */
+    truncation?: import('@/AI/AIAgent/shared/subAgents/types').AgentTruncationSettings;
+    /** Truncation caps for tool results returned to a sub-agent. */
+    subAgentTruncation?: import('@/AI/AIAgent/shared/subAgents/types').AgentTruncationSettings;
 }
 
 export interface AgentUserInputResponse {

--- a/src/AI/shared/utils/webTools.ts
+++ b/src/AI/shared/utils/webTools.ts
@@ -547,10 +547,187 @@ export async function runWebFetch(args: WebFetchArgs): Promise<WebToolResult> {
     };
 }
 
-interface SearchResult {
+export interface SearchResult {
     title: string;
     url: string;
     snippet: string;
+}
+
+export interface FetchedPage {
+    url: string;
+    title: string;
+    body: string;
+    contentType: string;
+    via: string;
+    fetchedAt: number;
+    status: number;
+}
+
+/**
+ * Lower-level fetch that returns the raw markdown body without the header /
+ * pagination scaffolding `runWebFetch` adds for LLM display. Used by the
+ * `investigate_web` sub-agent's `web_scrape_and_index` tool to feed pages
+ * into the chunker + embedder.
+ *
+ * Reuses the same cache + `fetchAndBuildEntry` pipeline as `runWebFetch` so
+ * concurrent calls share fetched bodies.
+ */
+export async function fetchPageMarkdown(
+    url: string,
+    mode: WebFetchMode = 'auto',
+): Promise<{ page?: FetchedPage; error?: string }> {
+    if (!/^https?:\/\//i.test(url)) {
+        return { error: `Invalid URL (must be http/https): ${url}` };
+    }
+
+    const cacheKey = `${mode}|${url}`;
+    let entry = cacheGet(cacheKey);
+
+    if (!entry) {
+        const fetched = await fetchAndBuildEntry(url, mode);
+        if (fetched.error || !fetched.entry) {
+            return { error: fetched.error ?? 'Unknown fetch error' };
+        }
+        entry = fetched.entry;
+        cacheSet(cacheKey, entry);
+    }
+
+    if (entry.status >= 400) {
+        return { error: `HTTP ${entry.status} ${entry.statusText} for ${url}` };
+    }
+
+    return {
+        page: {
+            url: entry.url,
+            title: extractMarkdownTitle(entry.body) ?? deriveTitleFromUrl(entry.url),
+            body: entry.body,
+            contentType: entry.contentType,
+            via: entry.via,
+            fetchedAt: entry.fetchedAt,
+            status: entry.status,
+        },
+    };
+}
+
+function extractMarkdownTitle(markdown: string): string | undefined {
+    // First non-empty `# ` line, looking only at the first ~40 lines so we don't
+    // misidentify a deep heading as the page title.
+    const lines = markdown.split('\n', 40);
+    for (const line of lines) {
+        const m = /^\s*#\s+(.+?)\s*$/.exec(line);
+        if (m) return m[1];
+    }
+
+    return undefined;
+}
+
+function deriveTitleFromUrl(url: string): string {
+    try {
+        const u = new URL(url);
+
+        return `${u.hostname}${u.pathname}`;
+    } catch {
+        return url;
+    }
+}
+
+/**
+ * Structured search that returns `SearchResult[]` instead of a formatted
+ * string. Tries Jina first if `JINA_API` is set, falls back to DuckDuckGo
+ * lite. Used by the `investigate_web` sub-agent's `web_search` tool so the
+ * model gets a clean JSON list of `{title, url, snippet}` to triage.
+ */
+export async function searchPagesStructured(
+    query: string,
+    limit: number = DEFAULT_MAX_RESULTS,
+): Promise<{ results: SearchResult[]; error?: string }> {
+    const trimmed = query.trim();
+    if (!trimmed) return { results: [], error: 'Missing required argument: query' };
+
+    const cap = Math.min(limit, HARD_MAX_RESULTS);
+
+    if (process.env.JINA_API) {
+        const jina = await searchJinaStructured(trimmed, cap);
+        if (jina.results.length > 0) return jina;
+    }
+
+    return await searchDuckDuckGoLiteStructured(trimmed, cap);
+}
+
+async function searchJinaStructured(
+    query: string,
+    limit: number,
+): Promise<{ results: SearchResult[]; error?: string }> {
+    const apiKey = process.env.JINA_API;
+    if (!apiKey) return { results: [], error: 'JINA_API not set' };
+
+    try {
+        const response = await fetchWithTimeout(`https://s.jina.ai/?q=${encodeURIComponent(query)}`, {
+            method: 'GET',
+            redirect: 'follow',
+            headers: {
+                'User-Agent': USER_AGENT,
+                Authorization: `Bearer ${apiKey}`,
+                Accept: 'application/json',
+                'X-Respond-With': 'no-content',
+            },
+        });
+
+        if (!response.ok) {
+            return { results: [], error: `Jina HTTP ${response.status} ${response.statusText}` };
+        }
+
+        const json = await response.json() as JinaSearchResponse;
+        const items = Array.isArray(json.data) ? json.data : [];
+        const results = items.slice(0, limit).map((item) => ({
+            title: (item.title ?? '').trim(),
+            url: (item.url ?? '').trim(),
+            snippet: (item.description ?? item.content ?? '').trim(),
+        })).filter((r) => r.title && r.url);
+
+        return { results };
+    } catch (error) {
+        return {
+            results: [],
+            error: error instanceof Error ? error.message : String(error),
+        };
+    }
+}
+
+async function searchDuckDuckGoLiteStructured(
+    query: string,
+    limit: number,
+): Promise<{ results: SearchResult[]; error?: string }> {
+    try {
+        const body = new URLSearchParams({ q: query, kl: 'wt-wt' }).toString();
+        const response = await fetchWithTimeout('https://lite.duckduckgo.com/lite/', {
+            method: 'POST',
+            redirect: 'follow',
+            headers: {
+                'User-Agent': USER_AGENT,
+                'Content-Type': 'application/x-www-form-urlencoded',
+                Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                'Accept-Language': 'en-US,en;q=0.9',
+            },
+            body,
+        });
+
+        if (!response.ok) {
+            return { results: [], error: `DuckDuckGo HTTP ${response.status} ${response.statusText}` };
+        }
+
+        const html = await response.text();
+        if (/anomaly|unusual traffic|blocked/i.test(html) && !/result-link/i.test(html)) {
+            return { results: [], error: 'DuckDuckGo rate-limited the request. Retry in a minute.' };
+        }
+
+        return { results: parseDuckDuckGoLiteHtml(html, limit) };
+    } catch (error) {
+        return {
+            results: [],
+            error: error instanceof Error ? error.message : String(error),
+        };
+    }
 }
 
 


### PR DESCRIPTION
new tool that lets the orchestrator hand multi-question web research to an isolated sub-agent. The sub-agent runs with a tight toolset (web_search + web_scrape_and_index + research_query + submit_result), scrapes pages into a local vector index, and returns a single structured summary with cited evidence — keeping URLs, raw HTML and exploratory dead-ends out of the orchestrator's context.

Schema takes `questions: string[]` so multiple related questions get bundled into one sub-agent invocation by construction. Orchestrator prompt + docs updated accordingly.