### PR TITLE
fix: popup focus recovery, spinner result preview

### DIFF
--- a/src/AI/TUI/state/popupRegistry.ts
+++ b/src/AI/TUI/state/popupRegistry.ts
@@ -29,211 +29,271 @@ let globallyHidden = false;
  * immediately so it doesn't flash visible for one frame.
  */
 export interface OverlayOptions {
-    /** Required when `pausedKeys` is set so we can re-pause on show. */
-    screen?: blessed.Widgets.Screen;
-    /**
-     * Screen-level keys this overlay wants suppressed while VISIBLE.
-     * When the overlay is hidden via the global hide toggle the keys are
-     * automatically restored, then re-paused on show. Without this, keys
-     * like `tab`/`escape` stay swallowed even though the popup is gone.
-     */
-    pausedKeys?: string[];
+	/** Required when `pausedKeys` is set so we can re-pause on show. */
+	screen?: blessed.Widgets.Screen;
+	/**
+	 * Screen-level keys this overlay wants suppressed while VISIBLE.
+	 * When the overlay is hidden via the global hide toggle the keys are
+	 * automatically restored, then re-paused on show. Without this, keys
+	 * like `tab`/`escape` stay swallowed even though the popup is gone.
+	 */
+	pausedKeys?: string[];
+	/**
+	 * Optional resolver for the inner widget that should actually receive
+	 * keyboard focus when the popup is (re-)focused via PopupRegistry.
+	 * Use this for popups whose outer box wraps an inner interactive
+	 * widget (textarea, list, …) that needs focus to function. Returning
+	 * null falls back to focusing the marked element itself.
+	 */
+	getFocusTarget?: () => blessed.Widgets.BlessedElement | null;
+	/**
+	 * If false, this overlay is treated as purely decorative — it can be
+	 * hidden / shown by the global toggle but is never picked as the
+	 * focus target by `PopupRegistry.show()` / `maintainFocus()`. Set to
+	 * false on non-interactive overlays (spinners, status badges, …)
+	 * that would otherwise steal focus from a real modal underneath.
+	 * Defaults to true.
+	 */
+	focusable?: boolean;
 }
 
 interface OverlayState {
-    screen: blessed.Widgets.Screen | undefined;
-    pausedKeys: string[] | undefined;
-    /** Closure returned by the most recent pauseScreenKeys call. */
-    currentRestore: (() => void) | null;
+	screen: blessed.Widgets.Screen | undefined;
+	pausedKeys: string[] | undefined;
+	/** Closure returned by the most recent pauseScreenKeys call. */
+	currentRestore: (() => void) | null;
+	getFocusTarget: (() => blessed.Widgets.BlessedElement | null) | undefined;
+	focusable: boolean;
 }
 
 export interface OverlayHandle {
-    /** Restore screen keys (if paused) and clear overlay markers. Idempotent. */
-    release(): void;
+	/** Restore screen keys (if paused) and clear overlay markers. Idempotent. */
+	release(): void;
 }
 
 import { pauseScreenKeys } from '@/UI/dashboard/screen';
 
 export function markOverlay(
-    el: blessed.Widgets.BlessedElement,
-    opts?: OverlayOptions,
+	el: blessed.Widgets.BlessedElement,
+	opts?: OverlayOptions,
 ): OverlayHandle {
-    (el as unknown as { __kraOverlay?: boolean }).__kraOverlay = true;
+	(el as unknown as { __kraOverlay?: boolean }).__kraOverlay = true;
 
-    const state: OverlayState = {
-        screen: opts?.screen,
-        pausedKeys: opts?.pausedKeys && opts.pausedKeys.length > 0 ? opts.pausedKeys : undefined,
-        currentRestore: null,
-    };
-    if (state.screen && state.pausedKeys) {
-        state.currentRestore = pauseScreenKeys(state.screen, state.pausedKeys);
-    }
-    (el as unknown as { __kraOverlayState?: OverlayState }).__kraOverlayState = state;
+	const state: OverlayState = {
+		screen: opts?.screen,
+		pausedKeys: opts?.pausedKeys && opts.pausedKeys.length > 0 ? opts.pausedKeys : undefined,
+		currentRestore: null,
+		getFocusTarget: opts?.getFocusTarget,
+		focusable: opts?.focusable !== false,
+	};
+	if (state.screen && state.pausedKeys) {
+		state.currentRestore = pauseScreenKeys(state.screen, state.pausedKeys);
+	}
+	(el as unknown as { __kraOverlayState?: OverlayState }).__kraOverlayState = state;
 
-    if (globallyHidden) {
-        (el as unknown as { __kraHidden?: boolean }).__kraHidden = true;
-        try { el.hide(); } catch { /* ignore */ }
-        // Honour user's hide intent: don't keep keys suppressed for an invisible overlay.
-        if (state.currentRestore) {
-            try { state.currentRestore(); } catch { /* ignore */ }
-            state.currentRestore = null;
-        }
-    }
+	if (globallyHidden) {
+		(el as unknown as { __kraHidden?: boolean }).__kraHidden = true;
+		try { el.hide(); } catch { /* ignore */ }
+		// Honour user's hide intent: don't keep keys suppressed for an invisible overlay.
+		if (state.currentRestore) {
+			try { state.currentRestore(); } catch { /* ignore */ }
+			state.currentRestore = null;
+		}
+	}
 
-    return {
-        release: () => {
-            if (state.currentRestore) {
-                try { state.currentRestore(); } catch { /* ignore */ }
-                state.currentRestore = null;
-            }
-            (el as unknown as { __kraOverlay?: boolean }).__kraOverlay = false;
-            (el as unknown as { __kraOverlayState?: OverlayState | null }).__kraOverlayState = null;
-        },
-    };
+	return {
+		release: () => {
+			if (state.currentRestore) {
+				try { state.currentRestore(); } catch { /* ignore */ }
+				state.currentRestore = null;
+			}
+			(el as unknown as { __kraOverlay?: boolean }).__kraOverlay = false;
+			(el as unknown as { __kraOverlayState?: OverlayState | null }).__kraOverlayState = null;
+		},
+	};
 }
 
 export class PopupRegistry {
-    private hidden = false;
-    private lastFocus: blessed.Widgets.BlessedElement | null = null;
+	private hidden = false;
+	private lastFocus: blessed.Widgets.BlessedElement | null = null;
 
-    /**
-     * @param screen          The screen to scan for overlays.
-     * @param getDefaultFocus Returns the element that should receive focus
-     *                        when overlays are hidden — typically the prompt
-     *                        pane so the user can navigate transcript/chat.
-     */
-    constructor(
-        private screen: blessed.Widgets.Screen,
-        private getDefaultFocus: () => blessed.Widgets.BlessedElement | null = () => null,
-    ) {}
+	/**
+	 * @param screen          The screen to scan for overlays.
+	 * @param getDefaultFocus Returns the element that should receive focus
+	 *                        when overlays are hidden — typically the prompt
+	 *                        pane so the user can navigate transcript/chat.
+	 */
+	constructor(
+		private screen: blessed.Widgets.Screen,
+		private getDefaultFocus: () => blessed.Widgets.BlessedElement | null = () => null,
+	) { }
 
-    isHidden(): boolean { return this.hidden; }
+	isHidden(): boolean { return this.hidden; }
 
-    private setGlobalFlag(v: boolean): void {
-        this.hidden = v;
-        globallyHidden = v;
-    }
 
-    toggle(): void {
-        if (this.hidden) this.show();
-        else this.hide();
-    }
+	private setGlobalFlag(v: boolean): void {
+		this.hidden = v;
+		globallyHidden = v;
+	}
 
-    hide(): void {
-        if (this.hidden) return;
-        this.setGlobalFlag(true);
-        const overlays = this.findOverlays();
-        // Remember whichever element currently has focus so we can return
-        // to it on un-hide. Most often this is one of the overlays itself.
-        this.lastFocus = this.screen.focused ?? null;
-        for (const el of overlays) {
-            (el as unknown as { __kraHidden?: boolean }).__kraHidden = true;
-            try { el.hide(); } catch { /* ignore */ }
-            // Restore any screen keys this overlay had paused — otherwise
-            // tab/escape stay swallowed and the user can't navigate the
-            // background as if the popup weren't there.
-            const st = (el as unknown as { __kraOverlayState?: OverlayState | null }).__kraOverlayState;
-            if (st?.currentRestore) {
-                try { st.currentRestore(); } catch { /* ignore */ }
-                st.currentRestore = null;
-            }
-        }
-        // Intentionally do NOT move focus on hide. The user explicitly
-        // toggled popups off; we leave focus exactly where it was. Background
-        // panes (transcript / prompt) are still reachable via Tab and the
-        // focus ring — we just don't pre-empt the user's choice.
-        void this.getDefaultFocus;
-        this.screen.render();
-    }
+	toggle(): void {
+		if (this.hidden) this.show();
+		else this.hide();
+	}
 
-    show(): void {
-        if (!this.hidden) return;
-        this.setGlobalFlag(false);
-        const overlays = this.findOverlays();
-        for (const el of overlays) {
-            (el as unknown as { __kraHidden?: boolean }).__kraHidden = false;
-            try { el.show(); } catch { /* ignore */ }
-            try { el.setFront(); } catch { /* ignore */ }
-            // Re-pause this overlay's screen keys now that it's visible again.
-            const st = (el as unknown as { __kraOverlayState?: OverlayState | null }).__kraOverlayState;
-            if (st && st.screen && st.pausedKeys && !st.currentRestore) {
-                st.currentRestore = pauseScreenKeys(st.screen, st.pausedKeys);
-            }
-        }
-        // Focus priority:
-        //   1. lastFocus, if it's still alive and lives inside an overlay —
-        //      restores focus to the exact widget (list, input pane, …) the
-        //      user was interacting with before the hide.
-        //   2. Topmost overlay box — covers the case where lastFocus is null,
-        //      detached, or was outside any overlay (e.g. a background pane).
-        //   3. lastFocus even if outside an overlay — e.g. the prompt pane.
-        // `findOverlays` walks depth-first; the last entry is the most
-        // recently added (topmost) overlay.
-        const topmost = overlays.length > 0 ? overlays[overlays.length - 1] : null;
-        // Prefer the exact element that had focus before hiding — it may be a
-        // nested interactive widget (list, input pane, …) inside an overlay box.
-        // Fall back to the topmost overlay box only when lastFocus is gone,
-        // detached, or lives outside every known overlay.
-        const lastFocusInOverlay = this.lastFocus
-            && !this.isDetached(this.lastFocus)
-            && this.isInsideAnyOverlay(this.lastFocus, overlays);
-        const target = lastFocusInOverlay
-            ? this.lastFocus
-            : (topmost ?? (this.lastFocus && !this.isDetached(this.lastFocus) ? this.lastFocus : null));
-        if (target) {
-            try { target.focus(); } catch { /* ignore */ }
-        }
-        this.screen.render();
-    }
+	hide(): void {
+		if (this.hidden) return;
+		this.setGlobalFlag(true);
+		const overlays = this.findOverlays();
+		// Remember whichever element currently has focus so we can return
+		// to it on un-hide. Most often this is one of the overlays itself.
+		this.lastFocus = this.screen.focused ?? null;
+		for (const el of overlays) {
+			(el as unknown as { __kraHidden?: boolean }).__kraHidden = true;
+			try { el.hide(); } catch { /* ignore */ }
+			// Restore any screen keys this overlay had paused — otherwise
+			// tab/escape stay swallowed and the user can't navigate the
+			// background as if the popup weren't there.
+			const st = (el as unknown as { __kraOverlayState?: OverlayState | null }).__kraOverlayState;
+			if (st?.currentRestore) {
+				try { st.currentRestore(); } catch { /* ignore */ }
+				st.currentRestore = null;
+			}
+		}
+		// Intentionally do NOT move focus on hide. The user explicitly
+		// toggled popups off; we leave focus exactly where it was. Background
+		// panes (transcript / prompt) are still reachable via Tab and the
+		// focus ring — we just don't pre-empt the user's choice.
+		void this.getDefaultFocus;
+		this.screen.render();
+	}
 
-    /**
-     * Re-focus the topmost visible overlay if focus has drifted off it
-     * (e.g. user mouse-clicked the transcript while a modal is open).
-     * No-op when popups are hidden, when there are no visible overlays,
-     * or when focus is already inside one.
-     */
-    maintainFocus(): void {
-        if (this.hidden) return;
-        const overlays = this.findOverlays();
-        if (overlays.length === 0) return;
-        const focused = this.screen.focused as blessed.Widgets.BlessedElement | undefined;
-        if (focused && this.isInsideAnyOverlay(focused, overlays)) return;
-        const topmost = overlays[overlays.length - 1];
-        try { topmost.setFront(); } catch { /* ignore */ }
-        try { topmost.focus(); } catch { /* ignore */ }
-        this.screen.render();
-    }
+	show(): void {
+		if (!this.hidden) return;
+		this.setGlobalFlag(false);
+		const overlays = this.findOverlays();
+		for (const el of overlays) {
+			(el as unknown as { __kraHidden?: boolean }).__kraHidden = false;
+			try { el.show(); } catch { /* ignore */ }
+			try { el.setFront(); } catch { /* ignore */ }
+			// Re-pause this overlay's screen keys now that it's visible again.
+			const st = (el as unknown as { __kraOverlayState?: OverlayState | null }).__kraOverlayState;
+			if (st && st.screen && st.pausedKeys && !st.currentRestore) {
+				st.currentRestore = pauseScreenKeys(st.screen, st.pausedKeys);
+			}
+		}
+		// Focus rule: when popups are un-hidden via the global toggle, the
+		// topmost overlay ALWAYS gets focus. This is the user's escape hatch
+		// when focus has drifted off a modal (e.g. an accidental mouse click
+		// on the transcript while the "Custom answer" popup is open):
+		// pressing <leader>t twice must reliably return focus to the popup.
+		//
+		// We only fall back to lastFocus when there is no overlay at all
+		// (defensive — show() is normally a no-op in that case).
+		// `findOverlays` walks depth-first; the last entry is the most
+		// recently added (topmost) overlay. Inner-widget focus (e.g.
+		// textarea inside a modal box) is preserved by the popup's own
+		// `box.on('focus', () => pane.focus())` delegator.
+		// Skip non-focusable overlays (spinners etc.) when picking the
+		// topmost focus target — otherwise a decorative overlay added
+		// after a real modal would steal its focus on every show().
+		const focusable = overlays.filter((el) => this.isOverlayFocusable(el));
+		const topmost = focusable.length > 0 ? focusable[focusable.length - 1] : null;
+		const target = topmost
+			?? (this.lastFocus && !this.isDetached(this.lastFocus) ? this.lastFocus : null);
+		const focusTarget = (): void => {
+			if (!target) return;
+			try { target.setFront(); } catch { /* ignore */ }
+			const inner = this.resolveInnerFocus(target);
+			try { (inner ?? target).focus(); } catch { /* ignore */ }
+		};
+		focusTarget();
+		// Re-focus on the next tick so we win against any focus change blessed
+		// performs while processing the toggle keystroke itself.
+		setImmediate(() => {
+			if (this.hidden) return;
+			focusTarget();
+			this.screen.render();
+		});
+		this.screen.render();
+	}
 
-    private isInsideAnyOverlay(
-        el: blessed.Widgets.BlessedElement,
-        overlays: blessed.Widgets.BlessedElement[],
-    ): boolean {
-        let cur: unknown = el;
-        while (cur) {
-            if (overlays.includes(cur as blessed.Widgets.BlessedElement)) return true;
-            cur = (cur as { parent?: unknown }).parent;
-        }
-        return false;
-    }
+	/**
+	 * Re-focus the topmost visible overlay if focus has drifted off it
+	 * (e.g. user mouse-clicked the transcript while a modal is open).
+	 * No-op when popups are hidden, when there are no visible overlays,
+	 * or when focus is already inside one.
+	 */
+	maintainFocus(): void {
+		if (this.hidden) return;
+		const overlays = this.findOverlays();
+		if (overlays.length === 0) return;
+		const focused = this.screen.focused as blessed.Widgets.BlessedElement | undefined;
+		// Already inside any overlay (focusable or not) — leave alone so
+		// the user can intentionally interact with non-modal overlays.
+		if (focused && this.isInsideAnyOverlay(focused, overlays)) return;
+		const focusable = overlays.filter((el) => this.isOverlayFocusable(el));
+		if (focusable.length === 0) return;
+		const topmost = focusable[focusable.length - 1];
+		try { topmost.setFront(); } catch { /* ignore */ }
+		const inner = this.resolveInnerFocus(topmost);
+		try { (inner ?? topmost).focus(); } catch { /* ignore */ }
+		this.screen.render();
+	}
 
-    private findOverlays(): blessed.Widgets.BlessedElement[] {
-        const out: blessed.Widgets.BlessedElement[] = [];
-        const walk = (node: unknown): void => {
-            const n = node as { children?: unknown[], __kraOverlay?: boolean };
-            if (n && n.__kraOverlay && !this.isDetached(n as blessed.Widgets.BlessedElement)) {
-                out.push(n as blessed.Widgets.BlessedElement);
-            }
-            if (n && Array.isArray(n.children)) {
-                for (const c of n.children) walk(c);
-            }
-        };
-        walk(this.screen);
+	private isOverlayFocusable(el: blessed.Widgets.BlessedElement): boolean {
+		const st = (el as unknown as { __kraOverlayState?: OverlayState | null }).__kraOverlayState;
+		return !st || st.focusable !== false;
+	}
 
-        return out;
-    }
+	/**
+	 * If the overlay registered a `getFocusTarget` resolver, return whatever
+	 * inner widget it points at (when still alive). Otherwise null — callers
+	 * fall back to focusing the marked overlay element itself.
+	 */
+	private resolveInnerFocus(
+		el: blessed.Widgets.BlessedElement,
+	): blessed.Widgets.BlessedElement | null {
+		const st = (el as unknown as { __kraOverlayState?: OverlayState | null }).__kraOverlayState;
+		if (!st?.getFocusTarget) return null;
+		try {
+			const inner = st.getFocusTarget();
+			if (inner && !this.isDetached(inner)) return inner;
+		} catch { /* ignore */ }
+		return null;
+	}
 
-    private isDetached(el: blessed.Widgets.BlessedElement): boolean {
-        const any = el as unknown as { detached?: boolean, parent?: unknown };
-        return !!any.detached || !any.parent;
-    }
+	private isInsideAnyOverlay(
+		el: blessed.Widgets.BlessedElement,
+		overlays: blessed.Widgets.BlessedElement[],
+	): boolean {
+		let cur: unknown = el;
+		while (cur) {
+			if (overlays.includes(cur as blessed.Widgets.BlessedElement)) return true;
+			cur = (cur as { parent?: unknown }).parent;
+		}
+		return false;
+	}
+
+	private findOverlays(): blessed.Widgets.BlessedElement[] {
+		const out: blessed.Widgets.BlessedElement[] = [];
+		const walk = (node: unknown): void => {
+			const n = node as { children?: unknown[], __kraOverlay?: boolean };
+			if (n && n.__kraOverlay && !this.isDetached(n as blessed.Widgets.BlessedElement)) {
+				out.push(n as blessed.Widgets.BlessedElement);
+			}
+			if (n && Array.isArray(n.children)) {
+				for (const c of n.children) walk(c);
+			}
+		};
+		walk(this.screen);
+
+		return out;
+	}
+
+	private isDetached(el: blessed.Widgets.BlessedElement): boolean {
+		const any = el as unknown as { detached?: boolean, parent?: unknown };
+		return !!any.detached || !any.parent;
+	}
 }
+

--- a/src/AI/TUI/widgets/indexProgressModal.ts
+++ b/src/AI/TUI/widgets/indexProgressModal.ts
@@ -19,142 +19,147 @@ import { markOverlay } from '../state/popupRegistry';
 import { BG_PRIMARY, BG_PANEL, BORDER_DIM } from '../theme';
 
 export interface IndexProgressModal {
-    /** Append a line to the scrollable log area (auto-scrolls). */
-    append: (line: string) => void;
-    /** Update the status / footer line shown under the log. */
-    setStatus: (text: string) => void;
-    /**
-     * Mark the indexing flow as complete and let the user dismiss the
-     * modal with Esc / q. Returns a promise that resolves once dismissed.
-     */
-    finish: (summary?: string) => Promise<void>;
-    /** Close immediately, regardless of completion. */
-    close: () => void;
+	/** Append a line to the scrollable log area (auto-scrolls). */
+	append: (line: string) => void;
+	/** Update the status / footer line shown under the log. */
+	setStatus: (text: string) => void;
+	/**
+	 * Mark the indexing flow as complete and let the user dismiss the
+	 * modal with Esc / q. Returns a promise that resolves once dismissed.
+	 */
+	finish: (summary?: string) => Promise<void>;
+	/** Close immediately, regardless of completion. */
+	close: () => void;
 }
 
 export interface ShowIndexProgressOptions {
-    title: string;
-    /** Optional initial body line. */
-    initial?: string;
+	title: string;
+	/** Optional initial body line. */
+	initial?: string;
 }
 
 export function showIndexProgressModal(
-    screen: blessed.Widgets.Screen,
-    opts: ShowIndexProgressOptions,
+	screen: blessed.Widgets.Screen,
+	opts: ShowIndexProgressOptions,
 ): IndexProgressModal {
-    const savedFocus = screen.focused;
+	const savedFocus = screen.focused;
 
-    const box = blessed.box({
-        parent: screen,
-        top: 'center',
-        left: 'center',
-        width: '80%',
-        height: '70%',
-        border: { type: 'line' },
-        style: {
-            border: { fg: BORDER_DIM },
-            bg: BG_PRIMARY,
-            fg: 'white',
-        },
-        label: ` ${opts.title} `,
-        keys: false,
-    });
-    markOverlay(box);
+	const box = blessed.box({
+		parent: screen,
+		top: 'center',
+		left: 'center',
+		width: '80%',
+		height: '70%',
+		border: { type: 'line' },
+		style: {
+			border: { fg: BORDER_DIM },
+			bg: BG_PRIMARY,
+			fg: 'white',
+		},
+		label: ` ${opts.title} `,
+		keys: false,
+	});
 
-    const log = blessed.log({
-        parent: box,
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 2,
-        scrollable: true,
-        alwaysScroll: true,
-        mouse: true,
-        keys: true,
-        vi: true,
-        scrollbar: {
-            ch: ' ',
-            style: { bg: 'grey' },
-        },
-        tags: false,
-        style: { bg: BG_PRIMARY, fg: 'white' },
-    });
-    markOverlay(log);
+	const log = blessed.log({
+		parent: box,
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 2,
+		scrollable: true,
+		alwaysScroll: true,
+		mouse: true,
+		keys: true,
+		vi: true,
+		scrollbar: {
+			ch: ' ',
+			style: { bg: 'grey' },
+		},
+		tags: false,
+		style: { bg: BG_PRIMARY, fg: 'white' },
+	});
+	// Mark only the outer box as the overlay; blessed already hides
+	// children when the parent is hidden, and keeping the inner log /
+	// statusLine / footer out of the registry means PopupRegistry's
+	// "focus topmost" logic targets the modal as a whole and routes
+	// focus to `log` via `getFocusTarget` below.
+	markOverlay(box, { getFocusTarget: () => log });
 
-    const statusLine = blessed.text({
-        parent: box,
-        bottom: 1,
-        left: 1,
-        right: 1,
-        height: 1,
-        content: 'indexing…',
-        style: { bg: BG_PANEL, fg: 'yellow' },
-    });
-    markOverlay(statusLine);
+	const statusLine = blessed.text({
+		parent: box,
+		bottom: 1,
+		left: 1,
+		right: 1,
+		height: 1,
+		content: 'indexing…',
+		style: { bg: BG_PANEL, fg: 'yellow' },
+	});
 
-    const footer = blessed.text({
-        parent: box,
-        bottom: 0,
-        left: 1,
-        right: 1,
-        height: 1,
-        content: '  Esc / q to dismiss (after indexing completes)',
-        style: { bg: BG_PANEL, fg: 'grey' },
-    });
-    markOverlay(footer);
+	const footer = blessed.text({
+		parent: box,
+		bottom: 0,
+		left: 1,
+		right: 1,
+		height: 1,
+		content: '  Esc / q to dismiss (after indexing completes)',
+		style: { bg: BG_PANEL, fg: 'grey' },
+	});
 
-    if (opts.initial) log.add(opts.initial);
+	if (opts.initial) log.add(opts.initial);
 
-    log.focus();
-    screen.render();
+	log.focus();
+	screen.render();
 
-    let closed = false;
-    let finishedResolve: (() => void) | null = null;
-    let finished = false;
+	let closed = false;
+	let finishedResolve: (() => void) | null = null;
+	let finished = false;
 
-    const closeNow = (): void => {
-        if (closed) return;
-        closed = true;
-        try { box.destroy(); } catch { /* ignore */ }
-        try { savedFocus.focus(); } catch { /* ignore */ }
-        screen.render();
-        if (finishedResolve) {
-            const r = finishedResolve;
-            finishedResolve = null;
-            r();
-        }
-    };
+	const closeNow = (): void => {
+		if (closed) return;
+		closed = true;
+		try { box.destroy(); } catch { /* ignore */ }
+		try { savedFocus.focus(); } catch { /* ignore */ }
+		screen.render();
+		if (finishedResolve) {
+			const r = finishedResolve;
+			finishedResolve = null;
+			r();
+		}
+	};
 
-    log.key(['escape', 'q'], () => {
-        // Only allow dismissal AFTER indexing completed. Before that,
-        // pressing Esc is a no-op so the user can't accidentally hide
-        // a flow they need to wait on.
-        if (finished) closeNow();
-    });
+	log.key(['escape', 'q'], () => {
+		// Only allow dismissal AFTER indexing completed. Before that,
+		// pressing Esc is a no-op so the user can't accidentally hide
+		// a flow they need to wait on.
+		if (finished) closeNow();
+	});
 
-    return {
-        append: (line) => {
-            if (closed) return;
-            log.add(line);
-            screen.render();
-        },
-        setStatus: (text) => {
-            if (closed) return;
-            statusLine.setContent(text);
-            screen.render();
-        },
-        finish: async (summary) => new Promise<void>((resolve) => {
-            if (closed) { resolve();
+	return {
+		append: (line) => {
+			if (closed) return;
+			log.add(line);
+			screen.render();
+		},
+		setStatus: (text) => {
+			if (closed) return;
+			statusLine.setContent(text);
+			screen.render();
+		},
+		finish: async (summary) => new Promise<void>((resolve) => {
+			if (closed) {
+				resolve();
 
- return; }
-            finished = true;
-            const finalText = summary ?? 'done · press Esc / q to dismiss';
-            statusLine.setContent(finalText);
-            (statusLine.style as { fg?: string }).fg = 'green';
-            footer.setContent('  Esc / q to dismiss');
-            screen.render();
-            finishedResolve = resolve;
-        }),
-        close: closeNow,
-    };
+				return;
+			}
+			finished = true;
+			const finalText = summary ?? 'done · press Esc / q to dismiss';
+			statusLine.setContent(finalText);
+			(statusLine.style as { fg?: string }).fg = 'green';
+			footer.setContent('  Esc / q to dismiss');
+			screen.render();
+			finishedResolve = resolve;
+		}),
+		close: closeNow,
+	};
 }
+

--- a/src/AI/TUI/widgets/jsonEditor.ts
+++ b/src/AI/TUI/widgets/jsonEditor.ts
@@ -5,23 +5,23 @@ import { BG_PRIMARY, BG_PANEL, BORDER_DIM, FG_BODY, FG_MUTED, ACCENT_BLUE, ACCEN
 const ACTIVE_BG = '#2e3450';
 
 export interface OpenJsonEditorOptions {
-    title: string;
-    initial: unknown;
+	title: string;
+	initial: unknown;
 }
 
 type FieldKind = 'string' | 'number' | 'boolean' | 'json';
 
 interface Field {
-    key: string;
-    kind: FieldKind;
-    /** Stable shadow value, updated whenever the user leaves a field. */
-    value: string;
-    /** Original parsed value — used to infer kind on save. */
-    original: unknown;
-    /** Row container (label + input). */
-    row: blessed.Widgets.BoxElement;
-    label: blessed.Widgets.BoxElement;
-    input: blessed.Widgets.TextboxElement;
+	key: string;
+	kind: FieldKind;
+	/** Stable shadow value, updated whenever the user leaves a field. */
+	value: string;
+	/** Original parsed value — used to infer kind on save. */
+	original: unknown;
+	/** Row container (label + input). */
+	row: blessed.Widgets.BoxElement;
+	label: blessed.Widgets.BoxElement;
+	input: blessed.Widgets.TextboxElement;
 }
 
 /**
@@ -37,408 +37,416 @@ interface Field {
  * Returns the edited value, or null if the user cancels.
  */
 export async function openJsonEditor(
-    screen: blessed.Widgets.Screen,
-    opts: OpenJsonEditorOptions,
+	screen: blessed.Widgets.Screen,
+	opts: OpenJsonEditorOptions,
 ): Promise<unknown | null> {
-    const isPlainObject = !!opts.initial
-        && typeof opts.initial === 'object'
-        && !Array.isArray(opts.initial);
+	const isPlainObject = !!opts.initial
+		&& typeof opts.initial === 'object'
+		&& !Array.isArray(opts.initial);
 
-    if (isPlainObject) {
-        return openFieldForm(screen, opts.title, opts.initial as Record<string, unknown>);
-    }
+	if (isPlainObject) {
+		return openFieldForm(screen, opts.title, opts.initial as Record<string, unknown>);
+	}
 
-    return openRawJsonEditor(screen, opts.title, opts.initial);
+	return openRawJsonEditor(screen, opts.title, opts.initial);
 }
 
 // --- field-by-field form -------------------------------------------------
 
 function openFieldForm(
-    screen: blessed.Widgets.Screen,
-    title: string,
-    initial: Record<string, unknown>,
+	screen: blessed.Widgets.Screen,
+	title: string,
+	initial: Record<string, unknown>,
 ): Promise<unknown | null> {
-    return new Promise((resolve) => {
-        const savedFocus = screen.focused;
+	return new Promise((resolve) => {
+		const savedFocus = screen.focused;
 
-        const entries = Object.entries(initial);
-        const usableHeight = Math.min(entries.length * 2 + 6, screen.height as number - 4);
+		const entries = Object.entries(initial);
+		const usableHeight = Math.min(entries.length * 2 + 6, screen.height as number - 4);
 
-        const box = blessed.box({
-            parent: screen,
-            top: 'center',
-            left: 'center',
-            width: '85%',
-            height: usableHeight,
-            label: ` ${title} `,
-            border: { type: 'line' },
-            style: { border: { fg: BORDER_DIM }, bg: BG_PRIMARY },
-            tags: true,
-        });
-        box.setFront();
-        const overlay = markOverlay(box, {
-            screen,
-            pausedKeys: ['C-s', 'C-c', 'q', 'escape', 'tab', 'S-tab'],
-        });
-        const restoreKeys = (): void => overlay.release();
+		const box = blessed.box({
+			parent: screen,
+			top: 'center',
+			left: 'center',
+			width: '85%',
+			height: usableHeight,
+			label: ` ${title} `,
+			border: { type: 'line' },
+			style: { border: { fg: BORDER_DIM }, bg: BG_PRIMARY },
+			tags: true,
+		});
+		box.setFront();
+		const overlay = markOverlay(box, {
+			screen,
+			pausedKeys: ['C-s', 'C-c', 'q', 'escape', 'tab', 'S-tab'],
+			// After a global popup hide/show, route focus back to the
+			// currently active field's textbox — not the outer box, which
+			// doesn't accept keystrokes.
+			getFocusTarget: () => fields[current]?.input ?? null,
+		});
+		const restoreKeys = (): void => overlay.release();
 
-        blessed.box({
-            parent: box,
-            top: 0,
-            left: 0,
-            right: 0,
-            height: 2,
-            tags: true,
-            style: { fg: FG_MUTED, bg: BG_PANEL },
-            content:
-                ` {${ACCENT_CYAN}-fg}[Tab/Shift-Tab]{/} navigate fields  ` +
-                `{${ACCENT_CYAN}-fg}[Ctrl-S]{/} save  ` +
-                `{${ACCENT_RED}-fg}[Esc]{/} cancel\n` +
-                ` {${FG_MUTED}-fg}Numbers/booleans/null parsed automatically; ` +
-                `JSON literals (start with [ {{ or "") are JSON.parse'd.{/}`,
-        });
+		blessed.box({
+			parent: box,
+			top: 0,
+			left: 0,
+			right: 0,
+			height: 2,
+			tags: true,
+			style: { fg: FG_MUTED, bg: BG_PANEL },
+			content:
+				` {${ACCENT_CYAN}-fg}[Tab/Shift-Tab]{/} navigate fields  ` +
+				`{${ACCENT_CYAN}-fg}[Ctrl-S]{/} save  ` +
+				`{${ACCENT_RED}-fg}[Esc]{/} cancel\n` +
+				` {${FG_MUTED}-fg}Numbers/booleans/null parsed automatically; ` +
+				`JSON literals (start with [ {{ or "") are JSON.parse'd.{/}`,
+		});
 
-        const status = blessed.box({
-            parent: box,
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: 1,
-            tags: true,
-            style: { fg: FG_MUTED, bg: BG_PANEL },
-            content: '',
-        });
+		const status = blessed.box({
+			parent: box,
+			bottom: 0,
+			left: 0,
+			right: 0,
+			height: 1,
+			tags: true,
+			style: { fg: FG_MUTED, bg: BG_PANEL },
+			content: '',
+		});
 
-        // Build a row per field.
-        const fields: Field[] = [];
-        const rowsTop = 2;
-        for (let i = 0; i < entries.length; i++) {
-            const [key, value] = entries[i];
-            const kind = inferKind(value);
+		// Build a row per field.
+		const fields: Field[] = [];
+		const rowsTop = 2;
+		for (let i = 0; i < entries.length; i++) {
+			const [key, value] = entries[i];
+			const kind = inferKind(value);
 
-            const row = blessed.box({
-                parent: box,
-                top: rowsTop + i * 2,
-                left: 1,
-                right: 1,
-                height: 1,
-                tags: true,
-                style: { bg: BG_PRIMARY },
-            });
+			const row = blessed.box({
+				parent: box,
+				top: rowsTop + i * 2,
+				left: 1,
+				right: 1,
+				height: 1,
+				tags: true,
+				style: { bg: BG_PRIMARY },
+			});
 
-            const label = blessed.box({
-                parent: row,
-                top: 0,
-                left: 0,
-                width: 28,
-                height: 1,
-                tags: true,
-                style: { fg: FG_MUTED, bg: BG_PANEL },
-            });
+			const label = blessed.box({
+				parent: row,
+				top: 0,
+				left: 0,
+				width: 28,
+				height: 1,
+				tags: true,
+				style: { fg: FG_MUTED, bg: BG_PANEL },
+			});
 
-            const input = blessed.textbox({
-                parent: row,
-                top: 0,
-                left: 28,
-                right: 0,
-                height: 1,
-                inputOnFocus: false,
-                keys: false,
-                mouse: false,
-                style: { fg: FG_BODY, bg: BG_PANEL },
-            });
+			const input = blessed.textbox({
+				parent: row,
+				top: 0,
+				left: 28,
+				right: 0,
+				height: 1,
+				inputOnFocus: false,
+				keys: false,
+				mouse: false,
+				style: { fg: FG_BODY, bg: BG_PANEL },
+			});
 
-            const valueStr = stringifyForKind(value, kind);
-            input.setValue(valueStr);
+			const valueStr = stringifyForKind(value, kind);
+			input.setValue(valueStr);
 
-            fields.push({ key, kind, value: valueStr, original: value, row, label, input });
-        }
+			fields.push({ key, kind, value: valueStr, original: value, row, label, input });
+		}
 
-        let current = 0;
+		let current = 0;
 
-        const renderLabels = (): void => {
-            for (let i = 0; i < fields.length; i++) {
-                const f = fields[i];
-                const isCur = i === current;
-                const kindBadge = `{${kindColor(f.kind)}-fg}[${f.kind}]{/}`;
-                const keyText = isCur
-                    ? `{${ACCENT_BLUE}-fg} ${escapeTags(f.key)} {/} ${kindBadge}`
-                    : ` ${escapeTags(f.key)} ${kindBadge}`;
-                f.label.setContent(keyText);
+		const renderLabels = (): void => {
+			for (let i = 0; i < fields.length; i++) {
+				const f = fields[i];
+				const isCur = i === current;
+				const kindBadge = `{${kindColor(f.kind)}-fg}[${f.kind}]{/}`;
+				const keyText = isCur
+					? `{${ACCENT_BLUE}-fg} ${escapeTags(f.key)} {/} ${kindBadge}`
+					: ` ${escapeTags(f.key)} ${kindBadge}`;
+				f.label.setContent(keyText);
 
-                if (isCur) {
-                    f.input.style.fg = FG_BODY;
-                    f.input.style.bg = ACTIVE_BG;
-                } else {
-                    f.input.style.fg = FG_BODY;
-                    f.input.style.bg = BG_PANEL;
-                }
-            }
-            screen.render();
-        };
+				if (isCur) {
+					f.input.style.fg = FG_BODY;
+					f.input.style.bg = ACTIVE_BG;
+				} else {
+					f.input.style.fg = FG_BODY;
+					f.input.style.bg = BG_PANEL;
+				}
+			}
+			screen.render();
+		};
 
-        let activeListener: ((ch: string | undefined, key: blessed.Widgets.Events.IKeyEventArg) => void) | null = null;
+		let activeListener: ((ch: string | undefined, key: blessed.Widgets.Events.IKeyEventArg) => void) | null = null;
 
-        const cleanup = (result: unknown | null): void => {
-            // Force-exit any active readInput cleanly.
-            if (activeListener) {
-                const cur = fields[current];
-                cur.input.removeListener('keypress', activeListener);
-                activeListener = null;
-                const inputAny = cur.input as unknown as { _done?: (e: unknown, v: unknown) => void };
-                if (inputAny._done) inputAny._done(null, null);
-            }
-            box.destroy();
-            restoreKeys();
-            if (savedFocus) {
-                try { savedFocus.focus(); } catch { /* ignore */ }
-            }
-            screen.render();
-            resolve(result);
-        };
+		const cleanup = (result: unknown | null): void => {
+			// Force-exit any active readInput cleanly.
+			if (activeListener) {
+				const cur = fields[current];
+				cur.input.removeListener('keypress', activeListener);
+				activeListener = null;
+				const inputAny = cur.input as unknown as { _done?: (e: unknown, v: unknown) => void };
+				if (inputAny._done) inputAny._done(null, null);
+			}
+			box.destroy();
+			restoreKeys();
+			if (savedFocus) {
+				try { savedFocus.focus(); } catch { /* ignore */ }
+			}
+			screen.render();
+			resolve(result);
+		};
 
-        // Captures current input.value into shadow + exits readInput.
-        const commitCurrent = (): void => {
-            const cur = fields[current];
-            const liveValue = (cur.input as unknown as { value?: string }).value;
-            if (typeof liveValue === 'string') cur.value = liveValue;
-            if (activeListener) {
-                cur.input.removeListener('keypress', activeListener);
-                activeListener = null;
-            }
-            const inputAny = cur.input as unknown as { _done?: (e: unknown, v: unknown) => void };
-            if (inputAny._done) inputAny._done(null, null);
-            // Reflect committed value in the visible textbox.
-            cur.input.setValue(cur.value);
-        };
+		// Captures current input.value into shadow + exits readInput.
+		const commitCurrent = (): void => {
+			const cur = fields[current];
+			const liveValue = (cur.input as unknown as { value?: string }).value;
+			if (typeof liveValue === 'string') cur.value = liveValue;
+			if (activeListener) {
+				cur.input.removeListener('keypress', activeListener);
+				activeListener = null;
+			}
+			const inputAny = cur.input as unknown as { _done?: (e: unknown, v: unknown) => void };
+			if (inputAny._done) inputAny._done(null, null);
+			// Reflect committed value in the visible textbox.
+			cur.input.setValue(cur.value);
+		};
 
-        const trySave = (): void => {
-            commitCurrent();
-            const out: Record<string, unknown> = {};
-            for (const f of fields) {
-                const parsed = parseForKind(f.value, f.kind);
-                if (parsed.ok) {
-                    out[f.key] = parsed.value;
-                } else {
-                    status.setContent(`{red-fg} ✗ ${f.key}: ${parsed.error}{/red-fg}`);
-                    screen.render();
-                    activate(fields.findIndex((x) => x.key === f.key));
+		const trySave = (): void => {
+			commitCurrent();
+			const out: Record<string, unknown> = {};
+			for (const f of fields) {
+				const parsed = parseForKind(f.value, f.kind);
+				if (parsed.ok) {
+					out[f.key] = parsed.value;
+				} else {
+					status.setContent(`{red-fg} ✗ ${f.key}: ${parsed.error}{/red-fg}`);
+					screen.render();
+					activate(fields.findIndex((x) => x.key === f.key));
 
-                    return;
-                }
-            }
-            cleanup(out);
-        };
+					return;
+				}
+			}
+			cleanup(out);
+		};
 
-        const navigate = (delta: number): void => {
-            commitCurrent();
-            current = (current + delta + fields.length) % fields.length;
-            activate(current);
-        };
+		const navigate = (delta: number): void => {
+			commitCurrent();
+			current = (current + delta + fields.length) % fields.length;
+			activate(current);
+		};
 
-        const activate = (idx: number): void => {
-            current = idx;
-            renderLabels();
-            const cur = fields[current];
-            // Make sure the displayed text matches the shadow before re-entering input mode.
-            cur.input.setValue(cur.value);
-            cur.input.focus();
-            cur.input.readInput(() => {
-                // Native readInput callback fires on Enter/Esc in the textbox.
-                // Our intercept (below) handles Tab/S-Tab/Ctrl-S/Esc explicitly,
-                // so this almost never runs. Sync shadow defensively.
-                const live = (cur.input as unknown as { value?: string }).value;
-                if (typeof live === 'string') cur.value = live;
-            });
+		const activate = (idx: number): void => {
+			current = idx;
+			renderLabels();
+			const cur = fields[current];
+			// Make sure the displayed text matches the shadow before re-entering input mode.
+			cur.input.setValue(cur.value);
+			cur.input.focus();
+			cur.input.readInput(() => {
+				// Native readInput callback fires on Enter/Esc in the textbox.
+				// Our intercept (below) handles Tab/S-Tab/Ctrl-S/Esc explicitly,
+				// so this almost never runs. Sync shadow defensively.
+				const live = (cur.input as unknown as { value?: string }).value;
+				if (typeof live === 'string') cur.value = live;
+			});
 
-            const onKey = (_ch: string | undefined, key: blessed.Widgets.Events.IKeyEventArg): void => {
-                const name = key.name ?? '';
-                // Ctrl-S → save (must intercept here because grabKeys=true while readInput active)
-                if (key.ctrl && name === 's') {
-                    trySave();
-                    return;
-                }
-                // Ctrl-C / Esc → cancel
-                if (name === 'escape' || (key.ctrl && name === 'c')) {
-                    cleanup(null);
-                    return;
-                }
-                // Tab / Shift-Tab → navigate
-                if (name === 'tab') {
-                    navigate(key.shift ? -1 : 1);
-                    return;
-                }
-                // Enter → commit current and move to next field (intuitive)
-                if (name === 'return' || name === 'enter') {
-                    if (current === fields.length - 1) {
-                        trySave();
-                    } else {
-                        navigate(1);
-                    }
-                    return;
-                }
-            };
+			const onKey = (_ch: string | undefined, key: blessed.Widgets.Events.IKeyEventArg): void => {
+				const name = key.name ?? '';
+				// Ctrl-S → save (must intercept here because grabKeys=true while readInput active)
+				if (key.ctrl && name === 's') {
+					trySave();
+					return;
+				}
+				// Ctrl-C / Esc → cancel
+				if (name === 'escape' || (key.ctrl && name === 'c')) {
+					cleanup(null);
+					return;
+				}
+				// Tab / Shift-Tab → navigate
+				if (name === 'tab') {
+					navigate(key.shift ? -1 : 1);
+					return;
+				}
+				// Enter → commit current and move to next field (intuitive)
+				if (name === 'return' || name === 'enter') {
+					if (current === fields.length - 1) {
+						trySave();
+					} else {
+						navigate(1);
+					}
+					return;
+				}
+			};
 
-            cur.input.on('keypress', onKey);
-            activeListener = onKey;
-        };
+			cur.input.on('keypress', onKey);
+			activeListener = onKey;
+		};
 
-        renderLabels();
-        activate(0);
-    });
+		renderLabels();
+		activate(0);
+	});
 }
 
 // --- raw JSON fallback ----------------------------------------------------
 
 function openRawJsonEditor(
-    screen: blessed.Widgets.Screen,
-    title: string,
-    initial: unknown,
+	screen: blessed.Widgets.Screen,
+	title: string,
+	initial: unknown,
 ): Promise<unknown | null> {
-    return new Promise((resolve) => {
-        const savedFocus = screen.focused;
+	return new Promise((resolve) => {
+		const savedFocus = screen.focused;
 
-        const box = blessed.box({
-            parent: screen,
-            top: 'center',
-            left: 'center',
-            width: '85%',
-            height: '70%',
-            label: ` ${title} (raw JSON) `,
-            border: { type: 'line' },
-            style: { border: { fg: BORDER_DIM }, bg: BG_PRIMARY },
-            tags: true,
-        });
-        box.setFront();
-        const overlay = markOverlay(box, {
-            screen,
-            pausedKeys: ['C-s', 'C-c', 'q', 'escape'],
-        });
-        const restoreKeys = (): void => overlay.release();
+		const box = blessed.box({
+			parent: screen,
+			top: 'center',
+			left: 'center',
+			width: '85%',
+			height: '70%',
+			label: ` ${title} (raw JSON) `,
+			border: { type: 'line' },
+			style: { border: { fg: BORDER_DIM }, bg: BG_PRIMARY },
+			tags: true,
+		});
+		box.setFront();
+		const overlay = markOverlay(box, {
+			screen,
+			pausedKeys: ['C-s', 'C-c', 'q', 'escape'],
+			// After a global popup hide/show, route focus back to the
+			// raw-JSON textarea instead of the outer box.
+			getFocusTarget: () => ta,
+		});
+		const restoreKeys = (): void => overlay.release();
 
-        blessed.box({
-            parent: box,
-            top: 0,
-            left: 0,
-            right: 0,
-            height: 1,
-            tags: true,
-            style: { fg: FG_MUTED, bg: BG_PANEL },
-            content: ` {${ACCENT_CYAN}-fg}[Ctrl-S]{/} save  {${ACCENT_RED}-fg}[Esc / Ctrl-C]{/} cancel`,
-        });
+		blessed.box({
+			parent: box,
+			top: 0,
+			left: 0,
+			right: 0,
+			height: 1,
+			tags: true,
+			style: { fg: FG_MUTED, bg: BG_PANEL },
+			content: ` {${ACCENT_CYAN}-fg}[Ctrl-S]{/} save  {${ACCENT_RED}-fg}[Esc / Ctrl-C]{/} cancel`,
+		});
 
-        const status = blessed.box({
-            parent: box,
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: 1,
-            tags: true,
-            style: { fg: FG_MUTED, bg: BG_PANEL },
-            content: '',
-        });
+		const status = blessed.box({
+			parent: box,
+			bottom: 0,
+			left: 0,
+			right: 0,
+			height: 1,
+			tags: true,
+			style: { fg: FG_MUTED, bg: BG_PANEL },
+			content: '',
+		});
 
-        const ta = blessed.textarea({
-            parent: box,
-            top: 1,
-            left: 1,
-            right: 1,
-            bottom: 1,
-            inputOnFocus: true,
-            keys: true,
-            mouse: true,
-            scrollable: true,
-            style: { fg: FG_BODY, bg: BG_PANEL },
-        });
+		const ta = blessed.textarea({
+			parent: box,
+			top: 1,
+			left: 1,
+			right: 1,
+			bottom: 1,
+			inputOnFocus: true,
+			keys: true,
+			mouse: true,
+			scrollable: true,
+			style: { fg: FG_BODY, bg: BG_PANEL },
+		});
 
-        try {
-            ta.setValue(JSON.stringify(initial, null, 2));
-        } catch {
-            ta.setValue(String(initial));
-        }
+		try {
+			ta.setValue(JSON.stringify(initial, null, 2));
+		} catch {
+			ta.setValue(String(initial));
+		}
 
-        const cleanup = (result: unknown | null): void => {
-            box.destroy();
-            restoreKeys();
-            if (savedFocus) {
-                try { savedFocus.focus(); } catch { /* ignore */ }
-            }
-            screen.render();
-            resolve(result);
-        };
+		const cleanup = (result: unknown | null): void => {
+			box.destroy();
+			restoreKeys();
+			if (savedFocus) {
+				try { savedFocus.focus(); } catch { /* ignore */ }
+			}
+			screen.render();
+			resolve(result);
+		};
 
-        const trySave = (): void => {
-            const raw = ta.getValue();
-            try {
-                cleanup(JSON.parse(raw));
-            } catch (e) {
-                const msg = e instanceof Error ? e.message : String(e);
-                status.setContent(`{red-fg} ✗ JSON parse error: ${msg}{/red-fg}`);
-                screen.render();
-            }
-        };
+		const trySave = (): void => {
+			const raw = ta.getValue();
+			try {
+				cleanup(JSON.parse(raw));
+			} catch (e) {
+				const msg = e instanceof Error ? e.message : String(e);
+				status.setContent(`{red-fg} ✗ JSON parse error: ${msg}{/red-fg}`);
+				screen.render();
+			}
+		};
 
-        ta.key(['C-s'], trySave);
-        ta.key(['escape', 'C-c'], () => cleanup(null));
+		ta.key(['C-s'], trySave);
+		ta.key(['escape', 'C-c'], () => cleanup(null));
 
-        ta.focus();
-        screen.render();
-    });
+		ta.focus();
+		screen.render();
+	});
 }
 
 // --- helpers --------------------------------------------------------------
 
 function inferKind(v: unknown): FieldKind {
-    if (typeof v === 'string') return 'string';
-    if (typeof v === 'number') return 'number';
-    if (typeof v === 'boolean') return 'boolean';
+	if (typeof v === 'string') return 'string';
+	if (typeof v === 'number') return 'number';
+	if (typeof v === 'boolean') return 'boolean';
 
-    return 'json';
+	return 'json';
 }
 
 function kindColor(kind: FieldKind): string {
-    switch (kind) {
-        case 'string':  return ACCENT_GREEN;
-        case 'number':  return ACCENT_MAGENTA;
-        case 'boolean': return ACCENT_CYAN;
-        default:        return ACCENT_YELLOW;
-    }
+	switch (kind) {
+		case 'string': return ACCENT_GREEN;
+		case 'number': return ACCENT_MAGENTA;
+		case 'boolean': return ACCENT_CYAN;
+		default: return ACCENT_YELLOW;
+	}
 }
 
 function stringifyForKind(v: unknown, kind: FieldKind): string {
-    if (kind === 'string') return v == null ? '' : String(v);
-    if (kind === 'number' || kind === 'boolean') return String(v);
-    try { return JSON.stringify(v); } catch { return String(v); }
+	if (kind === 'string') return v == null ? '' : String(v);
+	if (kind === 'number' || kind === 'boolean') return String(v);
+	try { return JSON.stringify(v); } catch { return String(v); }
 }
 
-interface ParseOk  { ok: true;  value: unknown }
+interface ParseOk { ok: true; value: unknown }
 interface ParseErr { ok: false; error: string }
 
 function parseForKind(raw: string, kind: FieldKind): ParseOk | ParseErr {
-    if (kind === 'string') return { ok: true, value: raw };
-    if (kind === 'number') {
-        if (raw === '') return { ok: false, error: 'expected a number' };
-        const n = Number(raw);
-        if (!Number.isFinite(n)) return { ok: false, error: `not a number: ${raw}` };
+	if (kind === 'string') return { ok: true, value: raw };
+	if (kind === 'number') {
+		if (raw === '') return { ok: false, error: 'expected a number' };
+		const n = Number(raw);
+		if (!Number.isFinite(n)) return { ok: false, error: `not a number: ${raw}` };
 
-        return { ok: true, value: n };
-    }
-    if (kind === 'boolean') {
-        if (raw === 'true')  return { ok: true, value: true };
-        if (raw === 'false') return { ok: true, value: false };
+		return { ok: true, value: n };
+	}
+	if (kind === 'boolean') {
+		if (raw === 'true') return { ok: true, value: true };
+		if (raw === 'false') return { ok: true, value: false };
 
-        return { ok: false, error: `expected true/false, got: ${raw}` };
-    }
-    // json
-    try {
-        return { ok: true, value: JSON.parse(raw) };
-    } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
+		return { ok: false, error: `expected true/false, got: ${raw}` };
+	}
+	// json
+	try {
+		return { ok: true, value: JSON.parse(raw) };
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
 
-        return { ok: false, error: `invalid JSON (${msg})` };
-    }
+		return { ok: false, error: `invalid JSON (${msg})` };
+	}
 }
 
 function escapeTags(s: string): string {
-    return s.replace(/[{}]/g, (c) => (c === '{' ? '{open}' : '{close}'));
+	return s.replace(/[{}]/g, (c) => (c === '{' ? '{open}' : '{close}'));
 }
+

--- a/src/AI/TUI/widgets/toolHistoryPanel.ts
+++ b/src/AI/TUI/widgets/toolHistoryPanel.ts
@@ -12,176 +12,186 @@ import { BG_PRIMARY, BG_PANEL, BORDER_DIM } from '../theme';
 import type { ToolHistoryStore, ToolHistoryEntry } from '../state/toolHistory';
 
 function fmtTime(ms: number): string {
-    const d = new Date(ms);
-    const pad = (n: number): string => String(n).padStart(2, '0');
-    return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+	const d = new Date(ms);
+	const pad = (n: number): string => String(n).padStart(2, '0');
+	return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
 function fmtDuration(start: number, end?: number): string {
-    if (!end) return ' ··· ';
-    const ms = end - start;
-    if (ms < 1000) return `${ms}ms`;
-    return `${(ms / 1000).toFixed(2)}s`;
+	if (!end) return ' ··· ';
+	const ms = end - start;
+	if (ms < 1000) return `${ms}ms`;
+	return `${(ms / 1000).toFixed(2)}s`;
 }
 
 function statusBadge(status: ToolHistoryEntry['status']): string {
-    if (status === 'running') return '{yellow-fg}\u25CF run{/yellow-fg}';
-    if (status === 'ok')      return '{green-fg}\u2713 ok{/green-fg}';
-    return '{red-fg}\u2717 fail{/red-fg}';
+	if (status === 'running') return '{yellow-fg}\u25CF run{/yellow-fg}';
+	if (status === 'ok') return '{green-fg}\u2713 ok{/green-fg}';
+	return '{red-fg}\u2717 fail{/red-fg}';
 }
 
 function escapeTags(s: string): string {
-    return s.replace(/[{}]/g, (c) => (c === '{' ? '{open}' : '{close}'));
+	return s.replace(/[{}]/g, (c) => (c === '{' ? '{open}' : '{close}'));
 }
 
 export async function showToolHistoryPanel(
-    screen: blessed.Widgets.Screen,
-    store: ToolHistoryStore,
+	screen: blessed.Widgets.Screen,
+	store: ToolHistoryStore,
 ): Promise<void> {
-    return new Promise((resolve) => {
-        const savedFocus = screen.focused;
+	return new Promise((resolve) => {
+		const savedFocus = screen.focused;
 
-        const box = blessed.box({
-            parent: screen,
-            label: ' Tool-call history ',
-            top: 'center',
-            left: 'center',
-            width: '90%',
-            height: '85%',
-            border: { type: 'line' },
-            style: { border: { fg: BORDER_DIM }, bg: BG_PRIMARY },
-            tags: true,
-        });
-         box.setFront();
-         const overlay = markOverlay(box, {
-             screen,
-             pausedKeys: ['q', 'C-c', 'escape', 'tab', 'S-tab'],
-         });
-         const restoreKeys = (): void => overlay.release();
+		const box = blessed.box({
+			parent: screen,
+			label: ' Tool-call history ',
+			top: 'center',
+			left: 'center',
+			width: '90%',
+			height: '85%',
+			border: { type: 'line' },
+			style: { border: { fg: BORDER_DIM }, bg: BG_PRIMARY },
+			tags: true,
+		});
+		box.setFront();
 
-        const list = blessed.list({
-            parent: box,
-            top: 0,
-            left: 0,
-            width: '40%',
-            bottom: 2,
-            keys: true,
-            mouse: true,
-            tags: true,
-            scrollable: true,
-            scrollbar: { ch: ' ', style: { bg: 'gray' } },
-            style: {
-                bg: BG_PRIMARY,
-                item: { fg: 'white' },
-                selected: { bg: 'cyan', fg: 'black', bold: true },
-            },
-            border: { type: 'line' },
-        });
+		const list = blessed.list({
+			parent: box,
+			top: 0,
+			left: 0,
+			width: '40%',
+			bottom: 2,
+			keys: true,
+			mouse: true,
+			tags: true,
+			scrollable: true,
+			scrollbar: { ch: ' ', style: { bg: 'gray' } },
+			style: {
+				bg: BG_PRIMARY,
+				item: { fg: 'white' },
+				selected: { bg: 'cyan', fg: 'black', bold: true },
+			},
+			border: { type: 'line' },
+		});
 
-        const detail = blessed.box({
-            parent: box,
-            top: 0,
-            right: 0,
-            width: '60%',
-            bottom: 2,
-            tags: true,
-            scrollable: true,
-            alwaysScroll: true,
-            keys: true,
-            mouse: true,
-            scrollbar: { ch: ' ', style: { bg: 'gray' } },
-            style: { bg: BG_PRIMARY, fg: 'white' },
-            border: { type: 'line' },
-            content: '',
-        });
+		const detail = blessed.box({
+			parent: box,
+			top: 0,
+			right: 0,
+			width: '60%',
+			bottom: 2,
+			tags: true,
+			scrollable: true,
+			alwaysScroll: true,
+			keys: true,
+			mouse: true,
+			scrollbar: { ch: ' ', style: { bg: 'gray' } },
+			style: { bg: BG_PRIMARY, fg: 'white' },
+			border: { type: 'line' },
+			content: '',
+		});
 
-        blessed.box({
-            parent: box,
-            bottom: 0,
-            left: 1,
-            right: 1,
-            height: 2,
-            tags: true,
-            style: { bg: BG_PANEL },
-            content:
-                '{cyan-fg}[\u2191/\u2193 j/k]{/cyan-fg} navigate  ' +
-                '{cyan-fg}[Tab]{/cyan-fg} switch focus  ' +
-                '{cyan-fg}[c]{/cyan-fg} clear  ' +
-                '{red-fg}[q/Esc]{/red-fg} close',
-        });
+		blessed.box({
+			parent: box,
+			bottom: 0,
+			left: 1,
+			right: 1,
+			height: 2,
+			tags: true,
+			style: { bg: BG_PANEL },
+			content:
+				'{cyan-fg}[\u2191/\u2193 j/k]{/cyan-fg} navigate  ' +
+				'{cyan-fg}[Tab]{/cyan-fg} switch focus  ' +
+				'{cyan-fg}[c]{/cyan-fg} clear  ' +
+				'{red-fg}[q/Esc]{/red-fg} close',
+		});
 
-        const renderList = (): void => {
-            const entries = store.list().slice().reverse();
-            if (entries.length === 0) {
-                list.setItems(['{gray-fg}(no tool calls yet){/gray-fg}']);
-                detail.setContent('{gray-fg}History is empty. Trigger a web_fetch / web_search etc. and it will show up here.{/gray-fg}');
-                screen.render();
-                return;
-            }
-            const items = entries.map((e) => {
-                const status = statusBadge(e.status);
-                return ` ${status} {bold}${escapeTags(e.toolName)}{/bold} {gray-fg}\u00b7 ${fmtTime(e.startedAt)}{/gray-fg}`;
-            });
-            list.setItems(items);
-            const sel = (list as unknown as { selected?: number }).selected ?? 0;
-            renderDetail(entries[sel]);
-            screen.render();
-        };
+		const renderList = (): void => {
+			const entries = store.list().slice().reverse();
+			if (entries.length === 0) {
+				list.setItems(['{gray-fg}(no tool calls yet){/gray-fg}']);
+				detail.setContent('{gray-fg}History is empty. Trigger a web_fetch / web_search etc. and it will show up here.{/gray-fg}');
+				screen.render();
+				return;
+			}
+			const items = entries.map((e) => {
+				const status = statusBadge(e.status);
+				return ` ${status} {bold}${escapeTags(e.toolName)}{/bold} {gray-fg}\u00b7 ${fmtTime(e.startedAt)}{/gray-fg}`;
+			});
+			list.setItems(items);
+			const sel = (list as unknown as { selected?: number }).selected ?? 0;
+			renderDetail(entries[sel]);
+			screen.render();
+		};
 
-        const renderDetail = (entry: ToolHistoryEntry | undefined): void => {
-            if (!entry) { detail.setContent(''); return; }
-            const lines: string[] = [];
-            lines.push(`{cyan-fg}Tool:{/cyan-fg} ${escapeTags(entry.toolName)}`);
-            lines.push(`{cyan-fg}Status:{/cyan-fg} ${statusBadge(entry.status)}  {gray-fg}(${fmtDuration(entry.startedAt, entry.finishedAt)}){/gray-fg}`);
-            lines.push(`{cyan-fg}Started:{/cyan-fg} ${fmtTime(entry.startedAt)}`);
-            if (entry.finishedAt) lines.push(`{cyan-fg}Finished:{/cyan-fg} ${fmtTime(entry.finishedAt)}`);
-            if (entry.summary) {
-                lines.push('');
-                lines.push('{gray-fg}── Summary ──────────────────────────{/gray-fg}');
-                lines.push(escapeTags(entry.summary));
-            }
-            lines.push('');
-            lines.push('{gray-fg}── Args ─────────────────────────────{/gray-fg}');
-            lines.push(escapeTags(entry.argsJson));
-            if (entry.result !== undefined) {
-                lines.push('');
-                lines.push(`{gray-fg}── Result ${entry.status === 'fail' ? '{red-fg}(failed){/red-fg}' : '{green-fg}(ok){/green-fg}'} ──────────────────────{/gray-fg}`);
-                const truncated = entry.result.length > 8000
-                    ? entry.result.slice(0, 8000) + `\n\n… (${entry.result.length - 8000} more chars)`
-                    : entry.result;
-                lines.push(escapeTags(truncated));
-            }
-            detail.setContent(lines.join('\n'));
-            detail.scrollTo(0);
-        };
+		const renderDetail = (entry: ToolHistoryEntry | undefined): void => {
+			if (!entry) { detail.setContent(''); return; }
+			const lines: string[] = [];
+			lines.push(`{cyan-fg}Tool:{/cyan-fg} ${escapeTags(entry.toolName)}`);
+			lines.push(`{cyan-fg}Status:{/cyan-fg} ${statusBadge(entry.status)}  {gray-fg}(${fmtDuration(entry.startedAt, entry.finishedAt)}){/gray-fg}`);
+			lines.push(`{cyan-fg}Started:{/cyan-fg} ${fmtTime(entry.startedAt)}`);
+			if (entry.finishedAt) lines.push(`{cyan-fg}Finished:{/cyan-fg} ${fmtTime(entry.finishedAt)}`);
+			if (entry.summary) {
+				lines.push('');
+				lines.push('{gray-fg}── Summary ──────────────────────────{/gray-fg}');
+				lines.push(escapeTags(entry.summary));
+			}
+			lines.push('');
+			lines.push('{gray-fg}── Args ─────────────────────────────{/gray-fg}');
+			lines.push(escapeTags(entry.argsJson));
+			if (entry.result !== undefined) {
+				lines.push('');
+				lines.push(`{gray-fg}── Result ${entry.status === 'fail' ? '{red-fg}(failed){/red-fg}' : '{green-fg}(ok){/green-fg}'} ──────────────────────{/gray-fg}`);
+				const truncated = entry.result.length > 8000
+					? entry.result.slice(0, 8000) + `\n\n… (${entry.result.length - 8000} more chars)`
+					: entry.result;
+				lines.push(escapeTags(truncated));
+			}
+			detail.setContent(lines.join('\n'));
+			detail.scrollTo(0);
+		};
 
-        const cleanup = (): void => {
-            box.destroy();
-            restoreKeys();
-            if (savedFocus) {
-                try { savedFocus.focus(); } catch { /* ignore */ }
-            }
-            screen.render();
-            resolve();
-        };
+		const cleanup = (): void => {
+			box.destroy();
+			restoreKeys();
+			if (savedFocus) {
+				try { savedFocus.focus(); } catch { /* ignore */ }
+			}
+			screen.render();
+			resolve();
+		};
 
-        list.on('select item', () => {
-            const entries = store.list().slice().reverse();
-            renderDetail(entries[(list as unknown as { selected?: number }).selected ?? 0]);
-            screen.render();
-        });
+		list.on('select item', () => {
+			const entries = store.list().slice().reverse();
+			renderDetail(entries[(list as unknown as { selected?: number }).selected ?? 0]);
+			screen.render();
+		});
 
-        list.key(['enter'], () => detail.focus());
-        list.key(['tab'], () => detail.focus());
-        detail.key(['tab'], () => list.focus());
-        detail.key(['S-tab'], () => list.focus());
-        list.key(['c'], () => { store.clear(); renderList(); });
-        list.key(['q', 'escape', 'C-c'], cleanup);
-        detail.key(['q', 'escape', 'C-c'], cleanup);
-        box.key(['q', 'escape', 'C-c'], cleanup);
+		list.key(['enter'], () => detail.focus());
+		list.key(['tab'], () => detail.focus());
+		detail.key(['tab'], () => list.focus());
+		detail.key(['S-tab'], () => list.focus());
 
-        renderList();
-        list.focus();
-        screen.render();
-    });
+		// Track which pane (list vs detail) was last focused so that when
+		// the popup is hidden + re-shown via the global toggle, focus goes
+		// back to the right inner widget rather than the outer box.
+		let lastInnerFocus: blessed.Widgets.BlessedElement = list;
+		list.on('focus', () => { lastInnerFocus = list; });
+		detail.on('focus', () => { lastInnerFocus = detail; });
+
+		const overlay = markOverlay(box, {
+			screen,
+			pausedKeys: ['q', 'C-c', 'escape', 'tab', 'S-tab'],
+			getFocusTarget: () => lastInnerFocus,
+		});
+		const restoreKeys = (): void => overlay.release();
+		list.key(['c'], () => { store.clear(); renderList(); });
+		list.key(['q', 'escape', 'C-c'], cleanup);
+		detail.key(['q', 'escape', 'C-c'], cleanup);
+		box.key(['q', 'escape', 'C-c'], cleanup);
+
+		renderList();
+		list.focus();
+		screen.render();
+	});
 }
+

--- a/src/AI/TUI/widgets/toolSpinner.ts
+++ b/src/AI/TUI/widgets/toolSpinner.ts
@@ -3,29 +3,40 @@ import { markOverlay } from '../state/popupRegistry';
 import { BG_PANEL, BORDER_DIM } from '../theme';
 
 interface ActiveEntry {
-    callId: string;
-    toolName: string;
-    summary: string;
-    argsJson: string;
-    /** Full multi-line details string built by the agent (Arguments,
-     *  progress, etc.). Shown in the indicator under the tool name so
-     *  the user can see WHAT the tool is doing without opening the
-     *  history popup — mirrors how the nvim plugin formats the body. */
-    details: string;
-    startedAt: number;
+	callId: string;
+	toolName: string;
+	summary: string;
+	argsJson: string;
+	/** Full multi-line details string built by the agent (Arguments,
+	 *  progress, etc.). Shown in the indicator under the tool name so
+	 *  the user can see WHAT the tool is doing without opening the
+	 *  history popup — mirrors how the nvim plugin formats the body. */
+	details: string;
+	startedAt: number;
 }
 
 interface RecentEntry {
-    toolName: string;
-    summary: string;
-    success: boolean;
-    finishedAt: number;
+	toolName: string;
+	summary: string;
+	success: boolean;
+	finishedAt: number;
+	/** Trimmed preview of the actual result string the agent received
+	 *  back from the tool. Surfaced in the spinner popup for the few
+	 *  seconds the entry lingers so the user can see, at a glance, what
+	 *  the AI was told (e.g. a deny reason, a tiny diff summary, the
+	 *  first lines of a fetched page). */
+	resultPreview: string;
 }
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-const RECENT_LINGER_MS = 2500;
+// Linger longer once results are shown so the user has time to actually
+// read the preview before it disappears.
+const RECENT_LINGER_MS = 6000;
 const MAX_RECENT = 3;
 const BODY_WIDTH = 70;
+// Recent-result preview shown under each completed tool entry.
+const RESULT_PREVIEW_ROWS = 6;
+const RESULT_PREVIEW_WIDTH = 76;
 
 /**
  * Top-right floating popup that shows currently-running tool calls with
@@ -36,183 +47,194 @@ const BODY_WIDTH = 70;
  * it with the global "hide popups" toggle (<space> t).
  */
 export class ToolSpinnerWidget {
-    private box: blessed.Widgets.BoxElement;
-    private active = new Map<string, ActiveEntry>();
-    private recent: RecentEntry[] = [];
-    private frame = 0;
-    private timer: NodeJS.Timeout | null = null;
-    private fallbackSeq = 0;
+	private box: blessed.Widgets.BoxElement;
+	private active = new Map<string, ActiveEntry>();
+	private recent: RecentEntry[] = [];
+	private frame = 0;
+	private timer: NodeJS.Timeout | null = null;
+	private fallbackSeq = 0;
 
-    constructor(private screen: blessed.Widgets.Screen) {
-        this.box = blessed.box({
-            parent: screen,
-            top: 1,
-            right: 1,
-            width: 80,
-            height: 'shrink' as unknown as number,
-            label: ' Tools ',
-            border: { type: 'line' },
-            style: { border: { fg: BORDER_DIM }, bg: BG_PANEL },
-            tags: true,
-        });
-        this.box.hide();
-        this.box.setFront();
-        markOverlay(this.box);
-    }
+	constructor(private screen: blessed.Widgets.Screen) {
+		this.box = blessed.box({
+			parent: screen,
+			top: 1,
+			right: 1,
+			width: 80,
+			height: 'shrink' as unknown as number,
+			label: ' Tools ',
+			border: { type: 'line' },
+			style: { border: { fg: BORDER_DIM }, bg: BG_PANEL },
+			tags: true,
+		});
+		this.box.hide();
+		this.box.setFront();
+		// Spinner is purely decorative — never let PopupRegistry steal
+		// focus to it (would strand the user inside an unresponsive
+		// status box while a real modal sits underneath).
+		markOverlay(this.box, { focusable: false });
+	}
 
-    start(input: { toolName: string, summary: string, details?: string, argsJson?: string, callId?: string }): void {
-        const callId = input.callId ?? `__nokey_${++this.fallbackSeq}`;
-        this.active.set(callId, {
-            callId,
-            toolName: input.toolName,
-            summary: input.summary,
-            details: input.details ?? '',
-            argsJson: input.argsJson ?? '',
-            startedAt: Date.now(),
-        });
-        this.render();
-        this.ensureTicking();
-    }
+	start(input: { toolName: string, summary: string, details?: string, argsJson?: string, callId?: string }): void {
+		const callId = input.callId ?? `__nokey_${++this.fallbackSeq}`;
+		this.active.set(callId, {
+			callId,
+			toolName: input.toolName,
+			summary: input.summary,
+			details: input.details ?? '',
+			argsJson: input.argsJson ?? '',
+			startedAt: Date.now(),
+		});
+		this.render();
+		this.ensureTicking();
+	}
 
-    /** Refresh an in-flight entry's summary/details (e.g. when a tool
-     *  emits a progress message). No-op if the entry is unknown. */
-    update(input: { toolName: string, summary?: string, details?: string, callId?: string }): void {
-        let target: ActiveEntry | undefined;
-        if (input.callId && this.active.has(input.callId)) {
-            target = this.active.get(input.callId);
-        } else {
-            for (const v of this.active.values()) {
-                if (v.toolName === input.toolName) { target = v; break; }
-            }
-        }
-        if (!target) return;
-        if (input.summary !== undefined) target.summary = input.summary;
-        if (input.details !== undefined) target.details = input.details;
-        this.render();
-    }
+	/** Refresh an in-flight entry's summary/details (e.g. when a tool
+	 *  emits a progress message). No-op if the entry is unknown. */
+	update(input: { toolName: string, summary?: string, details?: string, callId?: string }): void {
+		let target: ActiveEntry | undefined;
+		if (input.callId && this.active.has(input.callId)) {
+			target = this.active.get(input.callId);
+		} else {
+			for (const v of this.active.values()) {
+				if (v.toolName === input.toolName) { target = v; break; }
+			}
+		}
+		if (!target) return;
+		if (input.summary !== undefined) target.summary = input.summary;
+		if (input.details !== undefined) target.details = input.details;
+		this.render();
+	}
 
-    complete(input: { toolName: string, success: boolean, callId?: string }): void {
-        let target: ActiveEntry | undefined;
-        if (input.callId && this.active.has(input.callId)) {
-            target = this.active.get(input.callId);
-            this.active.delete(input.callId);
-        } else {
-            for (const [k, v] of this.active) {
-                if (v.toolName === input.toolName) {
-                    target = v;
-                    this.active.delete(k);
-                    break;
-                }
-            }
-        }
-        const summary = target?.summary ?? input.toolName;
-        this.recent.unshift({
-            toolName: input.toolName,
-            summary,
-            success: input.success,
-            finishedAt: Date.now(),
-        });
-        if (this.recent.length > MAX_RECENT) this.recent.length = MAX_RECENT;
-        this.render();
-        this.ensureTicking();
-    }
+	complete(input: { toolName: string, success: boolean, result?: string, callId?: string }): void {
+		let target: ActiveEntry | undefined;
+		if (input.callId && this.active.has(input.callId)) {
+			target = this.active.get(input.callId);
+			this.active.delete(input.callId);
+		} else {
+			for (const [k, v] of this.active) {
+				if (v.toolName === input.toolName) {
+					target = v;
+					this.active.delete(k);
+					break;
+				}
+			}
+		}
+		const summary = target?.summary ?? input.toolName;
+		this.recent.unshift({
+			toolName: input.toolName,
+			summary,
+			success: input.success,
+			finishedAt: Date.now(),
+			resultPreview: previewResult(input.result ?? ''),
+		});
+		if (this.recent.length > MAX_RECENT) this.recent.length = MAX_RECENT;
+		this.render();
+		this.ensureTicking();
+	}
 
-    private ensureTicking(): void {
-        const needsTick = this.active.size > 0 || this.recent.length > 0;
-        if (needsTick && !this.timer) {
-            this.timer = setInterval(() => {
-                this.frame = (this.frame + 1) % SPINNER_FRAMES.length;
-                // Drop expired recents.
-                const now = Date.now();
-                const before = this.recent.length;
-                this.recent = this.recent.filter((r) => now - r.finishedAt < RECENT_LINGER_MS);
-                if (this.recent.length !== before || this.active.size > 0) this.render();
-                else this.render();
-                if (this.active.size === 0 && this.recent.length === 0) {
-                    this.stopTicking();
-                }
-            }, 100);
-        } else if (!needsTick && this.timer) {
-            this.stopTicking();
-        }
-    }
+	private ensureTicking(): void {
+		const needsTick = this.active.size > 0 || this.recent.length > 0;
+		if (needsTick && !this.timer) {
+			this.timer = setInterval(() => {
+				this.frame = (this.frame + 1) % SPINNER_FRAMES.length;
+				// Drop expired recents.
+				const now = Date.now();
+				const before = this.recent.length;
+				this.recent = this.recent.filter((r) => now - r.finishedAt < RECENT_LINGER_MS);
+				if (this.recent.length !== before || this.active.size > 0) this.render();
+				else this.render();
+				if (this.active.size === 0 && this.recent.length === 0) {
+					this.stopTicking();
+				}
+			}, 100);
+		} else if (!needsTick && this.timer) {
+			this.stopTicking();
+		}
+	}
 
-    private stopTicking(): void {
-        if (this.timer) { clearInterval(this.timer); this.timer = null; }
-    }
+	private stopTicking(): void {
+		if (this.timer) { clearInterval(this.timer); this.timer = null; }
+	}
 
-    private render(): void {
-        if (this.active.size === 0 && this.recent.length === 0) {
-            this.box.hide();
-            this.screen.render();
+	private render(): void {
+		if (this.active.size === 0 && this.recent.length === 0) {
+			this.box.hide();
+			this.screen.render();
 
-            return;
-        }
-        if ((this.box as unknown as { __kraHidden?: boolean }).__kraHidden) {
-            // Globally hidden by PopupRegistry — don't fight the user.
-            this.screen.render();
+			return;
+		}
+		if ((this.box as unknown as { __kraHidden?: boolean }).__kraHidden) {
+			// Globally hidden by PopupRegistry — don't fight the user.
+			this.screen.render();
 
-            return;
-        }
-        const sp = SPINNER_FRAMES[this.frame];
-        const lines: string[] = [];
-        for (const e of this.active.values()) {
-            const elapsed = formatElapsed(Date.now() - e.startedAt);
-            lines.push(` {#d4b860-fg}${sp}{/} {bold}${escapeTags(e.toolName)}{/bold}  {gray-fg}${elapsed}{/gray-fg}`);
-            if (e.summary) {
-                lines.push(`   {#7fb8c9-fg}${escapeTags(truncate(e.summary, BODY_WIDTH))}{/}`);
-            }
-            // Prefer the rich `details` body over a flat argsJson dump.
-            // It already includes "Arguments: …" / "Streaming tool output…"
-            // / progress text built by the agent. Fallback to argPreview
-            // when no details were supplied (older code paths).
-            const detailLines = pickDetailLines(e.details, 6);
-            if (detailLines.length > 0) {
-                for (const detail of detailLines) {
-                    lines.push(`   {gray-fg}${escapeTags(truncate(detail, BODY_WIDTH))}{/gray-fg}`);
-                }
-            } else {
-                for (const detail of argPreview(e.argsJson, 3)) {
-                    lines.push(`   {gray-fg}${escapeTags(truncate(detail, BODY_WIDTH))}{/gray-fg}`);
-                }
-            }
-        }
-        if (this.active.size > 0 && this.recent.length > 0) {
-            lines.push(' {gray-fg}──────────────────────────────────────{/gray-fg}');
-        }
-        for (const r of this.recent) {
-            const icon = r.success ? '{green-fg}\u2713{/green-fg}' : '{red-fg}\u2717{/red-fg}';
-            const name = r.success
-                ? `{green-fg}${escapeTags(r.toolName)}{/green-fg}`
-                : `{red-fg}${escapeTags(r.toolName)}{/red-fg}`;
-            lines.push(` ${icon} ${name}  {gray-fg}${escapeTags(truncate(r.summary, BODY_WIDTH))}{/gray-fg}`);
-        }
-        this.box.height = lines.length + 2;
-        this.box.setContent(lines.join('\n'));
-        this.box.show();
-        this.box.setFront();
-        this.screen.render();
-    }
+			return;
+		}
+		const sp = SPINNER_FRAMES[this.frame];
+		const lines: string[] = [];
+		for (const e of this.active.values()) {
+			const elapsed = formatElapsed(Date.now() - e.startedAt);
+			lines.push(` {#d4b860-fg}${sp}{/} {bold}${escapeTags(e.toolName)}{/bold}  {gray-fg}${elapsed}{/gray-fg}`);
+			if (e.summary) {
+				lines.push(`   {#7fb8c9-fg}${escapeTags(truncate(e.summary, BODY_WIDTH))}{/}`);
+			}
+			// Prefer the rich `details` body over a flat argsJson dump.
+			// It already includes "Arguments: …" / "Streaming tool output…"
+			// / progress text built by the agent. Fallback to argPreview
+			// when no details were supplied (older code paths).
+			const detailLines = pickDetailLines(e.details, 6);
+			if (detailLines.length > 0) {
+				for (const detail of detailLines) {
+					lines.push(`   {gray-fg}${escapeTags(truncate(detail, BODY_WIDTH))}{/gray-fg}`);
+				}
+			} else {
+				for (const detail of argPreview(e.argsJson, 3)) {
+					lines.push(`   {gray-fg}${escapeTags(truncate(detail, BODY_WIDTH))}{/gray-fg}`);
+				}
+			}
+		}
+		if (this.active.size > 0 && this.recent.length > 0) {
+			lines.push(' {gray-fg}──────────────────────────────────────{/gray-fg}');
+		}
+		for (const r of this.recent) {
+			const icon = r.success ? '{green-fg}\u2713{/green-fg}' : '{red-fg}\u2717{/red-fg}';
+			const name = r.success
+				? `{green-fg}${escapeTags(r.toolName)}{/green-fg}`
+				: `{red-fg}${escapeTags(r.toolName)}{/red-fg}`;
+			lines.push(` ${icon} ${name}  {gray-fg}${escapeTags(truncate(r.summary, BODY_WIDTH))}{/gray-fg}`);
+			if (r.resultPreview) {
+				const label = r.success ? 'result' : 'error';
+				const color = r.success ? '#7fb8c9' : '#d4a0a0';
+				for (const line of r.resultPreview.split('\n')) {
+					lines.push(`     {gray-fg}${label}{/gray-fg} {${color}-fg}${escapeTags(line)}{/}`);
+				}
+			}
+		}
+		this.box.height = lines.length + 2;
+		this.box.setContent(lines.join('\n'));
+		this.box.show();
+		this.box.setFront();
+		this.screen.render();
+	}
 }
 
 function escapeTags(s: string): string {
-    return s.replace(/[{}]/g, (c) => (c === '{' ? '{open}' : '{close}'));
+	return s.replace(/[{}]/g, (c) => (c === '{' ? '{open}' : '{close}'));
 }
 
 function truncate(s: string, max: number): string {
-    if (s.length <= max) return s;
+	if (s.length <= max) return s;
 
-    return s.slice(0, max - 1) + '\u2026';
+	return s.slice(0, max - 1) + '\u2026';
 }
 
 function formatElapsed(ms: number): string {
-    if (ms < 1000) return `${ms}ms`;
-    const s = ms / 1000;
-    if (s < 60) return `${s.toFixed(1)}s`;
-    const m = Math.floor(s / 60);
-    const r = Math.floor(s % 60);
+	if (ms < 1000) return `${ms}ms`;
+	const s = ms / 1000;
+	if (s < 60) return `${s.toFixed(1)}s`;
+	const m = Math.floor(s / 60);
+	const r = Math.floor(s % 60);
 
-    return `${m}m${r.toString().padStart(2, '0')}s`;
+	return `${m}m${r.toString().padStart(2, '0')}s`;
 }
 
 /** Pick a compact slice of the agent's `details` string for display
@@ -220,44 +242,62 @@ function formatElapsed(ms: number): string {
  *  (it duplicates info we already show), trims blanks, and caps to
  *  `maxRows`. */
 function pickDetailLines(details: string, maxRows: number): string[] {
-    if (!details) return [];
-    const raw = details.split('\n');
-    const out: string[] = [];
-    let skippedHeader = false;
-    for (const line of raw) {
-        const trimmed = line.trim();
-        if (!skippedHeader && /^Running\s+/i.test(trimmed)) {
-            skippedHeader = true;
-            continue;
-        }
-        if (trimmed.length === 0) continue;
-        out.push(trimmed);
-        if (out.length >= maxRows) break;
-    }
-    if (raw.length > out.length + (skippedHeader ? 1 : 0)) {
-        out.push('…');
-    }
+	if (!details) return [];
+	const raw = details.split('\n');
+	const out: string[] = [];
+	let skippedHeader = false;
+	for (const line of raw) {
+		const trimmed = line.trim();
+		if (!skippedHeader && /^Running\s+/i.test(trimmed)) {
+			skippedHeader = true;
+			continue;
+		}
+		if (trimmed.length === 0) continue;
+		out.push(trimmed);
+		if (out.length >= maxRows) break;
+	}
+	if (raw.length > out.length + (skippedHeader ? 1 : 0)) {
+		out.push('…');
+	}
 
-    return out;
+	return out;
+}
+
+/** Compact preview of the AI-visible result string. Trims blank lines,
+ *  caps to a few rows of `RESULT_PREVIEW_WIDTH` chars each, and adds a
+ *  trailing … line when the original was longer. Empty result → ''. */
+function previewResult(result: string): string {
+	if (!result) return '';
+	const raw = result.replace(/\r/g, '').split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+	if (raw.length === 0) return '';
+	const out: string[] = [];
+	for (const line of raw) {
+		if (out.length >= RESULT_PREVIEW_ROWS) break;
+		out.push(truncate(line, RESULT_PREVIEW_WIDTH));
+	}
+	if (raw.length > out.length) out.push('…');
+
+	return out.join('\n');
 }
 
 function argPreview(argsJson: string, maxRows: number): string[] {
-    if (!argsJson) return [];
-    let parsed: unknown;
-    try { parsed = JSON.parse(argsJson); } catch { return []; }
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
-    const entries = Object.entries(parsed as Record<string, unknown>);
-    const out: string[] = [];
-    for (const [k, v] of entries) {
-        if (out.length >= maxRows) break;
-        let val: string;
-        if (v === null) val = 'null';
-        else if (typeof v === 'string') val = v;
-        else if (typeof v === 'number' || typeof v === 'boolean') val = String(v);
-        else { try { val = JSON.stringify(v); } catch { val = '…'; } }
-        out.push(`• ${k}: ${val}`);
-    }
-    if (entries.length > out.length) out.push(`• … (+${entries.length - out.length} more)`);
+	if (!argsJson) return [];
+	let parsed: unknown;
+	try { parsed = JSON.parse(argsJson); } catch { return []; }
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+	const entries = Object.entries(parsed as Record<string, unknown>);
+	const out: string[] = [];
+	for (const [k, v] of entries) {
+		if (out.length >= maxRows) break;
+		let val: string;
+		if (v === null) val = 'null';
+		else if (typeof v === 'string') val = v;
+		else if (typeof v === 'number' || typeof v === 'boolean') val = String(v);
+		else { try { val = JSON.stringify(v); } catch { val = '…'; } }
+		out.push(`• ${k}: ${val}`);
+	}
+	if (entries.length > out.length) out.push(`• … (+${entries.length - out.length} more)`);
 
-    return out;
+	return out;
 }
+

--- a/src/AI/TUI/widgets/whichKeyModal.ts
+++ b/src/AI/TUI/widgets/whichKeyModal.ts
@@ -3,17 +3,17 @@ import { pauseScreenKeys } from '@/UI/dashboard/screen';
 import { BG_PRIMARY } from '../theme';
 
 export interface WhichKeyItem {
-    key: string;
-    label: string;
-    description?: string;
-    /**
-     * Optional grouping. Items sharing a category render together under
-     * a section header in the modal. Items without a category fall into
-     * a trailing "Other" section. Category order in the modal matches
-     * the order categories first appear in the items array.
-     */
-    category?: string;
-    action: () => void;
+	key: string;
+	label: string;
+	description?: string;
+	/**
+	 * Optional grouping. Items sharing a category render together under
+	 * a section header in the modal. Items without a category fall into
+	 * a trailing "Other" section. Category order in the modal matches
+	 * the order categories first appear in the items array.
+	 */
+	category?: string;
+	action: () => void;
 }
 
 /**
@@ -27,114 +27,138 @@ let leaderOpen = false;
 export function isLeaderOpen(): boolean { return leaderOpen; }
 
 export function showWhichKey(
-    screen: blessed.Widgets.Screen,
-    items: WhichKeyItem[],
-    opts: { title?: string } = {},
+	screen: blessed.Widgets.Screen,
+	items: WhichKeyItem[],
+	opts: { title?: string } = {},
 ): Promise<void> {
-    if (leaderOpen) return Promise.resolve();
-    leaderOpen = true;
-    return new Promise((resolve) => {
-        const savedFocus = screen.focused;
-        const hotkeys = items.map((i) => i.key);
-        const restoreKeys = pauseScreenKeys(
-            screen,
-            ['escape', 'q', 'C-c', ...hotkeys],
-        );
+	if (leaderOpen) return Promise.resolve();
+	leaderOpen = true;
+	return new Promise((resolve) => {
+		const savedFocus = screen.focused;
+		const hotkeys = items.map((i) => i.key);
+		const restoreKeys = pauseScreenKeys(
+			screen,
+			['escape', 'q', 'C-c', ...hotkeys],
+		);
 
-        const labelMaxLen = items.reduce((m, i) => Math.max(m, i.label.length), 0);
+		const labelMaxLen = items.reduce((m, i) => Math.max(m, i.label.length), 0);
 
-        // Group items by category, preserving the order categories first
-        // appear in the items array. Items without a category fall into a
-        // trailing "Other" group.
-        const groups: { name: string; items: WhichKeyItem[] }[] = [];
-        const groupIndex = new Map<string, number>();
-        for (const item of items) {
-            const name = item.category ?? 'Other';
-            let idx = groupIndex.get(name);
-            if (idx === undefined) {
-                idx = groups.length;
-                groupIndex.set(name, idx);
-                groups.push({ name, items: [] });
-            }
-            groups[idx].items.push(item);
-        }
+		// Group items by category, preserving the order categories first
+		// appear in the items array. Items without a category fall into a
+		// trailing "Other" group.
+		const groups: { name: string; items: WhichKeyItem[] }[] = [];
+		const groupIndex = new Map<string, number>();
+		for (const item of items) {
+			const name = item.category ?? 'Other';
+			let idx = groupIndex.get(name);
+			if (idx === undefined) {
+				idx = groups.length;
+				groupIndex.set(name, idx);
+				groups.push({ name, items: [] });
+			}
+			groups[idx].items.push(item);
+		}
 
-        const lines: string[] = [];
-        groups.forEach((group, gi) => {
-            if (gi > 0) lines.push('');
-            lines.push(` {bold}{cyan-fg}━ ${escapeTags(group.name)} ━{/cyan-fg}{/bold}`);
-            for (const i of group.items) {
-                const key = padRight(`{magenta-fg}${escapeTags(i.key)}{/magenta-fg}`, 6);
-                const label = padRight(escapeTags(i.label), labelMaxLen + 2);
-                const desc = i.description
-                    ? `  {gray-fg}${escapeTags(i.description)}{/gray-fg}`
-                    : '';
-                lines.push(`   ${key} →  ${label}${desc}`);
-            }
-        });
-        lines.push('');
-        lines.push(' {gray-fg}[Esc/q] cancel{/gray-fg}');
+		const lines: string[] = [];
+		groups.forEach((group, gi) => {
+			if (gi > 0) lines.push('');
+			lines.push(` {bold}{cyan-fg}━ ${escapeTags(group.name)} ━{/cyan-fg}{/bold}`);
+			for (const i of group.items) {
+				const key = padRight(`{magenta-fg}${escapeTags(i.key)}{/magenta-fg}`, 6);
+				const label = padRight(escapeTags(i.label), labelMaxLen + 2);
+				const desc = i.description
+					? `  {gray-fg}${escapeTags(i.description)}{/gray-fg}`
+					: '';
+				lines.push(`   ${key} →  ${label}${desc}`);
+			}
+		});
+		lines.push('');
+		lines.push(' {gray-fg}[Esc/q] cancel{/gray-fg}');
 
-        // height = content lines + 2 borders
-        const height = lines.length + 2;
+		// height = content lines + 2 borders
+		const height = lines.length + 2;
 
-        const box = blessed.box({
-            parent: screen,
-            label: ` ${opts.title ?? 'Leader'} `,
-            bottom: 1,
-            left: 'center',
-            width: '70%',
-            height,
-            border: { type: 'line' },
-            style: { border: { fg: 'magenta' }, bg: BG_PRIMARY },
-            tags: true,
-        });
-        box.setFront();
-        box.setContent(lines.join('\n'));
+		const box = blessed.box({
+			parent: screen,
+			label: ` ${opts.title ?? 'Leader'} `,
+			bottom: 1,
+			left: 'center',
+			width: '70%',
+			height,
+			border: { type: 'line' },
+			style: { border: { fg: 'magenta' }, bg: BG_PRIMARY },
+			tags: true,
+		});
+		box.setFront();
+		box.setContent(lines.join('\n'));
 
-        const cleanup = (chosen: WhichKeyItem | null): void => {
-            leaderOpen = false;
-            box.destroy();
-            restoreKeys();
-            if (savedFocus) {
-                try { savedFocus.focus(); } catch { /* ignore */ }
-            }
-            screen.render();
-            if (chosen) chosen.action();
-            resolve();
-        };
+		let cleanup = (chosen: WhichKeyItem | null): void => {
+			leaderOpen = false;
+			box.destroy();
+			restoreKeys();
+			if (savedFocus) {
+				try { savedFocus.focus(); } catch { /* ignore */ }
+			}
+			screen.render();
+			if (chosen) chosen.action();
+			resolve();
+		};
 
-        // Items with single ASCII letter keys may bind their opposite case
-        // ONLY if no other item explicitly claims that case (otherwise the
-        // lower-case binding would shadow upper-case items like `A`/`R`/`P`).
-        const claimedKeys = new Set(items.map((i) => i.key));
-        for (const item of items) {
-            const isLetter = item.key.length === 1 && /[a-z]/i.test(item.key);
-            const opposite = isLetter
-                ? (item.key === item.key.toLowerCase()
-                    ? item.key.toUpperCase()
-                    : item.key.toLowerCase())
-                : null;
-            const variants = isLetter && opposite && !claimedKeys.has(opposite)
-                ? [item.key, opposite]
-                : [item.key];
-            box.key(variants, () => cleanup(item));
-        }
-        box.key(['escape', 'q', 'C-c'], () => cleanup(null));
+		// Items with single ASCII letter keys may bind their opposite case
+		// ONLY if no other item explicitly claims that case (otherwise the
+		// lower-case binding would shadow upper-case items like `A`/`R`/`P`).
+		const claimedKeys = new Set(items.map((i) => i.key));
+		for (const item of items) {
+			const isLetter = item.key.length === 1 && /[a-z]/i.test(item.key);
+			const opposite = isLetter
+				? (item.key === item.key.toLowerCase()
+					? item.key.toUpperCase()
+					: item.key.toLowerCase())
+				: null;
+			const variants = isLetter && opposite && !claimedKeys.has(opposite)
+				? [item.key, opposite]
+				: [item.key];
+			box.key(variants, () => cleanup(item));
+		}
+		box.key(['escape', 'q', 'C-c'], () => cleanup(null));
 
-        box.focus();
-        screen.render();
-    });
+		// The which-key modal must own keyboard focus until the user
+		// explicitly dismisses it with Esc / q / Ctrl-C — otherwise a
+		// stray mouse click or focus-changing keystroke would strand
+		// the popup with no way to act on its hotkeys. Snap focus back
+		// on every blur until cleanup() flips `dismissed` true.
+		let dismissed = false;
+		const reclaimFocus = (): void => {
+			if (dismissed) return;
+			setImmediate(() => {
+				if (dismissed) return;
+				try { box.focus(); } catch { /* ignore */ }
+			});
+		};
+		box.on('blur', reclaimFocus);
+		screen.on('mouse', reclaimFocus);
+		const origCleanup = cleanup;
+		cleanup = (chosen: WhichKeyItem | null): void => {
+			dismissed = true;
+			try { box.removeListener('blur', reclaimFocus); } catch { /* ignore */ }
+			try { screen.removeListener('mouse', reclaimFocus); } catch { /* ignore */ }
+			origCleanup(chosen);
+		};
+
+		box.focus();
+		screen.render();
+	});
 }
 
 function escapeTags(s: string): string {
-    return s.replace(/[{}]/g, (c) => (c === '{' ? '{open}' : '{close}'));
+	return s.replace(/[{}]/g, (c) => (c === '{' ? '{open}' : '{close}'));
 }
 
 // Pads using the visible length (ignoring blessed tags).
 function padRight(s: string, width: number): string {
-    const visible = s.replace(/\{[^}]+\}/g, '');
-    const pad = Math.max(0, width - visible.length);
+	const visible = s.replace(/\{[^}]+\}/g, '');
+	const pad = Math.max(0, width - visible.length);
 
-    return s + ' '.repeat(pad);
+	return s + ' '.repeat(pad);
 }
+


### PR DESCRIPTION
popupRegistry: add focusable + getFocusTarget options. show() always refocuses the topmost focusable overlay (with a setImmediate retry), maintainFocus skips non-focusable overlays. Wire getFocusTarget into toolHistoryPanel, indexProgressModal, and jsonEditor so leader-t and mouse races recover the right inner widget.

toolSpinner: mark as non-focusable so it can't steal focus from real modals. Show a multi-line preview of the AI-visible result (or error) under each completed tool entry; bump linger to 6s so it's readable.

whichKeyModal: self-managed sticky focus via blur/mouse reclaim until Esc/q dismissal.