### PR TITLE
fix: prevent silent agent crash on first-time repo indexing

### DIFF
--- a/src/AI/AIAgent/shared/memory/db.ts
+++ b/src/AI/AIAgent/shared/memory/db.ts
@@ -245,7 +245,13 @@ void ensureContentFtsIndex(t, key, codeFtsEnsuredKeys);
             [seedRow as unknown as Record<string, unknown>],
         );
         codeChunksTableCache.set(key, t);
-void ensureContentFtsIndex(t, key, codeFtsEnsuredKeys);
+        // MUST await on the create path: firing this concurrently with the
+        // bulk writes that immediately follow a fresh reindex (table.add /
+        // table.delete on the same table) can crash LanceDB's native side
+        // and silently terminate the Node process. On the open path above
+        // we already short-circuit when the FTS index exists, so it's safe
+        // to keep that one fire-and-forget.
+        await ensureContentFtsIndex(t, key, codeFtsEnsuredKeys);
 
         return { table: t, justCreated: true };
     });
@@ -365,7 +371,10 @@ export async function getDocChunksTable(seedRow: DocChunkRow | null): Promise<Ge
             DOC_CHUNKS_TABLE,
             [seedRow as unknown as Record<string, unknown>],
         );
-        void ensureContentFtsIndex(docChunksTableCache, DOC_FTS_KEY, docFtsEnsuredKeys);
+        // See getCodeChunksTable: must await on the create path so the
+        // FTS index build does not race with the writes the caller is
+        // about to issue against the freshly-created table.
+        await ensureContentFtsIndex(docChunksTableCache, DOC_FTS_KEY, docFtsEnsuredKeys);
 
         return { table: docChunksTableCache, justCreated: true };
     });

--- a/src/AI/AIAgent/shared/memory/registry.ts
+++ b/src/AI/AIAgent/shared/memory/registry.ts
@@ -130,13 +130,19 @@ export async function upsertRegistryEntry(
         const reg = await loadRegistry();
         const existing: RegistryEntry | undefined = reg.repos[id];
 
+        // `existing` is undefined on first-time registration. Using
+        // `existing.X` directly here threw a TypeError on the first index
+        // of any new repo (most visible via the `repoKey` line, since the
+        // caller does not pass it), which propagated as an unhandled
+        // rejection and silently killed the agent process after indexing
+        // finished.
         const next: RegistryEntry = {
-            alias: patch.alias ?? existing.alias ?? id,
-            rootPath: patch.rootPath ?? existing.rootPath ?? '',
-            repoKey: patch.repoKey ?? existing.repoKey ?? computeRepoKey(id),
-            lastIndexedCommit: patch.lastIndexedCommit ?? existing.lastIndexedCommit ?? '',
-            lastIndexedAt: patch.lastIndexedAt ?? existing.lastIndexedAt ?? 0,
-            chunksCount: patch.chunksCount ?? existing.chunksCount ?? 0,
+            alias: patch.alias ?? existing?.alias ?? id,
+            rootPath: patch.rootPath ?? existing?.rootPath ?? '',
+            repoKey: patch.repoKey ?? existing?.repoKey ?? computeRepoKey(id),
+            lastIndexedCommit: patch.lastIndexedCommit ?? existing?.lastIndexedCommit ?? '',
+            lastIndexedAt: patch.lastIndexedAt ?? existing?.lastIndexedAt ?? 0,
+            chunksCount: patch.chunksCount ?? existing?.chunksCount ?? 0,
         };
 
         reg.repos[id] = next;


### PR DESCRIPTION
upsertRegistryEntry dereferenced `existing` (undefined on first run) when filling defaults, throwing inside Promise.all and killing the process via unhandled rejection right after files finished indexing. Switched the fallbacks to optional chaining

await ensureContentFtsIndex on the create-table path so the FTS index build doesn't race with the bulk writes that follow on a fresh reindex (LanceDB native can crash under that race)