### PR TITLE
fix: smooth nvim transcript streaming

### DIFF
--- a/__tests__/AI/AIChat/utils/conversation.test.ts
+++ b/__tests__/AI/AIChat/utils/conversation.test.ts
@@ -18,6 +18,9 @@ jest.mock('@/AI/AIChat/utils/aiUtils');
 jest.mock('@/filePaths', () => ({
     neovimConfig: '/home/krasen/programming/kra-tmux/ai-files/init.lua'
 }));
+jest.mock('@/utils/common', () => ({
+    loadSettings: jest.fn(async () => ({})),
+}));
 
 describe('converse', () => {
     const chatFile = 'chat.md';

--- a/__tests__/AI/shared/aiNeovimHelper.test.ts
+++ b/__tests__/AI/shared/aiNeovimHelper.test.ts
@@ -21,6 +21,9 @@ import * as fs from 'fs/promises';
 // Mock modules
 jest.mock('os');
 jest.mock('fs/promises');
+jest.mock('@/utils/common', () => ({
+    loadSettings: jest.fn(async () => ({})),
+}));
 
 // Mock StreamController
 const mockStreamController = {
@@ -155,7 +158,15 @@ describe('nvim-utils', () => {
                     .mockResolvedValueOnce(undefined);
 
                 await setupChatSplitLayout(mockNvim, 123, '/tmp/test-chat.md');
-                expect(mockNvim.executeLua).toHaveBeenNthCalledWith(1, `require('kra_chat_layout').setup(...)`, [123, '/tmp/test-chat.md']);
+                expect(mockNvim.executeLua).toHaveBeenNthCalledWith(
+                    1,
+                    `require('kra_chat_layout').setup(...)`,
+                    [123, '/tmp/test-chat.md', expect.objectContaining({
+                        scroll_tick_ms: expect.any(Number),
+                        scroll_acceleration: expect.any(Number),
+                        append_debounce_ms: expect.any(Number),
+                    })],
+                );
 
                 const prompt = await getChatPromptText(mockNvim);
                 expect(prompt).toBe('Prompt text');

--- a/ai-files/lua/kra_prompt_layout.lua
+++ b/ai-files/lua/kra_prompt_layout.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.create(config)
     local function state_key(name)
-        return config.namespace .. '_' .. name
+        return config.namespace .. "_" .. name
     end
 
     local function get_state(name)
@@ -14,11 +14,11 @@ function M.create(config)
     end
 
     local function is_valid_win(win)
-        return type(win) == 'number' and vim.api.nvim_win_is_valid(win)
+        return type(win) == "number" and vim.api.nvim_win_is_valid(win)
     end
 
     local function is_valid_buf(buf)
-        return type(buf) == 'number' and vim.api.nvim_buf_is_valid(buf)
+        return type(buf) == "number" and vim.api.nvim_buf_is_valid(buf)
     end
 
     local function mark_buffer(buf)
@@ -27,7 +27,7 @@ function M.create(config)
     end
 
     local function with_autohide_suppressed(callback)
-        local suppress_key = state_key('suppress_prompt_autohide')
+        local suppress_key = state_key("suppress_prompt_autohide")
         local previous = vim.g[suppress_key]
         vim.g[suppress_key] = true
 
@@ -43,9 +43,9 @@ function M.create(config)
     end
 
     local function store_prompt_cursor()
-        local prompt_win = get_state('prompt_win')
+        local prompt_win = get_state("prompt_win")
         if is_valid_win(prompt_win) then
-            set_state('prompt_cursor', vim.api.nvim_win_get_cursor(prompt_win))
+            set_state("prompt_cursor", vim.api.nvim_win_get_cursor(prompt_win))
         end
     end
 
@@ -55,38 +55,38 @@ function M.create(config)
         end
 
         local line_count = math.max(vim.api.nvim_buf_line_count(prompt_buf), 1)
-        local cursor = get_state('prompt_cursor')
-        if type(cursor) ~= 'table' or #cursor < 2 then
-            local line = vim.api.nvim_buf_get_lines(prompt_buf, line_count - 1, line_count, false)[1] or ''
+        local cursor = get_state("prompt_cursor")
+        if type(cursor) ~= "table" or #cursor < 2 then
+            local line = vim.api.nvim_buf_get_lines(prompt_buf, line_count - 1, line_count, false)[1] or ""
             vim.api.nvim_win_set_cursor(prompt_win, { line_count, #line })
             return
         end
 
         local target_line = math.min(math.max(cursor[1], 1), line_count)
-        local line = vim.api.nvim_buf_get_lines(prompt_buf, target_line - 1, target_line, false)[1] or ''
+        local line = vim.api.nvim_buf_get_lines(prompt_buf, target_line - 1, target_line, false)[1] or ""
         local target_col = math.min(math.max(cursor[2], 0), #line)
         vim.api.nvim_win_set_cursor(prompt_win, { target_line, target_col })
     end
 
     local function set_prompt_window_options(prompt_buf, prompt_win)
-        vim.bo[prompt_buf].buftype = 'nofile'
-        vim.bo[prompt_buf].bufhidden = 'hide'
+        vim.bo[prompt_buf].buftype = "nofile"
+        vim.bo[prompt_buf].bufhidden = "hide"
         vim.bo[prompt_buf].swapfile = false
-        vim.bo[prompt_buf].filetype = 'markdown'
+        vim.bo[prompt_buf].filetype = "markdown"
         vim.wo[prompt_win].number = false
         vim.wo[prompt_win].relativenumber = false
-        vim.wo[prompt_win].signcolumn = 'no'
+        vim.wo[prompt_win].signcolumn = "no"
         vim.wo[prompt_win].winfixheight = true
         vim.wo[prompt_win].wrap = true
         vim.wo[prompt_win].cursorline = true
-        vim.wo[prompt_win].winbar = config.prompt_winbar or ' USER PROMPT '
-        vim.wo[prompt_win].statusline = config.prompt_statusline or ' USER PROMPT '
+        vim.wo[prompt_win].winbar = config.prompt_winbar or " USER PROMPT "
+        vim.wo[prompt_win].statusline = config.prompt_statusline or " USER PROMPT "
     end
 
     local function set_transcript_window_options(transcript_buf, transcript_win)
         mark_buffer(transcript_buf)
-        vim.wo[transcript_win].winbar = config.transcript_winbar or ' CONVERSATION '
-        vim.wo[transcript_win].statusline = config.transcript_statusline or ' TRANSCRIPT '
+        vim.wo[transcript_win].winbar = config.transcript_winbar or " CONVERSATION "
+        vim.wo[transcript_win].statusline = config.transcript_statusline or " TRANSCRIPT "
 
         if config.setup_transcript_buffer then
             config.setup_transcript_buffer(transcript_buf, transcript_win)
@@ -98,7 +98,7 @@ function M.create(config)
 
     local function toggle_window()
         local current = vim.api.nvim_get_current_win()
-        local prompt_win = get_state('prompt_win')
+        local prompt_win = get_state("prompt_win")
 
         if current == prompt_win then
             hide_prompt_window()
@@ -108,7 +108,7 @@ function M.create(config)
         local reopened_prompt = create_prompt_window()
         if is_valid_win(reopened_prompt) then
             vim.api.nvim_set_current_win(reopened_prompt)
-            restore_prompt_cursor(reopened_prompt, get_state('prompt_buf'))
+            restore_prompt_cursor(reopened_prompt, get_state("prompt_buf"))
         end
     end
 
@@ -116,11 +116,11 @@ function M.create(config)
         local map = vim.keymap.set
         local opts = { buffer = buf, silent = true }
 
-        map('n', '<CR>', function()
-            vim.fn.rpcnotify(channel_id, 'prompt_action', 'submit_pressed')
-        end, vim.tbl_extend('force', opts, { desc = 'Submit prompt without writing scratch buffer' }))
-        map('n', '<Tab>', toggle_window, vim.tbl_extend('force', opts, { desc = 'Toggle prompt split' }))
-        map('n', '<S-Tab>', toggle_window, vim.tbl_extend('force', opts, { desc = 'Toggle prompt split' }))
+        map("n", "<CR>", function()
+            vim.fn.rpcnotify(channel_id, "prompt_action", "submit_pressed")
+        end, vim.tbl_extend("force", opts, { desc = "Submit prompt without writing scratch buffer" }))
+        map("n", "<Tab>", toggle_window, vim.tbl_extend("force", opts, { desc = "Toggle prompt split" }))
+        map("n", "<S-Tab>", toggle_window, vim.tbl_extend("force", opts, { desc = "Toggle prompt split" }))
 
         if config.extend_keymaps then
             config.extend_keymaps(buf, channel_id)
@@ -128,9 +128,9 @@ function M.create(config)
     end
 
     create_prompt_window = function()
-        local transcript_win = get_state('transcript_win')
-        local prompt_buf = get_state('prompt_buf')
-        local channel_id = get_state('channel')
+        local transcript_win = get_state("transcript_win")
+        local prompt_buf = get_state("prompt_buf")
+        local channel_id = get_state("channel")
 
         if not is_valid_win(transcript_win) then
             return nil
@@ -139,20 +139,20 @@ function M.create(config)
         if not is_valid_buf(prompt_buf) then
             prompt_buf = vim.api.nvim_create_buf(false, true)
             vim.api.nvim_buf_set_name(prompt_buf, config.prompt_buffer_name)
-            vim.api.nvim_buf_set_lines(prompt_buf, 0, -1, false, { '' })
+            vim.api.nvim_buf_set_lines(prompt_buf, 0, -1, false, { "" })
             mark_buffer(prompt_buf)
             add_keymaps(prompt_buf, channel_id)
-            set_state('prompt_buf', prompt_buf)
+            set_state("prompt_buf", prompt_buf)
         end
 
-        local prompt_win = get_state('prompt_win')
+        local prompt_win = get_state("prompt_win")
         if is_valid_win(prompt_win) then
             return prompt_win
         end
 
         prompt_win = with_autohide_suppressed(function()
             vim.api.nvim_set_current_win(transcript_win)
-            vim.cmd('botright ' .. (config.prompt_height or 8) .. 'split')
+            vim.cmd("botright " .. (config.prompt_height or 8) .. "split")
 
             local new_prompt_win = vim.api.nvim_get_current_win()
             vim.api.nvim_win_set_buf(new_prompt_win, prompt_buf)
@@ -161,47 +161,47 @@ function M.create(config)
             return new_prompt_win
         end)
 
-        set_state('prompt_win', prompt_win)
+        set_state("prompt_win", prompt_win)
 
         return prompt_win
     end
 
     hide_prompt_window = function()
-        local prompt_win = get_state('prompt_win')
+        local prompt_win = get_state("prompt_win")
         if not is_valid_win(prompt_win) then
-            set_state('prompt_win', nil)
+            set_state("prompt_win", nil)
             return
         end
 
         store_prompt_cursor()
 
         with_autohide_suppressed(function()
-            local transcript_win = get_state('transcript_win')
+            local transcript_win = get_state("transcript_win")
             if vim.api.nvim_get_current_win() == prompt_win and is_valid_win(transcript_win) then
                 vim.api.nvim_set_current_win(transcript_win)
             end
             pcall(vim.api.nvim_win_close, prompt_win, true)
         end)
 
-        set_state('prompt_win', nil)
+        set_state("prompt_win", nil)
     end
 
     local function attach_transcript_autohide(transcript_buf)
-        local autohide_key = state_key('prompt_autohide_attached')
+        local autohide_key = state_key("prompt_autohide_attached")
         if vim.b[transcript_buf][autohide_key] then
             return
         end
 
         vim.b[transcript_buf][autohide_key] = true
 
-        vim.api.nvim_create_autocmd('WinEnter', {
+        vim.api.nvim_create_autocmd("WinEnter", {
             buffer = transcript_buf,
             callback = function()
-                if vim.g[state_key('suppress_prompt_autohide')] then
+                if vim.g[state_key("suppress_prompt_autohide")] then
                     return
                 end
 
-                local transcript_win = get_state('transcript_win')
+                local transcript_win = get_state("transcript_win")
                 if is_valid_win(transcript_win) and vim.api.nvim_get_current_win() == transcript_win then
                     hide_prompt_window()
                 end
@@ -229,7 +229,7 @@ function M.create(config)
         local prompt_buf = vim.api.nvim_create_buf(false, true)
 
         vim.api.nvim_buf_set_name(prompt_buf, config.prompt_buffer_name)
-        vim.api.nvim_buf_set_lines(prompt_buf, 0, -1, false, { '' })
+        vim.api.nvim_buf_set_lines(prompt_buf, 0, -1, false, { "" })
 
         set_transcript_window_options(transcript_buf, transcript_win)
         mark_buffer(prompt_buf)
@@ -237,64 +237,76 @@ function M.create(config)
         add_keymaps(prompt_buf, channel_id)
         attach_transcript_autohide(transcript_buf)
 
-        set_state('channel', channel_id)
-        set_state('transcript_win', transcript_win)
-        set_state('transcript_buf', transcript_buf)
-        set_state('prompt_win', nil)
-        set_state('prompt_buf', prompt_buf)
-        set_state('prompt_cursor', nil)
+        set_state("channel", channel_id)
+        set_state("transcript_win", transcript_win)
+        set_state("transcript_buf", transcript_buf)
+        set_state("prompt_win", nil)
+        set_state("prompt_buf", prompt_buf)
+        set_state("prompt_cursor", nil)
 
         create_prompt_window()
 
-        if type(chat_file_path_arg) == 'string' and chat_file_path_arg ~= '' then
+        if type(chat_file_path_arg) == "string" and chat_file_path_arg ~= "" then
             chat_file_path = chat_file_path_arg
-            if type(opts) == 'table' and type(opts.tail_bytes) == 'number' then
+            if type(opts) == "table" and type(opts.tail_bytes) == "number" then
                 tail_bytes = opts.tail_bytes
+            end
+            if type(opts) == "table" then
+                if type(opts.scroll_tick_ms) == "number" and opts.scroll_tick_ms > 0 then
+                    SCROLL_TICK_MS = opts.scroll_tick_ms
+                end
+                if type(opts.scroll_acceleration) == "number" and opts.scroll_acceleration > 0 then
+                    SCROLL_ACCEL = opts.scroll_acceleration
+                end
+                if type(opts.append_debounce_ms) == "number" and opts.append_debounce_ms >= 0 then
+                    APPEND_DEBOUNCE_MS = opts.append_debounce_ms
+                end
             end
             -- Detach the transcript buffer from its file: no :edit! reload, no :w
             -- writes back to disk. TS owns all writes via fs.appendFile; this buffer
             -- is only ever a view into a (possibly truncated) tail of that file.
             pcall(function()
-                vim.bo[transcript_buf].buftype = 'nofile'
+                vim.bo[transcript_buf].buftype = "nofile"
                 vim.bo[transcript_buf].swapfile = false
             end)
             load_initial_tail()
             attach_history_loader(transcript_buf)
-            pcall(vim.keymap.set, 'n', 'gh', function() load_more_history() end,
-                { buffer = transcript_buf, silent = true, desc = 'Load more chat history' })
+            pcall(vim.keymap.set, "n", "gh", function()
+                load_more_history()
+            end, { buffer = transcript_buf, silent = true, desc = "Load more chat history" })
         end
     end
 
     function layout.get_prompt_text()
-        local prompt_buf = get_state('prompt_buf')
+        local prompt_buf = get_state("prompt_buf")
         if not is_valid_buf(prompt_buf) then
-            return ''
+            return ""
         end
 
         local lines = vim.api.nvim_buf_get_lines(prompt_buf, 0, -1, false)
-        while #lines > 0 and lines[1]:match('^%s*$') do
+        while #lines > 0 and lines[1]:match("^%s*$") do
             table.remove(lines, 1)
         end
-        while #lines > 0 and lines[#lines]:match('^%s*$') do
+        while #lines > 0 and lines[#lines]:match("^%s*$") do
             table.remove(lines)
         end
 
-        return table.concat(lines, '\n')
+        return table.concat(lines, "\n")
     end
 
     function layout.clear_prompt()
-        local prompt_buf = get_state('prompt_buf')
+        local prompt_buf = get_state("prompt_buf")
         if not is_valid_buf(prompt_buf) then
             return
         end
 
-        vim.api.nvim_buf_set_lines(prompt_buf, 0, -1, false, { '' })
-        set_state('prompt_cursor', nil)
+        vim.api.nvim_buf_set_lines(prompt_buf, 0, -1, false, { "" })
+        set_state("prompt_cursor", nil)
     end
 
     function layout.focus_prompt()
         local prompt_win = create_prompt_window()
-        local prompt_buf = get_state('prompt_buf')
+        local prompt_buf = get_state("prompt_buf")
         if not is_valid_win(prompt_win) then
             return
         end
@@ -302,61 +314,157 @@ function M.create(config)
         vim.api.nvim_set_current_win(prompt_win)
     end
 
-    -- Render-markdown is left enabled during streaming so formatting appears
-    -- as the agent types. Tail-windowing keeps the transcript bounded so the
-    -- per-change extmark recompute stays cheap.
+    -- During streaming we DISABLE render-markdown.nvim on the transcript
+    -- buffer. Its extmark recompute on every TextChanged is the dominant
+    -- cost when chunks arrive at ~30 Hz; suspending it lets the buffer
+    -- mutate at near-raw-speed and we re-enable it at flush boundaries
+    -- (`streaming_ended`) for a single full repaint of the styled view.
+    local streaming_active = false
+    local function rm_buf_set(buf, on)
+        if not is_valid_buf(buf) then return end
+        local ok, rm = pcall(require, 'render-markdown')
+        if not ok or not rm then return end
+        -- buf_enable/buf_disable operate on the CURRENT buffer (no arg),
+        -- so we have to swap into the transcript buffer's context first.
+        pcall(vim.api.nvim_buf_call, buf, function()
+            if on then
+                if type(rm.buf_enable) == 'function' then
+                    rm.buf_enable()
+                end
+                -- buf_enable does NOT auto-trigger a repaint, so kick one.
+                if type(rm.render) == 'function' then
+                    pcall(rm.render, { buf = buf, event = 'KraStreamEnd' })
+                end
+            else
+                if type(rm.buf_disable) == 'function' then
+                    rm.buf_disable()
+                end
+            end
+        end)
+    end
 
     -- Incremental append: write text to the END of the transcript buffer without
-    -- reloading from disk. Coalesces a burst of streaming chunks via a short timer
-    -- so we do at most ~1 buffer mutation per debounce window.
-    local pending_append = ''
+    -- reloading from disk. The TS host now paces deltas at ~60 Hz so we want
+    -- the Lua side to flush each batch as soon as it lands — a long debounce
+    -- here would just re-clump the carefully-spaced batches and re-introduce
+    -- the visible "chunk" feel. 4 ms is enough to coalesce the back-to-back
+    -- rpcnotify calls of a single tick, no more.
+    local pending_append = ""
     local append_timer = nil
-    local APPEND_DEBOUNCE_MS = 10
+    -- Configurable from TS via setup() opts (forwarded from settings.toml
+    -- [ai.chat_interface]). Defaults match the tuned values.
+    local APPEND_DEBOUNCE_MS = 0
+
+    -- Smooth auto-scroll animator. The TS pacer drips ~250 chars/sec; each
+    -- newline would normally cause an instant 1-row scroll jump (cursor
+    -- snap to bottom). We instead remember a target line and advance the
+    -- cursor toward it 1 row per timer tick, so the viewport scrolls at a
+    -- steady ~60 Hz instead of in instantaneous steps. If the model gets
+    -- way ahead (target > current + a few rows) we accelerate so we never
+    -- fall behind on a long response.
+    local SCROLL_TICK_MS = 16
+    local SCROLL_ACCEL = 8
+    local cursor_target_line = nil
+    local scroll_timer = nil
+
+    local function stop_scroll_timer()
+        if scroll_timer then
+            pcall(function() scroll_timer:stop() end)
+            pcall(function() scroll_timer:close() end)
+            scroll_timer = nil
+        end
+    end
+
+    local function tick_scroll()
+        local transcript_buf = get_state("transcript_buf")
+        local transcript_win = get_state("transcript_win")
+        if not is_valid_buf(transcript_buf) or not is_valid_win(transcript_win) or cursor_target_line == nil then
+            stop_scroll_timer()
+            cursor_target_line = nil
+            return
+        end
+        -- Don't fight a user reading / scrolling history.
+        if vim.api.nvim_get_current_win() == transcript_win then
+            stop_scroll_timer()
+            cursor_target_line = nil
+            return
+        end
+        local ok_cur, cur = pcall(vim.api.nvim_win_get_cursor, transcript_win)
+        if not ok_cur then
+            stop_scroll_timer()
+            cursor_target_line = nil
+            return
+        end
+        local current = cur[1]
+        local target = cursor_target_line
+        if current >= target then
+            local last = vim.api.nvim_buf_get_lines(transcript_buf, target - 1, target, false)[1] or ""
+            pcall(vim.api.nvim_win_set_cursor, transcript_win, { target, #last })
+            cursor_target_line = nil
+            stop_scroll_timer()
+            return
+        end
+        local diff = target - current
+        -- 1 row/tick when within 8 rows of target, accelerate beyond that.
+        local step = math.max(1, math.floor(diff / SCROLL_ACCEL))
+        local next_line = math.min(target, current + step)
+        pcall(vim.api.nvim_win_set_cursor, transcript_win, { next_line, 0 })
+    end
+
+    local function schedule_smooth_scroll(target_line)
+        cursor_target_line = target_line
+        if not scroll_timer then
+            scroll_timer = (vim.uv or vim.loop).new_timer()
+            scroll_timer:start(SCROLL_TICK_MS, SCROLL_TICK_MS, vim.schedule_wrap(tick_scroll))
+        end
+    end
 
     local function flush_append()
-        local transcript_buf = get_state('transcript_buf')
+        local transcript_buf = get_state("transcript_buf")
         if not is_valid_buf(transcript_buf) then
-            pending_append = ''
+            pending_append = ""
             return
         end
 
         local text = pending_append
-        pending_append = ''
-        if text == '' then return end
-
+        pending_append = ""
+        if text == "" then
+            return
+        end
 
         local last_line = vim.api.nvim_buf_line_count(transcript_buf)
-        local last_line_content = vim.api.nvim_buf_get_lines(
-            transcript_buf, last_line - 1, last_line, false
-        )[1] or ''
+        local last_line_content = vim.api.nvim_buf_get_lines(transcript_buf, last_line - 1, last_line, false)[1] or ""
         local last_col = #last_line_content
-        local lines = vim.split(text, '\n', { plain = true })
+        local lines = vim.split(text, "\n", { plain = true })
 
         local was_modifiable = vim.bo[transcript_buf].modifiable
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = true end
-        pcall(vim.api.nvim_buf_set_text,
-            transcript_buf, last_line - 1, last_col, last_line - 1, last_col, lines)
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = true
+        end
+        pcall(vim.api.nvim_buf_set_text, transcript_buf, last_line - 1, last_col, last_line - 1, last_col, lines)
         byte_end_in_file = byte_end_in_file + #text
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = false end
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = false
+        end
 
         -- Buffer + disk are kept in sync by the TS side (it appends the same
         -- text to the file). Clear the modified flag so :edit! at boundaries
         -- is a no-op reload and no "buffer modified" warnings appear.
-        pcall(function() vim.bo[transcript_buf].modified = false end)
+        pcall(function()
+            vim.bo[transcript_buf].modified = false
+        end)
 
         -- Auto-scroll the transcript window only if the user isn't currently
         -- focused on it (don't fight a user reading / scrolling history).
-        local transcript_win = get_state('transcript_win')
-        if is_valid_win(transcript_win)
-            and vim.api.nvim_get_current_win() ~= transcript_win then
+        local transcript_win = get_state("transcript_win")
+        if is_valid_win(transcript_win) and vim.api.nvim_get_current_win() ~= transcript_win then
             local new_count = vim.api.nvim_buf_line_count(transcript_buf)
-            local last = vim.api.nvim_buf_get_lines(
-                transcript_buf, new_count - 1, new_count, false
-            )[1] or ''
-            pcall(vim.api.nvim_win_set_cursor, transcript_win, { new_count, #last })
+            schedule_smooth_scroll(new_count)
         end
 
-        if chat_file_path then trim_buffer_to_tail(transcript_buf) end
+        if chat_file_path then
+            trim_buffer_to_tail(transcript_buf)
+        end
     end
     -- ---- Tail-windowing helpers (defined after flush_append so they can
     -- close over pending_append / flush_append).
@@ -367,31 +475,40 @@ function M.create(config)
     end
 
     local function fs_read_range(path, offset, length)
-        if length <= 0 then return '' end
-        local fd = vim.loop.fs_open(path, 'r', 438)
-        if not fd then return '' end
+        if length <= 0 then
+            return ""
+        end
+        local fd = vim.loop.fs_open(path, "r", 438)
+        if not fd then
+            return ""
+        end
         local data = vim.loop.fs_read(fd, length, offset)
         vim.loop.fs_close(fd)
-        return data or ''
+        return data or ""
     end
 
     local function format_history_sentinel(bytes_above)
         local label
         if bytes_above < 1024 then
-            label = bytes_above .. ' B'
+            label = bytes_above .. " B"
         elseif bytes_above < 1024 * 1024 then
-            label = string.format('%.1f KB', bytes_above / 1024)
+            label = string.format("%.1f KB", bytes_above / 1024)
         else
-            label = string.format('%.2f MB', bytes_above / (1024 * 1024))
+            label = string.format("%.2f MB", bytes_above / (1024 * 1024))
         end
-        return '<!-- \xe2\x94\x80\xe2\x94\x80 ' .. label
-            .. ' earlier \xe2\x80\x94 scroll up or press gh to load more \xe2\x94\x80\xe2\x94\x80 -->'
+        return "<!-- \xe2\x94\x80\xe2\x94\x80 "
+            .. label
+            .. " earlier \xe2\x80\x94 scroll up or press gh to load more \xe2\x94\x80\xe2\x94\x80 -->"
     end
 
     local function update_history_sentinel(transcript_buf)
-        if not is_valid_buf(transcript_buf) then return end
+        if not is_valid_buf(transcript_buf) then
+            return
+        end
         local was_modifiable = vim.bo[transcript_buf].modifiable
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = true end
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = true
+        end
         if byte_start_in_file > 0 then
             local sentinel = format_history_sentinel(byte_start_in_file)
             if has_history_sentinel then
@@ -404,14 +521,22 @@ function M.create(config)
             vim.api.nvim_buf_set_lines(transcript_buf, 0, 1, false, {})
             has_history_sentinel = false
         end
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = false end
-        pcall(function() vim.bo[transcript_buf].modified = false end)
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = false
+        end
+        pcall(function()
+            vim.bo[transcript_buf].modified = false
+        end)
     end
 
     load_initial_tail = function()
-        if not chat_file_path then return end
-        local transcript_buf = get_state('transcript_buf')
-        if not is_valid_buf(transcript_buf) then return end
+        if not chat_file_path then
+            return
+        end
+        local transcript_buf = get_state("transcript_buf")
+        if not is_valid_buf(transcript_buf) then
+            return
+        end
         local size = fs_size(chat_file_path)
         byte_end_in_file = size
         if size <= tail_bytes then
@@ -419,54 +544,72 @@ function M.create(config)
             head_loaded = true
         else
             local raw = fs_read_range(chat_file_path, size - tail_bytes, tail_bytes)
-            local nl = raw:find('\n')
+            local nl = raw:find("\n")
             byte_start_in_file = nl and (size - tail_bytes + nl) or (size - tail_bytes)
             head_loaded = false
         end
-        local content = fs_read_range(chat_file_path, byte_start_in_file,
-            byte_end_in_file - byte_start_in_file)
-        local lines = vim.split(content, '\n', { plain = true })
-        if #lines == 0 then lines = { '' } end
+        local content = fs_read_range(chat_file_path, byte_start_in_file, byte_end_in_file - byte_start_in_file)
+        local lines = vim.split(content, "\n", { plain = true })
+        if #lines == 0 then
+            lines = { "" }
+        end
         local was_modifiable = vim.bo[transcript_buf].modifiable
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = true end
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = true
+        end
         vim.api.nvim_buf_set_lines(transcript_buf, 0, -1, false, lines)
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = false end
-        pcall(function() vim.bo[transcript_buf].modified = false end)
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = false
+        end
+        pcall(function()
+            vim.bo[transcript_buf].modified = false
+        end)
         has_history_sentinel = false
         update_history_sentinel(transcript_buf)
         update_history_sentinel(transcript_buf)
     end
 
     trim_buffer_to_tail = function(transcript_buf)
-        if not chat_file_path then return end
-        if (byte_end_in_file - byte_start_in_file) <= 2 * tail_bytes then return end
+        if not chat_file_path then
+            return
+        end
+        if (byte_end_in_file - byte_start_in_file) <= 2 * tail_bytes then
+            return
+        end
 
-        local transcript_win = get_state('transcript_win')
-        if is_valid_win(transcript_win)
-            and vim.api.nvim_get_current_win() == transcript_win then
+        local transcript_win = get_state("transcript_win")
+        if is_valid_win(transcript_win) and vim.api.nvim_get_current_win() == transcript_win then
             return
         end
 
         local new_target_start = byte_end_in_file - tail_bytes
         local read_len = byte_end_in_file - new_target_start
         local raw = fs_read_range(chat_file_path, new_target_start, read_len)
-        if not raw then return end
+        if not raw then
+            return
+        end
 
         local actual_start = new_target_start
         if new_target_start > 0 then
-            local nl = raw:find('\n', 1, true)
+            local nl = raw:find("\n", 1, true)
             if nl then
                 raw = raw:sub(nl + 1)
                 actual_start = new_target_start + nl
             end
         end
 
-        local lines = vim.split(raw, '\n', { plain = true })
+        local lines = vim.split(raw, "\n", { plain = true })
         local was_modifiable = vim.bo[transcript_buf].modifiable
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = true end
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = true
+        end
         pcall(vim.api.nvim_buf_set_lines, transcript_buf, 0, -1, false, lines)
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = false end
-        pcall(function() vim.bo[transcript_buf].modified = false end)
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = false
+        end
+        pcall(function()
+            vim.bo[transcript_buf].modified = false
+        end)
 
         byte_start_in_file = actual_start
         head_loaded = (actual_start == 0)
@@ -475,76 +618,106 @@ function M.create(config)
 
         if is_valid_win(transcript_win) then
             local n = vim.api.nvim_buf_line_count(transcript_buf)
-            local last = vim.api.nvim_buf_get_lines(transcript_buf, n - 1, n, false)[1] or ''
+            local last = vim.api.nvim_buf_get_lines(transcript_buf, n - 1, n, false)[1] or ""
             pcall(vim.api.nvim_win_set_cursor, transcript_win, { n, #last })
         end
     end
 
     load_more_history = function()
-        if head_loaded or not chat_file_path then return end
-        local transcript_buf = get_state('transcript_buf')
-        if not is_valid_buf(transcript_buf) then return end
+        if head_loaded or not chat_file_path then
+            return
+        end
+        local transcript_buf = get_state("transcript_buf")
+        if not is_valid_buf(transcript_buf) then
+            return
+        end
         local new_start = math.max(0, byte_start_in_file - tail_bytes)
         local read_len = byte_start_in_file - new_start
         local raw = fs_read_range(chat_file_path, new_start, read_len)
         local actual_start = new_start
         if new_start > 0 then
-            local nl = raw:find('\n')
+            local nl = raw:find("\n")
             if nl then
                 raw = raw:sub(nl + 1)
                 actual_start = new_start + nl
             end
         end
-        local lines = vim.split(raw, '\n', { plain = true })
-        if #lines > 0 and lines[#lines] == '' then table.remove(lines) end
-        if #lines == 0 then return end
-        local transcript_win = get_state('transcript_win')
+        local lines = vim.split(raw, "\n", { plain = true })
+        if #lines > 0 and lines[#lines] == "" then
+            table.remove(lines)
+        end
+        if #lines == 0 then
+            return
+        end
+        local transcript_win = get_state("transcript_win")
         local view = nil
         if is_valid_win(transcript_win) then
-            view = vim.api.nvim_win_call(transcript_win, function() return vim.fn.winsaveview() end)
+            view = vim.api.nvim_win_call(transcript_win, function()
+                return vim.fn.winsaveview()
+            end)
         end
         local before_count = vim.api.nvim_buf_line_count(transcript_buf)
         local was_modifiable = vim.bo[transcript_buf].modifiable
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = true end
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = true
+        end
         local replace_to = has_history_sentinel and 1 or 0
         vim.api.nvim_buf_set_lines(transcript_buf, 0, replace_to, false, lines)
         has_history_sentinel = false
         byte_start_in_file = actual_start
         head_loaded = (actual_start == 0)
-        if not was_modifiable then vim.bo[transcript_buf].modifiable = false end
-        pcall(function() vim.bo[transcript_buf].modified = false end)
+        if not was_modifiable then
+            vim.bo[transcript_buf].modifiable = false
+        end
+        pcall(function()
+            vim.bo[transcript_buf].modified = false
+        end)
         update_history_sentinel(transcript_buf)
         if view and is_valid_win(transcript_win) then
             local after_count = vim.api.nvim_buf_line_count(transcript_buf)
             local shift = after_count - before_count
             view.topline = view.topline + shift
             view.lnum = view.lnum + shift
-            pcall(vim.api.nvim_win_call, transcript_win, function() vim.fn.winrestview(view) end)
+            pcall(vim.api.nvim_win_call, transcript_win, function()
+                vim.fn.winrestview(view)
+            end)
         end
     end
 
     attach_history_loader = function(transcript_buf)
-        local hist_key = state_key('history_loader_attached')
-        if vim.b[transcript_buf][hist_key] then return end
+        local hist_key = state_key("history_loader_attached")
+        if vim.b[transcript_buf][hist_key] then
+            return
+        end
         vim.b[transcript_buf][hist_key] = true
-        vim.api.nvim_create_autocmd('WinScrolled', {
+        vim.api.nvim_create_autocmd("WinScrolled", {
             buffer = transcript_buf,
             callback = function()
-                if head_loaded then return end
-                local transcript_win = get_state('transcript_win')
-                if not is_valid_win(transcript_win) then return end
+                if head_loaded then
+                    return
+                end
+                local transcript_win = get_state("transcript_win")
+                if not is_valid_win(transcript_win) then
+                    return
+                end
                 local topline = vim.api.nvim_win_call(transcript_win, function()
-                    return vim.fn.line('w0')
+                    return vim.fn.line("w0")
                 end)
-                if topline <= 2 then load_more_history() end
+                if topline <= 2 then
+                    load_more_history()
+                end
             end,
         })
     end
 
     smart_refresh = function()
-        if not chat_file_path then return false end
-        local transcript_buf = get_state('transcript_buf')
-        if not is_valid_buf(transcript_buf) then return true end
+        if not chat_file_path then
+            return false
+        end
+        local transcript_buf = get_state("transcript_buf")
+        if not is_valid_buf(transcript_buf) then
+            return true
+        end
         -- Always reload the visible tail from disk. Pure-append diffing was unsafe
         -- because TS code paths mutate the chat file in-place (e.g.
         -- materializeUserDraft rewriting `(draft)` -> `· timestamp`), and a
@@ -553,43 +726,77 @@ function M.create(config)
         -- still cheap relative to a full :edit! reload of an unbounded file.
         -- Drop any in-flight pending bytes; we're about to replace the buffer
         -- entirely from disk, so the in-memory tail is now stale.
-        pending_append = ''
+        pending_append = ""
         load_initial_tail()
         return true
     end
 
     function layout.append_text(text)
-        if type(text) ~= 'string' or text == '' then return end
+        if type(text) ~= "string" or text == "" then
+            return
+        end
         pending_append = pending_append .. text
-        if append_timer then return end
+        if append_timer then
+            return
+        end
         append_timer = vim.defer_fn(function()
             append_timer = nil
             flush_append()
         end, APPEND_DEBOUNCE_MS)
     end
 
+    -- Called by the TS host immediately before it begins streaming a
+    -- response. Disables render-markdown on the transcript buffer so the
+    -- per-chunk extmark recompute storm doesn't drag the UI. The buffer
+    -- still receives raw markdown text — syntax highlighting via
+    -- treesitter is the only style applied during streaming. The plugin
+    -- is re-enabled by `streaming_ended` for a single batched repaint.
+    function layout.streaming_started()
+        if streaming_active then return end
+        streaming_active = true
+        local transcript_buf = get_state("transcript_buf")
+        rm_buf_set(transcript_buf, false)
+    end
+
+    function layout.streaming_ended()
+        if not streaming_active then return end
+        streaming_active = false
+        if append_timer then
+            pcall(function() append_timer:stop(); append_timer:close() end)
+            append_timer = nil
+        end
+        flush_append()
+        local transcript_buf = get_state("transcript_buf")
+        rm_buf_set(transcript_buf, true)
+    end
+
     function layout.refresh()
         -- Flush any pending streaming text into the buffer first.
         if append_timer then
-            pcall(function() append_timer:stop(); append_timer:close() end)
+            pcall(function()
+                append_timer:stop()
+                append_timer:close()
+            end)
             append_timer = nil
         end
         flush_append()
 
         -- Tail-windowing path: cheap on-disk diff sync, no full reload.
         if smart_refresh() then
-            local transcript_win = get_state('transcript_win')
+            local transcript_win = get_state("transcript_win")
             if is_valid_win(transcript_win) then
-                pcall(vim.api.nvim_win_call, transcript_win, function() vim.cmd('normal! G') end)
+                pcall(vim.api.nvim_win_call, transcript_win, function()
+                    vim.cmd("normal! G")
+                end)
             end
-            pcall(vim.cmd, 'redraw')
+            pcall(vim.cmd, "redraw")
             return
         end
 
         -- Legacy fallback for callers that didn't set chat_file_path.
-        local transcript_win = get_state('transcript_win')
-        local prompt_win = get_state('prompt_win')
-        local prompt_buf = get_state('prompt_buf')
+        local transcript_win = get_state("transcript_win")
+        local prompt_win = get_state("prompt_win")
+        local prompt_buf = get_state("prompt_buf")
         local current_win = vim.api.nvim_get_current_win()
         local prompt_cursor = nil
 
@@ -600,13 +807,13 @@ function M.create(config)
         with_autohide_suppressed(function()
             if is_valid_win(transcript_win) then
                 vim.api.nvim_win_call(transcript_win, function()
-                    vim.cmd('silent keepalt keepjumps edit!')
-                    vim.cmd('normal! G')
+                    vim.cmd("silent keepalt keepjumps edit!")
+                    vim.cmd("normal! G")
                 end)
             end
 
             if is_valid_win(prompt_win) and is_valid_buf(prompt_buf) and prompt_cursor then
-                set_state('prompt_cursor', prompt_cursor)
+                set_state("prompt_cursor", prompt_cursor)
                 restore_prompt_cursor(prompt_win, prompt_buf)
             end
 
@@ -615,7 +822,7 @@ function M.create(config)
             end
         end)
 
-        pcall(vim.cmd, 'redraw!')
+        pcall(vim.cmd, "redraw!")
     end
     return layout
 end

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -135,6 +135,119 @@ validateExcerpts = true      # reject hallucinated snippets at the tool layer
 [ai.chat.approval]
 mode = "strict"             # "strict" | "yolo"
 
+# ============================================================================
+# Chat / agent streaming UI (transcript pane)
+# ============================================================================
+#
+# Tunables for how the nvim transcript pane renders streaming model output.
+# Both the chat and the agent share these values. Changes take effect on the
+# next chat/agent session start.
+#
+# Each option is documented on its own block below. Uncomment the
+# `[ai.chatInterface]` table at the bottom and override only the keys you
+# want to change.
+#
+#
+# ----------------------------------------------------------------------------
+# pacerIntervalMs            (default: 4)
+# ----------------------------------------------------------------------------
+#
+# What it does:
+#     Wake interval for the TS-side pacer that drips model chars into nvim.
+#
+# How to tune:
+#     Lower  -  faster typewriter on long outputs (queue drains more often).
+#     Higher -  slower, more deliberate cadence.
+#
+# Cap:
+#     Node clamps setInterval to ~4 ms, so values below 4 have no effect.
+#
+#
+# ----------------------------------------------------------------------------
+# pacerMinChars              (default: 1)
+# ----------------------------------------------------------------------------
+#
+# What it does:
+#     Minimum chars emitted per tick when the queue is small.
+#
+# How to tune:
+#     1   -  strict 1-char-per-tick typewriter feel.
+#     >1  -  brisker baseline cadence, but bigger visible jumps per tick.
+#
+#
+# ----------------------------------------------------------------------------
+# pacerDivisor               (default: 64)
+# ----------------------------------------------------------------------------
+#
+# What it does:
+#     Proportional drain factor for big bursts. Per tick we emit
+#     `max(pacerMinChars, ceil(queue_len / pacerDivisor))`.
+#
+# How to tune:
+#     Higher  -  tighter typewriter feel even with a huge backlog (slower
+#                catch-up).
+#     Lower   -  faster catch-up, but output starts to look chunked.
+#
+# Note:
+#     64 lets ~250 char/s through without the queue growing unbounded.
+#
+#
+# ----------------------------------------------------------------------------
+# scrollTickMs               (default: 16)
+# ----------------------------------------------------------------------------
+#
+# What it does:
+#     Lua-side smooth-scroll animator tick interval, in milliseconds.
+#     The animator advances the cursor toward the latest appended line a
+#     few rows at a time so the viewport scrolls fluidly instead of
+#     snapping in one jump per newline.
+#
+# How to tune:
+#     16 ≈ 60 Hz, which matches most terminals.
+#     Lower   -  smoother but more CPU.
+#     Higher  -  visibly steppier scroll.
+#
+#
+# ----------------------------------------------------------------------------
+# scrollAcceleration         (default: 8)
+# ----------------------------------------------------------------------------
+#
+# What it does:
+#     Catch-up factor for the smooth-scroll animator. When the cursor is
+#     N rows behind the target line, the animator advances
+#     `max(1, floor(N / scrollAcceleration))` rows per tick.
+#
+# How to tune:
+#     Higher  -  gentler scroll, more 1-row ticks; can lag long responses.
+#     Lower   -  snappier catch-up, closer to an instant jump on big bursts.
+#
+#
+# ----------------------------------------------------------------------------
+# appendDebounceMs           (default: 0)
+# ----------------------------------------------------------------------------
+#
+# What it does:
+#     Extra defer between a TS append rpcnotify and the Lua buffer flush.
+#
+# How to tune:
+#     0   -  flush on the next event-loop tick. Same-tick batches are still
+#            coalesced via vim.defer_fn, so this is the typical setting.
+#     >0  -  manually re-clump appends. Only useful if you're hitting RPC
+#            throughput issues; otherwise it just makes the stream feel
+#            chunkier.
+#
+#
+# ----------------------------------------------------------------------------
+# Defaults table — uncomment and edit any value you want to change.
+# ----------------------------------------------------------------------------
+[ai.chatInterface]
+pacerIntervalMs    = 4
+pacerMinChars      = 1
+pacerDivisor       = 64
+scrollTickMs       = 16
+scrollAcceleration = 8
+appendDebounceMs   = 0
+
 # ─── Quota dashboard (`kra ai quota-agent`) ──────────────────────────────────
 # Per-provider toggles for which sections the quota dashboard renders, and
 # whether the in-session quota tracker emits warnings when thresholds are

--- a/src/AI/AIAgent/shared/fileContext/format.ts
+++ b/src/AI/AIAgent/shared/fileContext/format.ts
@@ -41,12 +41,11 @@ export async function withDiagnostics(filePath: string, summary: string): Promis
 }
 
 /**
- * Render a 1-indexed slice of `lines` with right-padded line numbers.
- * Shared between read_lines (single + multi-range) and read_function so the
- * numbering format stays in lock-step across tools.
+ * Render a 1-indexed slice of `lines` as raw text. Line numbers are surfaced
+ * via the surrounding header (`Lines X\u2013Y:`) only — callers don't need
+ * per-line prefixes since `anchor_edit` is content-addressed (anchors must
+ * match the file verbatim) and line numbers would just be noise.
  */
 export function numberLines(lines: string[], start: number, end: number): string {
-    return lines.slice(start - 1, end)
-        .map((l, i) => `${String(start + i).padStart(5)}: ${l}`)
-        .join('\n');
+    return lines.slice(start - 1, end).join('\n');
 }

--- a/src/AI/AIAgent/shared/fileContext/tools.ts
+++ b/src/AI/AIAgent/shared/fileContext/tools.ts
@@ -13,7 +13,7 @@ export const TOOLS = [
 
     {
         name: 'read_lines',
-        description: 'Returns specific lines from a file (1-indexed, inclusive); each prefixed with its line number for use as an anchor. Up to 150 lines per call; larger reads on structured files are bounced back to get_outline (unstructured files are never gated). Hard cap 500 lines (summed across ranges). Supports multiple ranges via parallel startLines/endLines arrays — prefer that over multiple calls.',
+        description: 'Returns specific lines from a file (1-indexed, inclusive). Up to 150 lines per call; larger reads on structured files are bounced back to get_outline (unstructured files are never gated). Hard cap 500 lines (summed across ranges). Supports multiple ranges via parallel startLines/endLines arrays — prefer that over multiple calls.',
         inputSchema: {
             type: 'object',
             properties: {

--- a/src/AI/AIAgent/shared/main/agentNeovimSetup.ts
+++ b/src/AI/AIAgent/shared/main/agentNeovimSetup.ts
@@ -6,6 +6,7 @@ import { openVim } from '@/utils/neovimHelper';
 import { neovimConfig } from '@/filePaths';
 import * as aiNeovimHelper from '@/AI/shared/conversation';
 import { formatUserDraftHeader } from '@/AI/shared/utils/conversationUtils/chatHeaders';
+import { loadSettings } from '@/utils/common';
 const AGENT_PROMPT_ACTIONS = [
     ['ReviewProposal', 'review_proposal'],
     ['OpenProposalFile', 'open_proposal_file'],
@@ -72,7 +73,13 @@ export async function setupAgentSplitLayout(
     channelId: number,
     chatFile: string
 ): Promise<void> {
-    await nvimClient.executeLua(`require('kra_agent_layout').setup(...)`, [channelId, chatFile]);
+    const iface = (await loadSettings()).ai?.chatInterface;
+    const opts = {
+        scroll_tick_ms: iface?.scrollTickMs ?? 16,
+        scroll_acceleration: iface?.scrollAcceleration ?? 8,
+        append_debounce_ms: iface?.appendDebounceMs ?? 0,
+    };
+    await nvimClient.executeLua(`require('kra_agent_layout').setup(...)`, [channelId, chatFile, opts]);
 }
 
 
@@ -117,6 +124,28 @@ export function appendToAgentChatLayout(nvimClient: neovim.NeovimClient, text: s
     } catch {
         // Ignore — UI updates are best-effort.
     }
+}
+
+// See aiNeovimHelper.streamingStarted/Ended — same idea, agent layout.
+// Bracket each streaming response so render-markdown.nvim is suspended on
+// the transcript buffer between calls and we get a single styled repaint
+// at the end instead of per-chunk extmark recomputes.
+export function streamingStartedAgent(nvimClient: neovim.NeovimClient): void {
+    try {
+        nvimClient.notify('nvim_exec_lua', [
+            `require('kra_agent_layout').streaming_started()`,
+            [],
+        ]);
+    } catch { /* best-effort */ }
+}
+
+export function streamingEndedAgent(nvimClient: neovim.NeovimClient): void {
+    try {
+        nvimClient.notify('nvim_exec_lua', [
+            `require('kra_agent_layout').streaming_ended()`,
+            [],
+        ]);
+    } catch { /* best-effort */ }
 }
 
 export async function openAgentNeovim(chatFile: string): Promise<neovim.NeovimClient> {

--- a/src/AI/AIAgent/shared/utils/agentSessionEvents.ts
+++ b/src/AI/AIAgent/shared/utils/agentSessionEvents.ts
@@ -18,6 +18,7 @@ import * as bash from '@/utils/bashHelper';
 import { appendToChat } from '@/AI/AIAgent/shared/utils/agentToolHook';
 import type { AgentConversationState, AgentSession } from '@/AI/AIAgent/shared/types/agentTypes';
 import { setupQuotaTracking } from '@/AI/AIAgent/shared/utils/agentQuotaTracker';
+import { loadSettings } from '@/utils/common';
 
 function quote(value: string): string {
     return `'${value.replace(/'/g, `'\\''`)}'`;
@@ -198,7 +199,13 @@ export async function setupSessionEventHandlers(
     session: AgentSession = state.session,
     opts: SessionEventHandlerOptions = {}
 ): Promise<void> {
-    const FLUSH_INTERVAL_MS = 10;
+    // Smoothness pacer cadence. Defaults produce a 1-by-1 typewriter at
+    // ~250 chars/sec; bursts catch up via proportional drain so we never
+    // fall behind the model. See `[ai.chatInterface]` in settings.toml.example.
+    const iface = (await loadSettings()).ai?.chatInterface;
+    const PACER_INTERVAL_MS = iface?.pacerIntervalMs ?? 4;
+    const PACER_MIN_CHARS = iface?.pacerMinChars ?? 1;
+    const PACER_DIVISOR = iface?.pacerDivisor ?? 64;
     const agentLabel = opts.agentLabel;
     const labelTag = agentLabel ? `[${agentLabel}] ` : '';
     const isSubAgent = agentLabel !== undefined;
@@ -237,13 +244,21 @@ export async function setupSessionEventHandlers(
 
     let needsBlockquotePrefix = true;
 
-    const flushBuffer = (): void => {
+    // `force=true` drains everything (used at end-of-turn so the user
+    // doesn't watch the tail typewriter-trickle after the model is done).
+    const flushBuffer = (force = false): void => {
         if (!pendingBuffer) {
             return;
         }
 
-        const text = pendingBuffer;
-        pendingBuffer = '';
+        const drainCount = force
+            ? pendingBuffer.length
+            : Math.min(
+                pendingBuffer.length,
+                Math.max(PACER_MIN_CHARS, Math.ceil(pendingBuffer.length / PACER_DIVISOR)),
+            );
+        const text = pendingBuffer.slice(0, drainCount);
+        pendingBuffer = pendingBuffer.slice(drainCount);
         if (isSubAgent) {
             // Sub-agent output renders as a markdown blockquote so it stays
             // visually grouped under the sub-agent header. Each line in the
@@ -259,11 +274,9 @@ export async function setupSessionEventHandlers(
         }
     };
 
-    // Flush AI text every FLUSH_INTERVAL_MS so streaming is visible.
-    // Uses a self-scheduling setTimeout rather than setInterval so the timer
-    // goes completely dormant when there is nothing to flush (e.g. while the
-    // agent is paused waiting for user input). An active setInterval keeps the
-    // event loop alive and prevents V8 from running a full GC cycle.
+    // Pacer drains a fraction of pendingBuffer each tick. Self-scheduling
+    // setTimeout so the timer goes fully dormant when there's nothing to
+    // flush (avoids keeping the event loop hot between turns).
     let flushTimerHandle: ReturnType<typeof setTimeout> | null = null;
 
     const scheduleFlush = (): void => {
@@ -271,13 +284,12 @@ export async function setupSessionEventHandlers(
         flushTimerHandle = setTimeout(() => {
             flushTimerHandle = null;
             if (pendingBuffer && activeToolCount === 0) {
-                flushBuffer();
+                flushBuffer(false);
             }
-            // Keep rescheduling only while there is content waiting.
             if (pendingBuffer) {
                 scheduleFlush();
             }
-        }, FLUSH_INTERVAL_MS);
+        }, PACER_INTERVAL_MS);
     };
 
     const clearFlushTimer = (): void => {
@@ -403,7 +415,9 @@ export async function setupSessionEventHandlers(
     session.on('session.idle', () => {
         void (async () => {
             clearFlushTimer();
-            flushBuffer();
+            // Force-drain the remaining buffer so the user doesn't watch a
+            // typewriter tail after the model has already finished.
+            flushBuffer(true);
 
             await writeChain;
 

--- a/src/AI/AIChat/main/conversation.ts
+++ b/src/AI/AIChat/main/conversation.ts
@@ -5,6 +5,7 @@ import { aiRoles } from '@/AI/shared/data/roles';
 import { promptModel } from '@/AI/AIChat/utils/promptModel';
 import { createChatApprovalState, type ChatApprovalState } from '@/AI/AIChat/utils/chatToolApproval';
 import { loadChatApprovalSettings } from '@/AI/AIChat/utils/chatApprovalSettings';
+import { loadSettings } from '@/utils/common';
 import { saveChat } from '@/AI/AIChat/utils/saveChat';
 import { ChatHistory, Role, StreamController } from '@/AI/shared/types/aiTypes'
 import * as bash from '@/utils/bashHelper';
@@ -219,9 +220,43 @@ async function handleStreamingResponse(
     controller: StreamController
 ): Promise<void> {
     let pendingBuffer = '';
-    let lastUpdate = Date.now();
-    const updateInterval = 16;
     let trailingNewlines = 0;
+
+    // Smoothness pacer. Defaults produce a 1-by-1 typewriter at ~250 chars/sec;
+    // bursts catch up via proportional drain so we never fall behind the model.
+    // See `[ai.chatInterface]` in settings.toml.example for tuning notes.
+    const iface = (await loadSettings()).ai?.chatInterface;
+    const PACER_INTERVAL_MS = iface?.pacerIntervalMs ?? 4;
+    const PACER_MIN_CHARS = iface?.pacerMinChars ?? 1;
+    const PACER_DIVISOR = iface?.pacerDivisor ?? 64;
+    let pacerTimer: ReturnType<typeof setInterval> | null = null;
+    const flushPacedBatch = (force = false): void => {
+        if (!pendingBuffer) return;
+        const drainCount = force
+            ? pendingBuffer.length
+            : Math.min(
+                pendingBuffer.length,
+                Math.max(PACER_MIN_CHARS, Math.ceil(pendingBuffer.length / PACER_DIVISOR)),
+            );
+        const slice = pendingBuffer.slice(0, drainCount);
+        pendingBuffer = pendingBuffer.slice(drainCount);
+        aiNeovimHelper.appendToChatLayout(nvim, slice);
+        enqueueDiskWrite(slice);
+    };
+    const startPacer = (): void => {
+        if (pacerTimer !== null) return;
+        pacerTimer = setInterval(() => flushPacedBatch(false), PACER_INTERVAL_MS);
+    };
+    const stopPacer = (): void => {
+        if (pacerTimer === null) return;
+        clearInterval(pacerTimer);
+        pacerTimer = null;
+    };
+
+    let writeChain: Promise<void> = Promise.resolve();
+    const enqueueDiskWrite = (text: string): void => {
+        writeChain = writeChain.then(async () => appendToChat(chatFile, text)).catch(() => { /* swallow */ });
+    };
 
     const normalize = (chunk: string): string => {
         let out = '';
@@ -241,30 +276,27 @@ async function handleStreamingResponse(
     };
 
     try {
+        startPacer();
         for await (const chunk of response) {
             if (controller.isAborted) {
                 break;
             }
-
             pendingBuffer += normalize(chunk);
-
-            if (Date.now() - lastUpdate >= updateInterval) {
-                if (pendingBuffer) {
-                    await appendToChat(chatFile, pendingBuffer);
-                    aiNeovimHelper.appendToChatLayout(nvim, pendingBuffer);
-                    pendingBuffer = '';
-                }
-                lastUpdate = Date.now();
-            }
         }
 
-        if (pendingBuffer && !controller.isAborted) {
-            await appendToChat(chatFile, pendingBuffer);
-            aiNeovimHelper.appendToChatLayout(nvim, pendingBuffer);
+        // Stream finished — stop the pacer and dump whatever's left in one
+        // shot so the user doesn't wait an extra ~200 ms watching the tail
+        // drain at typewriter speed after the model is already done.
+        stopPacer();
+        if (!controller.isAborted) {
+            flushPacedBatch(true);
         }
 
+        await writeChain;
         await aiNeovimHelper.refreshChatLayout(nvim);
     } catch (error: unknown) {
+        // Make sure the pacer is dead even if the stream blew up.
+        stopPacer();
         if (!controller.isAborted) {
             throw error;
         }

--- a/src/AI/shared/utils/conversationUtils/aiNeovimHelper.ts
+++ b/src/AI/shared/utils/conversationUtils/aiNeovimHelper.ts
@@ -2,6 +2,7 @@ import { StreamController } from "@/AI/shared/types/aiTypes";
 import { NeovimClient } from "neovim";
 import os from 'os';
 import * as fs from 'fs/promises';
+import { loadSettings } from '@/utils/common';
 
 export async function handleStopStream(currentStreamController: StreamController | null, nvim: NeovimClient): Promise<void> {
     if (currentStreamController && !currentStreamController.isAborted) {
@@ -115,7 +116,13 @@ export async function setupKeyBindings(nvim: NeovimClient): Promise<void> {
 }
 
 export async function setupChatSplitLayout(nvim: NeovimClient, channelId: number, chatFile: string): Promise<void> {
-    await nvim.executeLua(`require('kra_chat_layout').setup(...)`, [channelId, chatFile]);
+    const iface = (await loadSettings()).ai?.chatInterface;
+    const opts = {
+        scroll_tick_ms: iface?.scrollTickMs ?? 16,
+        scroll_acceleration: iface?.scrollAcceleration ?? 8,
+        append_debounce_ms: iface?.appendDebounceMs ?? 0,
+    };
+    await nvim.executeLua(`require('kra_chat_layout').setup(...)`, [channelId, chatFile, opts]);
 }
 
 export async function getChatPromptText(nvim: NeovimClient): Promise<string> {
@@ -151,6 +158,29 @@ export function appendToChatLayout(nvim: NeovimClient, text: string): void {
     } catch {
         // Best-effort UI update.
     }
+}
+
+// Fire-and-forget hooks that bracket a streaming response. The Lua side
+// suspends render-markdown.nvim on the transcript buffer between these
+// two calls so per-chunk redraws don't pay for an extmark recompute over
+// the entire visible window every flush. `streaming_ended` re-enables it
+// for one final styled repaint.
+export function streamingStarted(nvim: NeovimClient): void {
+    try {
+        nvim.notify('nvim_exec_lua', [
+            `require('kra_chat_layout').streaming_started()`,
+            [],
+        ]);
+    } catch { /* best-effort */ }
+}
+
+export function streamingEnded(nvim: NeovimClient): void {
+    try {
+        nvim.notify('nvim_exec_lua', [
+            `require('kra_chat_layout').streaming_ended()`,
+            [],
+        ]);
+    } catch { /* best-effort */ }
 }
 
 export async function updateNvimAndGoToLastLine(nvim: NeovimClient): Promise<void> {

--- a/src/types/settingsTypes.ts
+++ b/src/types/settingsTypes.ts
@@ -87,6 +87,15 @@ export type WebSettings = {
     fetchMaxConcurrent?: number,
 }
 
+export type ChatInterfaceSettings = {
+    pacerIntervalMs?: number,
+    pacerMinChars?: number,
+    pacerDivisor?: number,
+    scrollTickMs?: number,
+    scrollAcceleration?: number,
+    appendDebounceMs?: number,
+}
+
 export type Settings = {
     autosave: Autosave,
 
@@ -94,6 +103,7 @@ export type Settings = {
         agent?: AgentSettings,
         docs?: DocsSettings,
         web?: WebSettings,
+        chatInterface?: ChatInterfaceSettings,
     },
     lsp?: Record<string, LspServerSettings>,
 }


### PR DESCRIPTION
Stream chunks were rendering in visible jumps. Added a TS-side pacer that drains the model output at a steady cadence (chat + agent), and a Lua-side smooth-scroll animator that walks the cursor toward the tail a few rows per tick instead of snapping on every newline.

All knobs (pacer interval / min / divisor, scroll tick / acceleration, append debounce) are exposed under `[ai.chatInterface]` in settings.toml.example, with defaults that produce a ~250 char/sec typewriter feel.