### PR TITLE
fix: reduce memory usage

### DIFF
--- a/ai-files/init.lua
+++ b/ai-files/init.lua
@@ -18,7 +18,6 @@ if not vim.loop.fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
--- Load plugins
 require("lazy").setup({
     -- Stunning markdown rendering optimized for chat
     {
@@ -520,7 +519,7 @@ require("lazy").setup({
     {
         "folke/tokyonight.nvim",
         lazy = false,
-        priority = 1000,
+priority = 1000,
         config = function()
             vim.cmd.colorscheme("tokyonight-night")
         end,
@@ -711,3 +710,21 @@ vim.api.nvim_create_autocmd("ColorScheme", {
 
 -- Apply colors immediately
 setup_markdown_colors()
+
+-- Periodic GC: long-running embed accumulates lua allocations from plugin
+-- TextChanged/CursorMoved/redraw callbacks; vim's incremental GC isn't
+-- aggressive enough to keep up. A manual collect every 30s drops the heap
+-- back to a sane baseline (observed 326 MB -> 175 MB on forced collect).
+-- collectgarbage('collect') is a full stop-the-world cycle but at 30s cadence
+-- it's imperceptible.
+local _kra_gc_timer = (vim.uv or vim.loop).new_timer()
+_kra_gc_timer:start(30000, 30000, vim.schedule_wrap(function()
+    collectgarbage("collect")
+end))
+vim.api.nvim_create_autocmd("VimLeavePre", {
+    once = true,
+    callback = function()
+        pcall(function() _kra_gc_timer:stop() end)
+        pcall(function() _kra_gc_timer:close() end)
+    end,
+})

--- a/ai-files/lua/kra_agent/diff/history.lua
+++ b/ai-files/lua/kra_agent/diff/history.lua
@@ -2,6 +2,37 @@ local M = {}
 
 local state = require("kra_agent.diff.state")
 local helpers = require("kra_agent.diff.helpers")
+local spill = require("kra_agent.util.spill")
+
+-- Loads the line tables that were spilled to disk by finalize_pending_diff.
+-- Returns (current_lines, applied_lines, proposed_lines), each a list of
+-- strings (or {} on failure). Kept local so we can swap the storage backend
+-- without touching the diff-rendering code that calls it.
+local function load_entry_lines(entry)
+    local crlf = entry.current_crlf or false
+    local current = (entry.current_sha and spill.load_lines(entry.current_sha, crlf))
+        or entry.current_lines -- fallback for legacy entries
+        or {}
+    local applied = (entry.applied_sha and spill.load_lines(entry.applied_sha, crlf))
+        or entry.applied_lines
+    local proposed = (entry.proposed_sha and spill.load_lines(entry.proposed_sha, crlf))
+        or entry.proposed_lines
+    return current, applied, proposed
+end
+
+-- Loads the pre-session original lines for a path. Handles both the new
+-- sha-ref layout and any legacy table-of-lines entries that may still be in
+-- memory from before the disk-back refactor.
+local function load_original_lines(path)
+    local entry = state.original_by_path[path]
+    if entry == nil then return nil end
+    if type(entry) == "string" then
+        local crlf = state.crlf_by_path[path] or false
+        return spill.load_lines(entry, crlf)
+    end
+    -- Legacy: still a list of lines.
+    return entry
+end
 
 -- Opens a focused 2-pane revert view.
 -- LEFT = current on-disk content, RIGHT = pre-session original (editable).
@@ -118,8 +149,9 @@ local function open_history_diff_view(entry)
     local diff_tab = vim.api.nvim_get_current_tabpage()
 
     -- LEFT: before (read-only reference)
+    local cur_lines, app_lines, prop_lines = load_entry_lines(entry)
     local left_buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, entry.current_lines or {})
+    vim.api.nvim_buf_set_lines(left_buf, 0, -1, false, cur_lines or {})
     vim.bo[left_buf].modifiable = false
     vim.bo[left_buf].filetype = ft
     local left_win = vim.api.nvim_get_current_win()
@@ -131,7 +163,7 @@ local function open_history_diff_view(entry)
     -- RIGHT: proposed (editable — <leader>a to apply to disk)
     vim.cmd("vsplit")
     local right_buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, entry.applied_lines or entry.proposed_lines or {})
+    vim.api.nvim_buf_set_lines(right_buf, 0, -1, false, app_lines or prop_lines or {})
     vim.bo[right_buf].buftype = "nofile"
     vim.bo[right_buf].bufhidden = "wipe"
     vim.bo[right_buf].swapfile = false
@@ -224,8 +256,25 @@ function M.finalize_pending_diff(success)
     end
     entry.seq = #state.diff_history + 1
     entry.status = "approved"
+    local crlf = entry.current_crlf or false
+    -- Spill the heavy line tables to disk. We keep only sha refs in heap so
+    -- the history never grows past O(entries) booleans + sha strings, even
+    -- across hundreds of large-file diffs in a single session.
+    if entry.current_lines then
+        entry.current_sha = spill.spill_lines(entry.current_lines, crlf)
+        entry.current_lines = nil
+    end
+    if entry.applied_lines then
+        entry.applied_sha = spill.spill_lines(entry.applied_lines, crlf)
+        entry.applied_lines = nil
+    end
+    if entry.proposed_lines then
+        entry.proposed_sha = spill.spill_lines(entry.proposed_lines, crlf)
+        entry.proposed_lines = nil
+    end
     if not state.original_by_path[entry.path] then
-        state.original_by_path[entry.path] = entry.current_lines
+        -- Reuse the same on-disk blob (sha is content-addressed, dedup is free).
+        state.original_by_path[entry.path] = entry.current_sha
         state.crlf_by_path[entry.path] = entry.current_crlf
     end
     table.insert(state.diff_history, entry)
@@ -268,7 +317,6 @@ function M.open_diff_history()
             table.insert(results, {
                 kind = "original",
                 path = e.path,
-                original_lines = state.original_by_path[e.path] or {},
             })
         end
     end
@@ -311,12 +359,13 @@ function M.open_diff_history()
                             0,
                             -1,
                             false,
-                            state.original_by_path[item.path] or { "(no content recorded)" }
+                            load_original_lines(item.path) or { "(no content recorded)" }
                         )
                         return
                     end
                     local h = item.entry
-                    local a_lines, b_lines = h.current_lines, h.applied_lines or h.proposed_lines
+                    local cur_lines, app_lines, prop_lines = load_entry_lines(h)
+                    local a_lines, b_lines = cur_lines, app_lines or prop_lines
 
                     local hunks = vim.diff(
                         table.concat(a_lines, "\n") .. "\n",
@@ -385,7 +434,7 @@ function M.open_diff_history()
                     if sel then
                         local item = sel.value
                         if item.kind == "original" then
-                            local orig = state.original_by_path[item.path]
+                            local orig = load_original_lines(item.path)
                             if orig then
                                 open_revert_diff_editor(item.path, orig)
                             end

--- a/ai-files/lua/kra_agent/diff/state.lua
+++ b/ai-files/lua/kra_agent/diff/state.lua
@@ -5,8 +5,16 @@ M.ns = vim.api.nvim_create_namespace("kra_agent_diff")
 -- Session-wide log of write diffs the user APPROVED *and* the tool actually
 -- applied. Denied diffs (or approved-with-edits that the tool later rejected)
 -- are never recorded — see pending_diff_entries below.
+-- diff_history entries store SHA refs (current_sha / applied_sha / proposed_sha)
+-- pointing into kra_agent.util.spill on disk — NOT the line tables themselves.
+-- See kra_agent.diff.history.finalize_pending_diff for the spill point and
+-- load_entry_lines() for the inverse. This keeps the lua heap from growing
+-- O(diff_count * file_size) over a long session.
 M.diff_history = {}
-M.original_by_path = {} -- first-seen content for each path, for revert
+-- Keyed by absolute path. Value is the SHA of the pre-session file content
+-- spilled to disk (or nil if the path has never been touched). Loaded back
+-- via spill.load_lines() in the revert UI.
+M.original_by_path = {}
 M.crlf_by_path = {} -- true if the original file used CRLF line endings
 
 -- FIFO of approved diff entries waiting for the matching tool.execution_complete

--- a/ai-files/lua/kra_agent/ui/history.lua
+++ b/ai-files/lua/kra_agent/ui/history.lua
@@ -3,6 +3,21 @@ local M = {}
 local state = require("kra_agent.ui.state")
 local rpc = require("kra_agent.util.rpc")
 local json = require("kra_agent.util.json")
+local spill = require("kra_agent.util.spill")
+
+-- Tool history entries can carry tens of KB each (full args_json + full tool
+-- output). With hundreds of calls per session that adds up to multi-MB of
+-- string content held in the lua heap forever. We spill the heavy fields to
+-- disk and only keep sha refs; the popup loads them back when actually opened.
+local function load_args(entry)
+    if entry.args_sha then return spill.load(entry.args_sha) or "" end
+    return entry.args_json or ""
+end
+
+local function load_full_result(entry)
+    if entry.full_result_sha then return spill.load(entry.full_result_sha) or "" end
+    return entry.full_result or ""
+end
 
 -- Resolve the existing history entry for a given tool_call_id, falling back
 -- to the legacy single active_entry_index when no id is provided. Returns
@@ -32,14 +47,15 @@ function M.upsert_history(tool_name, details, args_json, tool_call_id)
     if entry then
         entry.details = details
         entry.updated_at = timestamp
-        if args_json and args_json ~= "" and (entry.args_json == nil or entry.args_json == "") then
-            entry.args_json = args_json
+        if args_json and args_json ~= "" and entry.args_sha == nil and (entry.args_json == nil or entry.args_json == "") then
+            entry.args_sha = spill.spill(args_json)
+            entry.args_json = nil
         end
         return entry
     end
 
     entry = {
-        args_json = args_json or "",
+        args_sha = (args_json and args_json ~= "") and spill.spill(args_json) or nil,
         details = details,
         started_at = timestamp,
         status = "running",
@@ -69,7 +85,13 @@ function M.complete_history(tool_name, details, success, full_result, tool_call_
 
     entry.title = tool_name
     entry.result = details
-    entry.full_result = (full_result and full_result ~= "") and full_result or details
+    -- Full tool output can be huge (file reads, bash output, search results).
+    -- Spill to disk and keep only the sha; the popup lazy-loads on open.
+    local raw_full = (full_result and full_result ~= "") and full_result or details
+    if raw_full and raw_full ~= "" then
+        entry.full_result_sha = spill.spill(raw_full)
+    end
+    entry.full_result = nil
     entry.details = details
     entry.status = success and "done" or "failed"
     entry.updated_at = os.date("%H:%M:%S")
@@ -86,8 +108,13 @@ local function open_history_view(entry)
     vim.cmd("tabnew")
     local view_tab = vim.api.nvim_get_current_tabpage()
 
-    local args_text = json.pretty_via_jq((entry.args_json and entry.args_json ~= "") and entry.args_json or "{}")
-    local result_text = json.pretty_via_jq(entry.full_result or entry.result or entry.details or "(no result recorded)")
+    local args_raw = load_args(entry)
+    local args_text = json.pretty_via_jq((args_raw and args_raw ~= "") and args_raw or "{}")
+    local result_raw = load_full_result(entry)
+    if not result_raw or result_raw == "" then
+        result_raw = entry.result or entry.details or "(no result recorded)"
+    end
+    local result_text = json.pretty_via_jq(result_raw)
     local is_executable = state.executable_tools[entry.title] ~= nil
 
     -- LEFT (visually right after vsplit): args JSON. Editable when the tool is
@@ -213,7 +240,8 @@ function M.show_history()
                     title = "Tool args + result",
                     define_preview = function(self, entry)
                         local item = entry.value
-                        local args = json.pretty_via_jq((item.args_json and item.args_json ~= "") and item.args_json or "(none)")
+                        local args_raw = load_args(item)
+                        local args = json.pretty_via_jq((args_raw and args_raw ~= "") and args_raw or "(none)")
                         local result = json.pretty_via_jq(item.result or item.details or "(no result)")
                         local sep = string.rep("─", 60)
                         local text = table.concat({

--- a/ai-files/lua/kra_agent/ui/notify.lua
+++ b/ai-files/lua/kra_agent/ui/notify.lua
@@ -16,17 +16,29 @@ function M.current_icon()
     return state.icon
 end
 
-function M.render_notification(timeout)
+function M.render_notification(_timeout)
+    -- STATUSLINE-ONLY mode. We used to call vim.notify() here on every
+    -- tool start / progress / finish, which created a fresh floating
+    -- window + buffer + ~17 highlight extmarks per call. nvim-notify
+    -- can't reuse the previous buffer when its timeout has already
+    -- fired (replace= silently no-ops on a dead handle), so each call
+    -- ended up allocating new C-side extmark btree pages that macOS's
+    -- allocator never returns to the OS — the dominant ~96 MB/hour
+    -- RSS climb in the embed.
+    --
+    -- The spinner glyph + status text are already shown in the lualine
+    -- statusline (see kra_agent.ui.notify.statusline() wired into
+    -- lualine_x in init.lua), so dropping the popup costs nothing
+    -- visually for the running/finished status of a tool. Errors and
+    -- ask-user prompts use direct vim.notify() / popup windows from
+    -- elsewhere and are unaffected.
+    --
+    -- We still update state.title/body/statusline in the callers (see
+    -- set_state in ui/init.lua) so :KraDiag and any future status
+    -- inspector can read them.
     if state.popups_hidden then
         return
     end
-    state.notification = vim.notify(state.body or "", state.level, {
-        title = state.title,
-        replace = state.notification,
-        timeout = timeout,
-        hide_from_history = false,
-        icon = M.current_icon(),
-    })
     M.redraw_statusline()
 end
 
@@ -58,7 +70,14 @@ function M.start_spinner()
         120,
         vim.schedule_wrap(function()
             state.spinner_index = (state.spinner_index % #spinner_frames) + 1
-            M.render_notification(false)
+            -- IMPORTANT: do NOT re-render the notification here. Each
+            -- vim.notify() call (even with replace=...) builds a fresh
+            -- floating window, buffer + extmarks; nvim-notify does not
+            -- promptly free the replaced one and we leak ~hundreds of
+            -- KB per tick. The spinner glyph is also visible in the
+            -- statusline (statusline() reads current_icon()), so a
+            -- redrawstatus is enough to animate it without leaking.
+            M.redraw_statusline()
         end)
     )
 end

--- a/ai-files/lua/kra_agent/util/spill.lua
+++ b/ai-files/lua/kra_agent/util/spill.lua
@@ -1,0 +1,130 @@
+-- kra_agent.util.spill — shared disk-backed content cache.
+--
+-- Why: two in-memory caches in the embed grow monotonically and never
+-- shrink: kra_agent.diff.state.original_by_path / diff_history (full file
+-- bytes per touched path + per recorded diff) and kra_agent.ui.state.history
+-- (full args_json + tool result per call). Both balloon the lua heap into
+-- the hundreds of MB on a long session, which is the dominant cause of the
+-- nvim --embed RSS climb (~626 MB observed on a 1600-line chat).
+--
+-- This module spills string content to a per-process temp dir, returns a
+-- SHA-1 ref, and lazy-loads it back when something actually needs it. Same
+-- mechanism is mirrored on the TS side (src/AI/AIAgent/shared/utils/
+-- agentHistory.ts) for the originalContent map there.
+--
+-- Layout:  $XDG_CACHE_HOME/nvim/kra-agent-state-nvim-<pid>/blobs/<sha>.bin
+-- Cleanup: VimLeavePre autocmd + startup sweep of dirs whose pid is dead.
+
+local M = {}
+
+local sha1 = vim.fn.sha256
+-- vim.fn.sha256 returns 64 hex chars. Not literally SHA-1, but the name is
+-- only an internal detail; we just need a stable content-addressed key.
+
+local function state_root()
+    local cache = vim.fn.stdpath("cache")
+    return cache .. "/kra-agent-state-nvim-" .. vim.fn.getpid()
+end
+
+local function blobs_dir()
+    return state_root() .. "/blobs"
+end
+
+local ensured = false
+local function ensure_dir()
+    if ensured then return end
+    vim.fn.mkdir(blobs_dir(), "p")
+    ensured = true
+end
+
+-- Spill a string to disk; return a sha ref. Idempotent — if the same content
+-- has been spilled before, we skip the write. Empty strings get a stable sha
+-- and are still spilled so loaders see a real file.
+function M.spill(content)
+    if content == nil then return nil end
+    if type(content) ~= "string" then
+        content = tostring(content)
+    end
+    ensure_dir()
+    local sha = sha1(content)
+    local path = blobs_dir() .. "/" .. sha .. ".bin"
+    if vim.fn.filereadable(path) == 0 then
+        local f = io.open(path, "wb")
+        if f then
+            f:write(content)
+            f:close()
+        end
+    end
+    return sha
+end
+
+-- Load a spilled string by sha. Returns nil if the sha is missing / unreadable.
+function M.load(sha)
+    if sha == nil then return nil end
+    local path = blobs_dir() .. "/" .. sha .. ".bin"
+    local f = io.open(path, "rb")
+    if not f then return nil end
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+-- Convenience: spill a list of lines (joined with the appropriate separator)
+-- and return the sha. Use crlf=true for files that were CRLF originally so a
+-- subsequent load_lines round-trip matches the on-disk form.
+function M.spill_lines(lines, crlf)
+    if lines == nil then return nil end
+    local sep = crlf and "\r\n" or "\n"
+    return M.spill(table.concat(lines, sep))
+end
+
+-- Inverse of spill_lines. Returns nil if the sha is missing.
+function M.load_lines(sha, crlf)
+    local content = M.load(sha)
+    if content == nil then return nil end
+    local sep = crlf and "\r\n" or "\n"
+    -- vim.split with plain=true so the CRLF separator is matched literally.
+    return vim.split(content, sep, { plain = true })
+end
+
+-- Best-effort cleanup of this process's state dir. Safe to call multiple times.
+function M.cleanup()
+    pcall(vim.fn.delete, state_root(), "rf")
+    ensured = false
+end
+
+-- Sweep state dirs whose owner pid is gone (covers SIGKILL / OOM / crashes
+-- that bypass VimLeavePre). Called once at module load.
+local function sweep_stale()
+    local cache = vim.fn.stdpath("cache")
+    local entries = vim.fn.glob(cache .. "/kra-agent-state-nvim-*", false, true)
+    for _, dir in ipairs(entries) do
+        local pid = tonumber(dir:match("kra%-agent%-state%-nvim%-(%d+)$"))
+        if pid and pid ~= vim.fn.getpid() then
+            local alive = false
+            if vim.uv and vim.uv.kill then
+                local ok = pcall(vim.uv.kill, pid, 0)
+                alive = ok
+            end
+            if not alive then
+                pcall(vim.fn.delete, dir, "rf")
+            end
+        end
+    end
+end
+
+local autocmd_registered = false
+local function register_autocmd()
+    if autocmd_registered then return end
+    autocmd_registered = true
+    pcall(vim.api.nvim_create_autocmd, "VimLeavePre", {
+        group = vim.api.nvim_create_augroup("KraAgentSpillCleanup", { clear = true }),
+        callback = function() M.cleanup() end,
+    })
+end
+
+-- Eager init at require() time: register cleanup hook and sweep stale dirs.
+register_autocmd()
+pcall(sweep_stale)
+
+return M

--- a/ai-files/lua/kra_agent_layout.lua
+++ b/ai-files/lua/kra_agent_layout.lua
@@ -6,14 +6,55 @@ local layout = require('kra_prompt_layout').create({
     transcript_winbar = ' 󰭻 CONVERSATION ',
     transcript_statusline = ' AGENT ',
     setup_transcript_buffer = function(transcript_buf)
+        -- AgentReasoning highlight: every line starting with '>' is the
+        -- model's chain-of-thought. Was previously a `:syntax match` rule,
+        -- but vim's classic regex syntax engine retains per-line state
+        -- tables that grow without bound as the transcript appends —
+        -- a long thinking section drove nvim to multi-GB RSS. Extmarks
+        -- are O(changed range) per update and don't leak across appends.
         vim.api.nvim_set_hl(0, 'AgentReasoning', { fg = '#61AFEF' })
-        vim.api.nvim_buf_call(transcript_buf, function()
-            vim.cmd('syntax match AgentReasoning /^>.*/')
-        end)
+        local ns = vim.api.nvim_create_namespace('kra_agent_reasoning')
+
+        local function highlight_line(buf, lnum)
+            local ok, lines = pcall(vim.api.nvim_buf_get_lines, buf, lnum, lnum + 1, false)
+            if not ok or not lines or not lines[1] then return end
+            if lines[1]:sub(1, 1) == '>' then
+                pcall(vim.api.nvim_buf_set_extmark, buf, ns, lnum, 0, {
+                    end_row = lnum,
+                    end_col = #lines[1],
+                    hl_group = 'AgentReasoning',
+                })
+            end
+        end
+
+        local function rescan_range(buf, first, last)
+            pcall(vim.api.nvim_buf_clear_namespace, buf, ns, first, last)
+            for i = first, last - 1 do
+                highlight_line(buf, i)
+            end
+        end
+
+        local function rescan_all(buf)
+            if not vim.api.nvim_buf_is_valid(buf) then return end
+            local n = vim.api.nvim_buf_line_count(buf)
+            rescan_range(buf, 0, n)
+        end
+
+        rescan_all(transcript_buf)
+
+        vim.api.nvim_buf_attach(transcript_buf, false, {
+            on_lines = function(_, buf, _, first_line, _last_line_old, last_line_new)
+                if not vim.api.nvim_buf_is_valid(buf) then return true end
+                vim.schedule(function()
+                    rescan_range(buf, first_line, last_line_new)
+                end)
+            end,
+        })
+
         vim.api.nvim_create_autocmd('BufReadPost', {
             buffer = transcript_buf,
             callback = function()
-                vim.cmd('syntax match AgentReasoning /^>.*/')
+                rescan_all(transcript_buf)
             end,
         })
     end,

--- a/ai-files/lua/kra_prompt_layout.lua
+++ b/ai-files/lua/kra_prompt_layout.lua
@@ -73,6 +73,10 @@ function M.create(config)
         vim.bo[prompt_buf].bufhidden = "hide"
         vim.bo[prompt_buf].swapfile = false
         vim.bo[prompt_buf].filetype = "markdown"
+        vim.bo[prompt_buf].undofile = false
+        pcall(vim.api.nvim_set_option_value, "undolevels", -1, { buf = prompt_buf })
+
+
         vim.wo[prompt_win].number = false
         vim.wo[prompt_win].relativenumber = false
         vim.wo[prompt_win].signcolumn = "no"
@@ -85,6 +89,10 @@ function M.create(config)
 
     local function set_transcript_window_options(transcript_buf, transcript_win)
         mark_buffer(transcript_buf)
+        vim.bo[transcript_buf].undofile = false
+        pcall(vim.api.nvim_set_option_value, "undolevels", -1, { buf = transcript_buf })
+
+
         vim.wo[transcript_win].winbar = config.transcript_winbar or " CONVERSATION "
         vim.wo[transcript_win].statusline = config.transcript_statusline or " TRANSCRIPT "
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
             "dependencies": {
                 "@anthropic-ai/claude-agent-sdk": "^0.2.132",
                 "@github/copilot-sdk": "^0.2.2",
-                "@google/generative-ai": "^0.21.0",
                 "@lancedb/lancedb": "^0.27.2",
                 "@modelcontextprotocol/sdk": "^1.29.0",
                 "apache-arrow": "^18.1.0",
@@ -947,13 +946,6 @@
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@google/generative-ai": {
-            "version": "0.21.0",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.0.0"
             }
         },
         "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.132",
         "@github/copilot-sdk": "^0.2.2",
-        "@google/generative-ai": "^0.21.0",
         "@lancedb/lancedb": "^0.27.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "apache-arrow": "^18.1.0",

--- a/settings.toml.example
+++ b/settings.toml.example
@@ -11,6 +11,15 @@ timeoutMs = 20000
 #
 # Run `kra ai index` once per repo to build the initial code index, then
 # enable `indexCodeOnSave` to keep it fresh in the background.
+# Lazy-spawn behaviour for the local kra-* MCP servers (file-context, memory,
+# bash, web, session-complete). They're spun up on demand and shut down after
+# this many ms of inactivity, then re-spawned on the next tool call. Default
+# 5000 ms — keeps a short "warm" window during a burst of tool calls. Set to
+# 0 to shut down immediately when idle (cold-spawn every call, ~150 ms each).
+# Set to a large number to keep them warm for the whole session.
+# [ai.agent]
+# mcpClientIdleTimeoutMs = 5000
+
 [ai.agent.memory]
 enabled = true              # master switch for the whole memory layer
 indexCodeOnStart = false    # full reindex when an agent session starts
@@ -20,6 +29,7 @@ gitignoreMemory = true      # documentation-only: whether you keep .kra-memory/ 
 # Tune the chunker (defaults are good for most repos):
 # chunkLines = 80
 # chunkOverlap = 5
+# embedderIdleTimeoutMs = 60000  # unload the in-process embedder after this many ms idle (saves ~150–300 MB native heap). 0 = keep loaded.
 # includeExtensions = [".ts", ".js", ".py", ".go", ".rs", ".md"]
 # excludeGlobs = ["node_modules/**", "dest/**", "coverage/**", ".kra-memory/**"]
 

--- a/src/AI/AIAgent/commands/subAgentProviderPicker.ts
+++ b/src/AI/AIAgent/commands/subAgentProviderPicker.ts
@@ -31,9 +31,7 @@ import {
     formatCapabilitiesSummary,
     type ModelsDevModelInfo,
 } from '@/AI/shared/data/modelsDevCatalog';
-import { OpenAICompatibleClient } from '@/AI/AIAgent/providers/byok/byokClient';
-import { CopilotClientWrapper } from '@/AI/AIAgent/providers/copilot/copilotClient';
-import { ClaudeClient, type ClaudeModelInfo } from '@/AI/AIAgent/providers/claude';
+import type { ClaudeModelInfo } from '@/AI/AIAgent/providers/claude';
 import { getGithubToken } from '@/AI/AIAgent/shared/utils/agentSettings';
 import { type ModelInfo as CopilotModelInfo } from '@github/copilot-sdk';
 import type { AgentClient, ReasoningEffort } from '@/AI/AIAgent/shared/types/agentTypes';
@@ -213,6 +211,7 @@ async function pickByokRuntime(role: AgentRole): Promise<AgentRuntimePick> {
         }
     }
 
+    const { OpenAICompatibleClient } = await import('@/AI/AIAgent/providers/byok/byokClient');
     const client = new OpenAICompatibleClient({
         baseURL: getProviderBaseURL(provider),
         apiKey: getProviderApiKey(provider),
@@ -360,6 +359,7 @@ async function pickCopilotReasoningEffort(model: CopilotModelInfo): Promise<Reas
 
 async function pickCopilotRuntime(role: AgentRole): Promise<AgentRuntimePick> {
     const githubToken = getGithubToken();
+    const { CopilotClientWrapper } = await import('@/AI/AIAgent/providers/copilot/copilotClient');
     const client = new CopilotClientWrapper({
         ...(githubToken ? { githubToken } : {}),
         useLoggedInUser: !githubToken,
@@ -408,6 +408,7 @@ async function pickCopilotRuntime(role: AgentRole): Promise<AgentRuntimePick> {
 }
 
 async function pickClaudeRuntime(role: AgentRole): Promise<AgentRuntimePick> {
+    const { ClaudeClient } = await import('@/AI/AIAgent/providers/claude');
     const client = new ClaudeClient({ useLoggedInUser: true });
     await client.start();
 

--- a/src/AI/AIAgent/providers/byok/mcpClientPool.ts
+++ b/src/AI/AIAgent/providers/byok/mcpClientPool.ts
@@ -2,11 +2,16 @@
  * MCP client pool for BYOK sessions.
  *
  * Spawns each configured local MCP server (via @modelcontextprotocol/sdk's
- * StdioClientTransport), lists its tools, and exposes a flat registry that
- * maps namespaced tool names ("<server>__<tool>") to:
- *   - the MCP client to invoke,
- *   - the original (un-namespaced) tool name,
- *   - the OpenAI-shaped function tool definition.
+ * StdioClientTransport), lists its tools, then DISCONNECTS the transport.
+ * Subsequent `callTool` invocations transparently re-spawn the server on
+ * demand and shut it back down after a configurable idle window.
+ *
+ * Why on-demand: the kra-* MCP servers (file-context, memory, bash, web,
+ * session-complete) collectively hold ~300 MB of resident node + native
+ * heap (plus any LSP children file-context spawns), even when the agent
+ * isn't actively calling them. Most agent turns hit each server in a short
+ * burst, so paying ~150 ms per cold spawn is a good trade for keeping the
+ * standing memory cost near zero between bursts.
  *
  * Honors per-server `tools` allow-list and the session-level `excludedTools`
  * filter. Remote (http/sse) MCP servers are ignored — BYOK only deals with
@@ -18,6 +23,14 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import type { MCPServerConfig } from '@/AI/AIAgent/shared/types/mcpConfig';
 import { matchesSubAgentWhitelist } from '@/AI/AIAgent/shared/subAgents/whitelist';
 import { getActiveSearchRepoKeys } from '@/AI/AIAgent/shared/memory/groups';
+import { loadSettings } from '@/utils/common';
+
+export interface ToolClient {
+    callTool(req: { name: string; arguments: Record<string, unknown> }): Promise<{
+        content?: Array<{ type: string; text?: string }>;
+        [k: string]: unknown;
+    }>;
+}
 
 export interface RegisteredTool {
     server: string;
@@ -25,7 +38,7 @@ export interface RegisteredTool {
     namespacedName: string;
     description: string;
     inputSchema: Record<string, unknown>;
-    client: Client;
+    client: ToolClient;
 }
 
 export interface McpClientPool {
@@ -51,6 +64,36 @@ interface BuildPoolOptions {
     workingDirectory: string;
 }
 
+interface LazyClientSpec {
+    serverName: string;
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+    cwd?: string;
+    idleTimeoutMs: number;
+}
+
+const DEFAULT_MCP_IDLE_TIMEOUT_MS = 5_000;
+const MAX_MCP_IDLE_TIMEOUT_MS = 3_600_000;
+
+async function loadMcpClientIdleTimeoutMs(): Promise<number> {
+    try {
+        const settings = await loadSettings();
+        const raw = settings.ai?.agent?.mcpClientIdleTimeoutMs;
+        if (typeof raw === 'number' && Number.isFinite(raw)) {
+            const i = Math.round(raw);
+            if (i < 0) return 0;
+            if (i > MAX_MCP_IDLE_TIMEOUT_MS) return MAX_MCP_IDLE_TIMEOUT_MS;
+
+            return i;
+        }
+    } catch {
+        // Settings unavailable — fall back to default.
+    }
+
+    return DEFAULT_MCP_IDLE_TIMEOUT_MS;
+}
+
 function namespacedToolName(server: string, tool: string): string {
     const safeServer = server.replace(/[^a-zA-Z0-9_-]/g, '_');
     const safeTool = tool.replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -58,9 +101,166 @@ function namespacedToolName(server: string, tool: string): string {
     return `${safeServer}__${safeTool}`;
 }
 
+/**
+ * Lazy stdio MCP client. Spawns the server on first `callTool` (or via the
+ * helper `withConnection` used at build time for `tools/list`), reuses the
+ * connection across overlapping calls, and shuts down after `idleTimeoutMs`
+ * of inactivity. Refcounts in-flight calls so an idle timer never fires
+ * while work is pending.
+ */
+class LazyClient implements ToolClient {
+    private readonly spec: LazyClientSpec;
+    private client: Client | undefined;
+    private connecting: Promise<Client> | undefined;
+    private inflight = 0;
+    private idleTimer: NodeJS.Timeout | undefined;
+    private closed = false;
+
+    public constructor(spec: LazyClientSpec) {
+        this.spec = spec;
+    }
+
+    public async callTool(req: { name: string; arguments: Record<string, unknown> }): Promise<{
+        content?: Array<{ type: string; text?: string }>;
+        [k: string]: unknown;
+    }> {
+        const client = await this.acquire();
+        try {
+            return (await client.callTool(req)) as {
+                content?: Array<{ type: string; text?: string }>;
+                [k: string]: unknown;
+            };
+        } finally {
+            this.release();
+        }
+    }
+
+    /**
+     * Acquire a connected `Client`. Used by `buildMcpClientPool` to perform
+     * the initial `tools/list` enumeration; the caller MUST `release()` once
+     * done so the idle timer can re-arm.
+     */
+    public async withConnection<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+        const client = await this.acquire();
+        try {
+            return await fn(client);
+        } finally {
+            this.release();
+        }
+    }
+
+    public async close(): Promise<void> {
+        this.closed = true;
+        this.cancelIdleTimer();
+        // Wait briefly for in-flight calls to drain; in practice the pool is
+        // disconnected only at session teardown, after the orchestrator stops
+        // issuing tool calls.
+        const deadline = Date.now() + 5_000;
+        while (this.inflight > 0 && Date.now() < deadline) {
+            await new Promise((r) => setTimeout(r, 25));
+        }
+        await this.shutdownTransport();
+    }
+
+    private async acquire(): Promise<Client> {
+        if (this.closed) {
+            throw new Error(`MCP client for '${this.spec.serverName}' is closed`);
+        }
+        this.cancelIdleTimer();
+        this.inflight++;
+
+        if (this.client) {
+            return this.client;
+        }
+
+        if (!this.connecting) {
+            this.connecting = this.spawn();
+        }
+        try {
+            const client = await this.connecting;
+            this.client = client;
+
+            return client;
+        } catch (err) {
+            this.inflight--;
+            this.connecting = undefined;
+            throw err;
+        }
+    }
+
+    private release(): void {
+        if (this.inflight > 0) this.inflight--;
+        if (this.inflight === 0 && !this.closed) {
+            this.scheduleIdleShutdown();
+        }
+    }
+
+    private scheduleIdleShutdown(): void {
+        const ms = this.spec.idleTimeoutMs;
+        if (ms <= 0) {
+            // 0 ⇒ shut down immediately when idle (cold-spawn every call).
+            void this.shutdownTransport();
+
+            return;
+        }
+        this.cancelIdleTimer();
+        this.idleTimer = setTimeout(() => {
+            this.idleTimer = undefined;
+            if (this.inflight === 0 && !this.closed) {
+                void this.shutdownTransport();
+            }
+        }, ms);
+        this.idleTimer.unref();
+    }
+
+    private cancelIdleTimer(): void {
+        if (this.idleTimer) {
+            clearTimeout(this.idleTimer);
+            this.idleTimer = undefined;
+        }
+    }
+
+    private async spawn(): Promise<Client> {
+        const transport = new StdioClientTransport({
+            command: this.spec.command,
+            args: this.spec.args,
+            env: this.spec.env,
+            ...(this.spec.cwd ? { cwd: this.spec.cwd } : {}),
+        });
+        const client = new Client(
+            { name: 'kra-byok-agent', version: '1.0.0' },
+            { capabilities: {} }
+        );
+        try {
+            await client.connect(transport);
+        } catch (err) {
+            this.connecting = undefined;
+            const message = err instanceof Error ? err.message : String(err);
+            throw new Error(`Failed to connect MCP server '${this.spec.serverName}': ${message}`);
+        }
+        this.connecting = undefined;
+        // Keep a reference so V8 doesn't GC the transport while client owns it.
+        void transport;
+
+        return client;
+    }
+
+    private async shutdownTransport(): Promise<void> {
+        const client = this.client;
+        this.client = undefined;
+        this.connecting = undefined;
+        if (!client) return;
+        try {
+            await client.close();
+        } catch {
+            // Best-effort; the child may already be gone.
+        }
+    }
+}
+
 export async function buildMcpClientPool(options: BuildPoolOptions): Promise<McpClientPool> {
     const tools = new Map<string, RegisteredTool>();
-    const clients: Client[] = [];
+    const lazyClients: LazyClient[] = [];
     const excluded = new Set(options.excludedTools ?? []);
     const allowedSet = options.allowedTools ? new Set(options.allowedTools) : null;
 
@@ -69,6 +269,7 @@ export async function buildMcpClientPool(options: BuildPoolOptions): Promise<Mcp
     // (memoryMcpServer falls back to WORKING_DIR's repo on its own).
     const activeRepoKeys = await getActiveSearchRepoKeys();
     const searchRepoKeysEnv = activeRepoKeys.length > 0 ? activeRepoKeys.join(',') : '';
+    const idleTimeoutMs = await loadMcpClientIdleTimeoutMs();
 
     for (const [serverName, config] of Object.entries(options.servers)) {
         if (config.type !== 'local' && config.type !== 'stdio') {
@@ -84,29 +285,26 @@ export async function buildMcpClientPool(options: BuildPoolOptions): Promise<Mcp
             ...(searchRepoKeysEnv ? { KRA_SEARCH_REPO_KEYS: searchRepoKeysEnv } : {}),
         };
 
-        const transport = new StdioClientTransport({
+        const lazyClient = new LazyClient({
+            serverName,
             command: config.command,
             args: config.args ?? [],
             env,
             ...(config.cwd ? { cwd: config.cwd } : {}),
+            idleTimeoutMs,
         });
 
-        const client = new Client(
-            { name: 'kra-byok-agent', version: '1.0.0' },
-            { capabilities: {} }
-        );
-
+        const allowList = config.tools ? new Set(config.tools) : null;
+        let listed: { tools: Array<{ name: string; description?: string | undefined; inputSchema?: unknown }> };
         try {
-            await client.connect(transport);
+            listed = await lazyClient.withConnection(async (client) => client.listTools());
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
-            throw new Error(`Failed to connect MCP server '${serverName}': ${message}`);
+            await lazyClient.close().catch(() => undefined);
+            throw new Error(`Failed to enumerate MCP server '${serverName}': ${message}`);
         }
 
-        clients.push(client);
-
-        const allowList = config.tools ? new Set(config.tools) : null;
-        const listed = await client.listTools();
+        lazyClients.push(lazyClient);
 
         for (const tool of listed.tools) {
             if (allowList && !allowList.has(tool.name)) {
@@ -137,7 +335,7 @@ export async function buildMcpClientPool(options: BuildPoolOptions): Promise<Mcp
                     type: 'object',
                     properties: {},
                 },
-                client,
+                client: lazyClient,
             });
         }
     }
@@ -155,7 +353,7 @@ export async function buildMcpClientPool(options: BuildPoolOptions): Promise<Mcp
         tools,
         openaiTools,
         disconnect: async (): Promise<void> => {
-            await Promise.allSettled(clients.map(async (c) => c.close()));
+            await Promise.allSettled(lazyClients.map(async (c) => c.close()));
         },
     };
 }

--- a/src/AI/AIAgent/shared/memory/embedder.ts
+++ b/src/AI/AIAgent/shared/memory/embedder.ts
@@ -1,64 +1,189 @@
 /**
  * fastembed wrapper for the kra-memory layer.
  *
- * Uses BGESmallENV15 (384-dim, ~33MB quantized) for a balance of quality and
- * footprint. Model is loaded lazily on first call. The model cache lives in a
- * stable user-global directory so we don't pollute every working tree with a
- * local_cache/ folder.
+ * Runs fastembed in a SEPARATE OS process (`child_process.fork`) so that
+ * after `embedderIdleTimeoutMs` of inactivity we can `kill()` the child
+ * and the kernel reclaims the full ~450 MB ONNX runtime arena. In-process
+ * approaches (cachedModel = null, session.release(), worker_threads) all
+ * leave pages mapped to the parent PID on macOS — only a separate process
+ * gives guaranteed RSS return-to-OS.
+ *
+ * Behavior:
+ *   1. Child is forked lazily on the first embed call.
+ *   2. After `embedderIdleTimeoutMs` of no activity (default 60 s, 0
+ *      disables) the child is killed. The next embed call respawns.
+ *   3. Re-spawn cost is dominated by FlagEmbedding.init() (~160 ms once
+ *      the model file is cached on disk) plus ~80 ms node boot.
+ *
+ * Configuration:
+ *   - `[ai.agent.memory] embedder_idle_timeout_ms` in settings.toml
+ *   - `KRA_MEMORY_MODEL_CACHE` env var overrides the on-disk cache dir
  */
 
-import fs from 'fs';
 import path from 'path';
-import { EmbeddingModel, FlagEmbedding } from 'fastembed';
+import { fork, type ChildProcess } from 'child_process';
 import { kraHome } from '@/filePaths';
+import { loadMemorySettings } from './settings';
 
-const MODEL = EmbeddingModel.BGESmallENV15;
 export const VECTOR_DIM = 384;
 
-let cachedModel: FlagEmbedding | null = null;
-let pendingLoad: Promise<FlagEmbedding> | null = null;
+type PendingResponse = {
+    resolve: (vectors: number[][]) => void;
+    reject: (err: Error) => void;
+};
 
-// Serialize embed calls. fastembed/ONNX is not guaranteed to be reentrant
-// from concurrent JS callers — multi-repo parallel indexing would otherwise
-// dispatch overlapping embed batches into the same model instance.
+type ChildMessage =
+    | { type: 'ready' }
+    | { type: 'result'; id: number; vectors: number[][] }
+    | { type: 'error'; id: number; message: string };
+
+let cachedChild: ChildProcess | null = null;
+let pendingChild: Promise<ChildProcess> | null = null;
+let nextRequestId = 1;
+const pendingRequests = new Map<number, PendingResponse>();
+
+let idleTimer: NodeJS.Timeout | null = null;
+let cachedIdleTimeoutMs: number | null = null;
+
 let embedQueue: Promise<unknown> = Promise.resolve();
 
 function defaultCacheDir(): string {
     const override = process.env['KRA_MEMORY_MODEL_CACHE'];
-
-    if (override && override.length > 0) {
-        return override;
-    }
+    if (override && override.length > 0) return override;
 
     return path.join(kraHome(), 'cache', 'fastembed');
 }
 
-async function loadModel(): Promise<FlagEmbedding> {
-    if (cachedModel) {
-        return cachedModel;
+async function getIdleTimeoutMs(): Promise<number> {
+    if (cachedIdleTimeoutMs !== null) return cachedIdleTimeoutMs;
+    try {
+        const settings = await loadMemorySettings();
+        cachedIdleTimeoutMs = settings.embedderIdleTimeoutMs;
+    } catch {
+        cachedIdleTimeoutMs = 60_000;
     }
 
-    if (pendingLoad) {
-        return pendingLoad;
+    return cachedIdleTimeoutMs;
+}
+
+function clearIdleTimer(): void {
+    if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
     }
+}
 
-    const cacheDir = defaultCacheDir();
-    fs.mkdirSync(cacheDir, { recursive: true });
+function rejectAllPending(reason: Error): void {
+    for (const p of pendingRequests.values()) {
+        p.reject(reason);
+    }
+    pendingRequests.clear();
+}
 
-    pendingLoad = FlagEmbedding.init({
-        model: MODEL,
-        cacheDir,
-    }).then((model) => {
-        cachedModel = model;
-        pendingLoad = null;
+function childScriptPath(): string {
+    // After tsc, this file lives at dest/src/AI/AIAgent/shared/memory/embedder.js
+    // and the child is its sibling embedderChild.js.
+    return path.join(__dirname, 'embedderChild.js');
+}
 
-        return model;
-    }).catch((error) => {
-        pendingLoad = null;
-        throw error;
+function spawnChild(): Promise<ChildProcess> {
+    if (pendingChild) return pendingChild;
+    if (cachedChild) return Promise.resolve(cachedChild);
+
+    pendingChild = new Promise<ChildProcess>((resolve, reject) => {
+        const cp = fork(childScriptPath(), [], {
+            env: {
+                ...process.env,
+                KRA_EMBEDDER_CACHE_DIR: defaultCacheDir(),
+            },
+            // Inherit stdio so child errors show up in parent logs.
+            stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+            // Don't keep parent's event loop alive just for the child.
+            detached: false,
+        });
+
+        let ready = false;
+
+        cp.on('message', (msg: ChildMessage) => {
+            if (msg.type === 'ready') {
+                ready = true;
+                cachedChild = cp;
+                pendingChild = null;
+                resolve(cp);
+
+                return;
+            }
+            if (msg.type === 'result') {
+                const p = pendingRequests.get(msg.id);
+                if (p) {
+                    pendingRequests.delete(msg.id);
+                    p.resolve(msg.vectors);
+                }
+
+                return;
+            }
+            if (msg.type === 'error') {
+                const p = pendingRequests.get(msg.id);
+                if (p) {
+                    pendingRequests.delete(msg.id);
+                    p.reject(new Error(msg.message));
+                }
+            }
+        });
+
+        cp.on('error', (err) => {
+            if (!ready) {
+                pendingChild = null;
+                reject(err);
+            }
+            rejectAllPending(err);
+            cachedChild = null;
+        });
+
+        cp.on('exit', (code, signal) => {
+            cachedChild = null;
+            pendingChild = null;
+            if (pendingRequests.size > 0) {
+                rejectAllPending(new Error(`embedderChild exited (code=${code}, signal=${signal}) with pending requests`));
+            }
+        });
+
+        // Don't keep parent alive solely for this child.
+        try { cp.unref(); } catch { /* noop */ }
+        try { cp.channel?.unref(); } catch { /* noop */ }
     });
 
-    return pendingLoad;
+    return pendingChild;
+}
+
+function killChild(cp: ChildProcess): void {
+    // Try graceful disconnect first (the child has a 'disconnect' handler
+    // that exits cleanly), then SIGTERM, then SIGKILL.
+    try { cp.disconnect(); } catch { /* noop */ }
+    try { cp.kill('SIGTERM'); } catch { /* noop */ }
+    setTimeout(() => {
+        try {
+            if (!cp.killed && cp.exitCode === null) {
+                cp.kill('SIGKILL');
+            }
+        } catch { /* noop */ }
+    }, 1000).unref();
+}
+
+async function scheduleIdleUnload(): Promise<void> {
+    clearIdleTimer();
+    const ms = await getIdleTimeoutMs();
+    if (ms <= 0) return;
+
+    idleTimer = setTimeout(() => {
+        idleTimer = null;
+        const cp = cachedChild;
+        cachedChild = null;
+        if (!cp) return;
+        killChild(cp);
+    }, ms);
+
+    if (typeof idleTimer.unref === 'function') idleTimer.unref();
 }
 
 /**
@@ -67,7 +192,6 @@ async function loadModel(): Promise<FlagEmbedding> {
  */
 export async function embedOne(text: string): Promise<number[]> {
     const results = await embedMany([text]);
-
     if (results.length === 0) {
         throw new Error('embedOne: fastembed returned no vectors');
     }
@@ -79,27 +203,54 @@ export async function embedOne(text: string): Promise<number[]> {
  * Embed a batch of strings. Order of returned vectors matches input order.
  */
 export async function embedMany(texts: string[]): Promise<number[][]> {
-    if (texts.length === 0) {
-        return [];
-    }
+    if (texts.length === 0) return [];
+
+    clearIdleTimer();
 
     const next = embedQueue.then(async () => {
-        const model = await loadModel();
-        const out: number[][] = [];
+        const cp = await spawnChild();
+        const id = nextRequestId++;
 
-        for await (const batch of model.embed(texts, Math.min(32, texts.length))) {
-            for (const vec of batch) {
-                out.push(Array.from(vec));
+        return new Promise<number[][]>((resolve, reject) => {
+            pendingRequests.set(id, { resolve, reject });
+            try {
+                cp.send({ type: 'embed', id, texts }, (err) => {
+                    if (err) {
+                        pendingRequests.delete(id);
+                        reject(err);
+                    }
+                });
+            } catch (err) {
+                pendingRequests.delete(id);
+                reject(err instanceof Error ? err : new Error(String(err)));
             }
-        }
-
-        if (out.length !== texts.length) {
-            throw new Error(`embedMany: expected ${texts.length} vectors, got ${out.length}`);
-        }
-
-        return out;
+        });
     });
-    embedQueue = next.catch(() => undefined);
+
+    embedQueue = next
+        .catch(() => undefined)
+        .then(() => { void scheduleIdleUnload(); });
 
     return next;
 }
+
+/**
+ * Test/diagnostic hook: kill the child immediately. Safe to call anytime;
+ * in-flight `embedMany` calls will be rejected.
+ */
+export function __unloadEmbedderForTests(): void {
+    clearIdleTimer();
+    cachedIdleTimeoutMs = null;
+    const cp = cachedChild;
+    cachedChild = null;
+    pendingChild = null;
+    if (cp) killChild(cp);
+}
+
+// Make sure we don't orphan the child if the parent crashes hard.
+process.once('exit', () => {
+    const cp = cachedChild;
+    if (cp) {
+        try { cp.kill('SIGTERM'); } catch { /* noop */ }
+    }
+});

--- a/src/AI/AIAgent/shared/memory/embedderChild.ts
+++ b/src/AI/AIAgent/shared/memory/embedderChild.ts
@@ -1,0 +1,100 @@
+/**
+ * fastembed child process.
+ *
+ * Owns the FlagEmbedding model + ONNX runtime in a SEPARATE OS process
+ * (spawned via `child_process.fork`) so we can `kill()` it on idle to
+ * unconditionally return the ~450 MB native arena to the kernel.
+ * worker_threads are insufficient on macOS — they share the parent's
+ * malloc arena, so terminate() frees but does not unmap the pages.
+ *
+ * Protocol (parent <-> child):
+ *   parent -> child: { type: 'embed', id, texts }
+ *   child -> parent: { type: 'result', id, vectors } | { type: 'error', id, message }
+ *   child -> parent (one-shot at startup): { type: 'ready' }
+ */
+
+import fs from 'fs';
+import type { FlagEmbedding as FlagEmbeddingType } from 'fastembed';
+
+const cacheDir = process.env['KRA_EMBEDDER_CACHE_DIR'] ?? '';
+
+if (!cacheDir) {
+    process.stderr.write('embedderChild: missing KRA_EMBEDDER_CACHE_DIR env var\n');
+    process.exit(2);
+}
+
+if (typeof process.send !== 'function') {
+    process.stderr.write('embedderChild: not running as a forked child (process.send unavailable)\n');
+    process.exit(2);
+}
+
+const send = process.send.bind(process);
+
+let model: FlagEmbeddingType | null = null;
+let pending: Promise<FlagEmbeddingType> | null = null;
+
+async function loadModel(): Promise<FlagEmbeddingType> {
+    if (model) return model;
+    if (pending) return pending;
+
+    pending = (async () => {
+        fs.mkdirSync(cacheDir, { recursive: true });
+        const { EmbeddingModel, FlagEmbedding } = await import('fastembed');
+        const m = await FlagEmbedding.init({
+            model: EmbeddingModel.BGESmallENV15,
+            cacheDir,
+        });
+        model = m;
+        pending = null;
+
+        return m;
+    })().catch((err) => {
+        pending = null;
+        throw err;
+    });
+
+    return pending;
+}
+
+type EmbedRequest = { type: 'embed'; id: number; texts: string[] };
+
+let queue: Promise<unknown> = Promise.resolve();
+
+function handleEmbed(req: EmbedRequest): void {
+    queue = queue
+        .then(async () => {
+            const m = await loadModel();
+            const out: number[][] = [];
+
+            for await (const batch of m.embed(req.texts, Math.min(32, req.texts.length))) {
+                for (const vec of batch) {
+                    out.push(Array.from(vec));
+                }
+            }
+
+            if (out.length !== req.texts.length) {
+                throw new Error(`embedderChild: expected ${req.texts.length} vectors, got ${out.length}`);
+            }
+            send({ type: 'result', id: req.id, vectors: out });
+        })
+        .catch((err: unknown) => {
+            const message = err instanceof Error ? err.message : String(err);
+            send({ type: 'error', id: req.id, message });
+        });
+}
+
+process.on('message', (msg: unknown) => {
+    if (!msg || typeof msg !== 'object') return;
+    const m = msg as { type?: string };
+    if (m.type === 'embed') {
+        handleEmbed(msg as EmbedRequest);
+    }
+});
+
+// If the parent dies and the IPC channel closes, exit cleanly so we
+// don't linger as an orphan holding 450 MB.
+process.on('disconnect', () => {
+    process.exit(0);
+});
+
+send({ type: 'ready' });

--- a/src/AI/AIAgent/shared/memory/settings.ts
+++ b/src/AI/AIAgent/shared/memory/settings.ts
@@ -50,6 +50,7 @@ const DEFAULTS: MemorySettings = {
     excludeGlobs: DEFAULT_EXCLUDE_GLOBS,
     chunkLines: 80,
     chunkOverlap: 5,
+    embedderIdleTimeoutMs: 60_000,
 };
 
 interface RawMemorySettings {
@@ -62,6 +63,7 @@ interface RawMemorySettings {
     excludeGlobs?: string[];
     chunkLines?: number;
     chunkOverlap?: number;
+    embedderIdleTimeoutMs?: number;
 }
 
 export async function loadMemorySettings(): Promise<MemorySettings> {
@@ -91,6 +93,7 @@ export async function loadMemorySettings(): Promise<MemorySettings> {
             : DEFAULTS.excludeGlobs,
         chunkLines: clampInt(raw.chunkLines, 20, 400, DEFAULTS.chunkLines),
         chunkOverlap: clampInt(raw.chunkOverlap, 0, 50, DEFAULTS.chunkOverlap),
+        embedderIdleTimeoutMs: clampInt(raw.embedderIdleTimeoutMs, 0, 3_600_000, DEFAULTS.embedderIdleTimeoutMs),
     };
 }
 

--- a/src/AI/AIAgent/shared/memory/types.ts
+++ b/src/AI/AIAgent/shared/memory/types.ts
@@ -239,6 +239,13 @@ export interface MemorySettings {
     excludeGlobs: string[];
     chunkLines: number;
     chunkOverlap: number;
+    /**
+     * Idle window after which the in-process fastembed/ONNX model is
+     * unloaded to release ~150–300 MB of native heap. Reset on every
+     * embedMany() call. Set to 0 to disable auto-unload (keep alive for
+     * the lifetime of the process).
+     */
+    embedderIdleTimeoutMs: number;
 }
 
 

--- a/src/AI/AIAgent/shared/utils/agentHistory.ts
+++ b/src/AI/AIAgent/shared/utils/agentHistory.ts
@@ -1,21 +1,88 @@
 import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
 import * as path from 'path';
+import * as os from 'os';
+import * as crypto from 'crypto';
 import type * as neovim from 'neovim';
 import { execCommand } from '@/utils/bashHelper';
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
 const BINARY_CHECK_BYTES = 8 * 1024;   // 8 KB
 
+// ---- Disk-backed original-content cache ---------------------------------
+// Original (pre-edit) file content is hashed and spilled to a per-process
+// temp dir. The in-memory map only retains the SHA (or `null` when the file
+// did not exist pre-edit). This keeps `originalContent` from holding tens of
+// megabytes of file bytes for the lifetime of an agent session.
+//
+// Layout: $TMPDIR/kra-agent-state-ts-<pid>/originals/<sha>.bin
+// Cleanup: best-effort on graceful exit (see registerExitCleanup() below).
+
+const STATE_DIR_ROOT = path.join(os.tmpdir(), `kra-agent-state-ts-${process.pid}`);
+const ORIGINALS_DIR = path.join(STATE_DIR_ROOT, 'originals');
+let originalsDirEnsured = false;
+let exitCleanupRegistered = false;
+
+function ensureOriginalsDir(): void {
+    if (originalsDirEnsured) return;
+    fsSync.mkdirSync(ORIGINALS_DIR, { recursive: true });
+    originalsDirEnsured = true;
+    registerExitCleanup();
+    sweepStaleStateDirs();
+}
+
+function registerExitCleanup(): void {
+    if (exitCleanupRegistered) return;
+    exitCleanupRegistered = true;
+    const cleanup = (): void => {
+        try { fsSync.rmSync(STATE_DIR_ROOT, { recursive: true, force: true }); } catch { /* ignore */ }
+    };
+    process.once('exit', cleanup);
+    for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+        process.once(sig, () => { cleanup(); process.exit(); });
+    }
+}
+
+// On startup, prune state dirs whose owner pid is no longer alive (covers
+// SIGKILL / OOM / hard crashes that bypass our exit handler).
+function sweepStaleStateDirs(): void {
+    try {
+        const root = os.tmpdir();
+        const entries = fsSync.readdirSync(root);
+        for (const name of entries) {
+            const m = /^kra-agent-state-ts-(\d+)$/.exec(name);
+            if (!m) continue;
+            const pid = Number(m[1]);
+            if (!Number.isFinite(pid) || pid === process.pid) continue;
+            try {
+                process.kill(pid, 0); // throws if pid is gone
+            } catch {
+                try { fsSync.rmSync(path.join(root, name), { recursive: true, force: true }); } catch { /* ignore */ }
+            }
+        }
+    } catch { /* ignore */ }
+}
+
+function spillOriginalSync(content: string): string {
+    ensureOriginalsDir();
+    const sha = crypto.createHash('sha1').update(content, 'utf8').digest('hex');
+    const filePath = path.join(ORIGINALS_DIR, `${sha}.bin`);
+    if (!fsSync.existsSync(filePath)) {
+        fsSync.writeFileSync(filePath, content, 'utf8');
+    }
+
+    return sha;
+}
+
+async function loadOriginal(sha: string): Promise<string> {
+    const filePath = path.join(ORIGINALS_DIR, `${sha}.bin`);
+
+    return await fs.readFile(filePath, 'utf8');
+}
+
 export interface BashSnapshot {
     /** git status snapshots keyed by repo cwd. */
     statusByCwd: Map<string, Map<string, string>>;
-}
-
-interface MutationEntry {
-    path: string;
-    beforeContent: string | null;
-    afterContent: string | null;
-    source: string;
 }
 
 export interface AgentHistory {
@@ -26,8 +93,9 @@ export interface AgentHistory {
         source: string;
     }) => void;
     /** Returns the first-ever recorded `beforeContent` for this path (pre-session state).
-     *  Returns `undefined` if the path has never been recorded. */
-    getOriginalContent: (filePath: string) => string | null | undefined;
+     *  Returns `undefined` if the path has never been recorded.
+     *  Async because content is spilled to disk to keep heap small. */
+    getOriginalContent: (filePath: string) => Promise<string | null | undefined>;
     /** Reverts every path in history back to its pre-session state. */
     revertAll: (nvim: neovim.NeovimClient) => Promise<void>;
     /** All absolute paths that have at least one recorded mutation. */
@@ -88,9 +156,13 @@ export function createAgentHistory(cwds: string[]): AgentHistory {
         throw new Error('createAgentHistory: at least one cwd required');
     }
     const trackedCwds: string[] = [...new Set(cwds)];
-    // First-seen "before" per absolute path — the pre-session original.
+    // First-seen pre-edit content per absolute path. Value is either the SHA
+    // of the spilled content (string) or `null` when the file did not exist.
     const originalContent = new Map<string, string | null>();
-    const entries: MutationEntry[] = [];
+    // Set of paths that have been mutated this session. Used by listChangedPaths
+    // and revertAll. Replaces the old MutationEntry[] which double-stored the
+    // before/after bytes for no reason.
+    const changedPaths = new Set<string>();
 
     function recordMutation(opts: {
         path: string;
@@ -99,32 +171,38 @@ export function createAgentHistory(cwds: string[]): AgentHistory {
         source: string;
     }): void {
         if (!originalContent.has(opts.path)) {
-            originalContent.set(opts.path, opts.beforeContent);
+            const sha = opts.beforeContent === null ? null : spillOriginalSync(opts.beforeContent);
+            originalContent.set(opts.path, sha);
         }
-        entries.push(opts);
+        changedPaths.add(opts.path);
     }
 
-    function getOriginalContent(filePath: string): string | null | undefined {
+    async function getOriginalContent(filePath: string): Promise<string | null | undefined> {
         if (!originalContent.has(filePath)) return undefined;
-
-        return originalContent.get(filePath) ?? null;
+        const sha = originalContent.get(filePath);
+        if (sha === null || sha === undefined) return null;
+        try {
+            return await loadOriginal(sha);
+        } catch {
+            return null;
+        }
     }
 
     async function revertAll(nvim: neovim.NeovimClient): Promise<void> {
-        const paths = new Set(entries.map(e => e.path));
         let reverted = 0;
         let failed = 0;
 
-        for (const filePath of paths) {
+        for (const filePath of changedPaths) {
             try {
-                const original = originalContent.get(filePath);
-                if (original === undefined) continue;
+                if (!originalContent.has(filePath)) continue;
+                const sha = originalContent.get(filePath);
 
-                if (original === null) {
+                if (sha === null || sha === undefined) {
                     // File didn't exist originally → delete it.
                     await fs.rm(filePath, { force: true });
                 } else {
-                    // File existed → restore its original content.
+                    // File existed → restore its original content from disk.
+                    const original = await loadOriginal(sha);
                     await fs.mkdir(path.dirname(filePath), { recursive: true });
                     await fs.writeFile(filePath, original, 'utf8');
                 }
@@ -144,7 +222,7 @@ export function createAgentHistory(cwds: string[]): AgentHistory {
     }
 
     function listChangedPaths(): string[] {
-        return [...new Set(entries.map(e => e.path))];
+        return [...changedPaths];
     }
 
     async function bashSnapshotBefore(): Promise<BashSnapshot> {

--- a/src/AI/AIChat/utils/deepSearch/chatSubAgent.ts
+++ b/src/AI/AIChat/utils/deepSearch/chatSubAgent.ts
@@ -16,7 +16,7 @@
  */
 
 import { randomUUID } from 'crypto';
-import OpenAI from 'openai';
+import type OpenAI from 'openai';
 
 import { requestChatToolApproval } from '@/AI/AIChat/utils/chatToolApproval';
 import type {
@@ -274,9 +274,10 @@ async function accumulateStream(
     return { content, toolCalls };
 }
 
-function makeOpenAiClient(provider: string): OpenAI {
+async function makeOpenAiClient(provider: string): Promise<OpenAI> {
     const apiKey = getProviderApiKey(provider);
     const baseURL = getProviderBaseURL(provider);
+    const { default: OpenAI } = await import('openai');
 
     return new OpenAI({ apiKey, baseURL });
 }
@@ -362,7 +363,7 @@ export async function runDeepSearch(options: RunDeepSearchOptions): Promise<Deep
         { role: 'user', content: userPrompt },
     ];
 
-    const openai = options.openai ?? makeOpenAiClient(provider);
+    const openai = options.openai ?? await makeOpenAiClient(provider);
     let toolCallCount = 0;
     let lastAssistantText = '';
 

--- a/src/AI/AIChat/utils/promptModel.ts
+++ b/src/AI/AIChat/utils/promptModel.ts
@@ -1,5 +1,5 @@
 import * as neovim from 'neovim';
-import OpenAI from 'openai';
+import type OpenAI from 'openai';
 import type {
     ChatCompletionAssistantMessageParam,
     ChatCompletionMessageParam,
@@ -186,6 +186,7 @@ export async function promptModel(
     const apiKey = getProviderApiKey(provider);
     const baseURL = getProviderBaseURL(provider);
 
+    const { default: OpenAI } = await import('openai');
     const openai = new OpenAI({ apiKey, baseURL });
 
     const enrichedContext: ChatToolContext | undefined = toolContext

--- a/src/types/settingsTypes.ts
+++ b/src/types/settingsTypes.ts
@@ -40,6 +40,7 @@ export type LspServerSettings = {
 
 type AgentSettings = {
     mcpServers?: Record<string, McpServerSettings>,
+    mcpClientIdleTimeoutMs?: number,
     memory?: {
         enabled?: boolean,
         indexCodeOnStart?: boolean,


### PR DESCRIPTION
fork fastembed into a separate child process

spill original file contents + diff/tool history to disk instead of keeping them in memory

stop notify/spinner churn — status now lives in lualine only

seplace transcript :syntax highlights with extmarks

disable undo history on the prompt + transcript buffers

add a periodic GC timer in the embed nvim