### PR TITLE
feat: add `kra notes` markdown app with bundled nvim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ With **on-demand activation** and **intelligent event-driven architecture**, Kra
 ### ⚡ [Autosave System](#autosave-system)
 *Enterprise-grade automated workspace persistence*
 
+### 📝 [Notes](docs/notes.md)
+*Self-contained markdown note app — bundled Neovim config, render-markdown, telescope picker, wiki-links & backlinks*
+
 ### 🛠️ [System Utilities](#system-utilities)
 *Developer productivity tools and utilities*
 

--- a/automationScripts/autocomplete/autocomplete.sh
+++ b/automationScripts/autocomplete/autocomplete.sh
@@ -8,7 +8,7 @@ _kra_completions() {
 
     # Top-level commands after "kra"
     if [[ ${COMP_CWORD} -eq 1 ]]; then
-        COMPREPLY=( $(compgen -W "git tmux sys settings ai memory" -- "$cur") )
+        COMPREPLY=( $(compgen -W "git tmux sys settings ai memory notes" -- "$cur") )
         return 0
     fi
 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,0 +1,124 @@
+# 📝 Notes
+
+A self-contained markdown note app built on top of Neovim with a bundled config — no extra setup required.
+
+## Usage
+
+```bash
+kra notes                 # open the fuzzy notes picker
+kra notes <name>          # open (or create) ~/.kra/notes/<name>.md
+kra notes <cat>/<name>    # categories are just subdirectories
+kra notes new <name>      # explicit create with seeded frontmatter
+kra notes pick            # same as bare `kra notes`
+kra notes journal         # today's journal entry (auto-seeded)
+kra notes journal yesterday
+kra notes journal 2025-01-15
+```
+
+Inside tmux: press `prefix o` to open the notes app in a centered popup (~90% of the screen). Because it's a popup, you can summon it from anywhere in any tmux session — pop it open over whatever you're working on, jot something down, hit `q`, and you're right back where you were. Outside tmux it just runs in the current terminal.
+
+All notes live under `~/.kra/notes/`. Sub-directories act as categories — they are auto-created on demand.
+
+## What's bundled
+
+The first run installs (into `~/.kra/notes/.nvim-data/`, isolated from your normal Neovim config):
+
+- `MeanderingProgrammer/render-markdown.nvim` — in-buffer markdown rendering (headings, code blocks, checkboxes…)
+- `nvim-telescope/telescope.nvim` — fuzzy file picker, live grep, backlinks viewer
+- `nvim-treesitter/nvim-treesitter` — syntax highlighting for markdown and code blocks
+- `folke/tokyonight.nvim` — dark theme
+- `folke/which-key.nvim` — popup that shows every `<leader>` keymap with a description as you type
+
+Notes auto-save on `FocusLost` / `BufLeave`.
+
+## Keymaps (leader = `<Space>`)
+
+### Navigation
+
+| Keys           | Action                                              |
+| -------------- | --------------------------------------------------- |
+| `<leader>f`    | Find note (Telescope `find_files`)                  |
+| `<leader>g`    | Live grep across notes                              |
+| `<leader>n`    | Prompt for new note name, create + open             |
+| `<leader>v`    | Open picked note in vertical split                  |
+| `<leader>s`    | Open picked note in horizontal split                |
+| `<leader>q`    | Close buffer (or quit if it's the last)             |
+| `<leader>j`    | Open today's journal entry                          |
+| `<leader>J`    | Pick a past journal entry                           |
+| `<BS>`         | Previous buffer                                     |
+| `<CR>` / `gf`  | Follow `[[wiki-link]]` or `[text](path)` under cursor |
+| `<C-]>`        | Same as `<CR>` (also works from insert mode)        |
+
+### Inserts
+
+| Keys              | Action                                            |
+| ----------------- | ------------------------------------------------- |
+| `<leader>t`       | Insert task `- [ ] `                              |
+| `<leader>x`       | Toggle task done/undone on current line           |
+| `<leader>d`       | Insert today's date `YYYY-MM-DD`                  |
+| `<leader>D`       | Insert datetime `YYYY-MM-DD HH:MM`                |
+| `<leader>h`       | Insert heading (prompts for level 1–6)            |
+| `<leader>c`       | Insert fenced code block (prompts for language)   |
+| `<leader>u`       | Insert bullet `- `                                |
+| `<leader>o`       | Insert ordered list item (continues numbering)    |
+| `<leader>r`       | Insert horizontal rule `---`                      |
+| `<leader>l`       | Insert link to another note (Telescope picker)    |
+| `<leader>*` (v)   | Wrap selection with `**bold**`                    |
+| `<leader>_` (v)   | Wrap selection with `*italic*`                    |
+| `<leader>k` (v)   | Wrap selection with `` `inline code` ``           |
+| `<leader>"` (v)   | Prefix selection with `> ` (blockquote)           |
+
+### Metadata
+
+| Keys           | Action                                                  |
+| -------------- | ------------------------------------------------------- |
+| `<leader>m`    | Edit frontmatter (creates one if missing)               |
+| `<leader>+`    | Add a tag to the frontmatter `tags: [...]` line         |
+| `<leader>b`    | Backlinks — references to the current note (Telescope)  |
+| `<leader>G`    | Link graph — ASCII outgoing tree + backlinks (sidebar)  |
+| `<leader>X`    | Delete the current note (or pick one if not in a note)   |
+| `<leader>R`    | Rename / move the current note (offers to rewrite links) |
+
+In the link-graph sidebar: `<CR>` opens the note under the cursor in the previous window, `gv`/`gs` open in vsplit/hsplit, `<Tab>` / `<S-Tab>` deepens / shrinks the tree, `r` re-renders, `q` closes.
+
+## Linking notes
+
+Two link forms work and are followed by `<CR>` / `gf` / `<C-]>`:
+
+- Wiki-style: `[[work/project-x]]` (no `.md` extension needed)
+- Markdown:   `[anything](work/project-x.md)` — http(s) and `mailto:` open in the system handler
+
+When you follow a link to a note that doesn't exist yet, the directory is auto-created and the file opens blank.
+
+## Backlinks
+
+`<leader>b` shells out to `ripgrep` to find every note that links to the current one (matches both `[[<basename>]]` and `](<relpath>)`), then opens the results in a Telescope quickfix view.
+
+## Link graph (`<leader>G`)
+
+Opens a sidebar (right-hand vsplit, ~40% wide) rooted at the current note that shows two things:
+
+- **▾ Outgoing tree** — the notes you link to, recursively, with `(N↗ M↙)` annotations on every node showing how many outgoing/incoming links it has. Cycles are marked `(cycle)` and stop recursing; truncated branches end in `…`.
+- **◂ Backlinks** — a flat list of every note that links to the current one.
+
+Sidebar keymaps:
+
+| Keys              | Action                                                |
+| ----------------- | ----------------------------------------------------- |
+| `<CR>`            | Open the note under the cursor in your previous window |
+| `gv` / `gs`       | Open in a vertical / horizontal split                 |
+| `<Tab>`           | Re-render with `max_depth + 1` (deeper tree)          |
+| `<S-Tab>`         | Re-render with `max_depth - 1` (shallower)            |
+| `r`               | Re-render at the current depth (catches new links)    |
+| `q`               | Close the sidebar                                     |
+
+From any note buffer, `<Tab>` jumps focus back to the graph sidebar when it's open (and falls through to the normal `<C-i>` jumplist when it isn't), so navigating between the graph and notes feels like flipping between two panes.
+
+Also exposed as `:KraNotesGraph [name]` if you want to root the graph at an arbitrary note.
+
+## Renaming and deleting
+
+- `<leader>R` (or `:KraNotesRename [new-rel]`) renames / moves the current note. You're prompted in a centered popup with the existing path pre-filled; type a new relative path (sub-directories are fine, `.md` is optional). Afterwards it asks whether to rewrite incoming `[[wiki]]` and `](path)` references across the whole vault.
+- `<leader>X` (or `:KraNotesDelete`) deletes the current note after a `Yes / No` confirmation. From a non-note buffer it opens a Telescope picker so you can choose which note to delete.
+
+Both refuse to touch anything outside `~/.kra/notes/`.

--- a/notes-files/init.lua
+++ b/notes-files/init.lua
@@ -1,0 +1,265 @@
+-- kra notes: self-contained nvim config for the markdown note app.
+-- Bootstraps lazy.nvim into ~/.kra/notes/.nvim-data and loads everything
+-- needed for in-buffer markdown rendering, telescope, treesitter,
+-- and the kra-notes keymaps. Isolated from the user's regular nvim config.
+
+local function notes_root()
+  local kra_home = os.getenv('KRA_HOME')
+  if kra_home and #kra_home > 0 then
+    return kra_home .. '/notes'
+  end
+  return os.getenv('HOME') .. '/.kra/notes'
+end
+
+local NOTES_ROOT = notes_root()
+local DATA_DIR   = NOTES_ROOT .. '/.nvim-data'
+local LAZY_DIR   = DATA_DIR .. '/lazy'
+local LAZY_PATH  = LAZY_DIR .. '/lazy.nvim'
+
+vim.fn.mkdir(NOTES_ROOT, 'p')
+vim.fn.mkdir(DATA_DIR, 'p')
+vim.fn.mkdir(LAZY_DIR, 'p')
+
+-- Leader must be set BEFORE plugins load.
+vim.g.mapleader      = ' '
+vim.g.maplocalleader = ' '
+
+-- Bootstrap lazy.nvim
+if not vim.loop.fs_stat(LAZY_PATH) then
+  print('[kra notes] bootstrapping lazy.nvim...')
+  vim.fn.system({
+    'git', 'clone', '--filter=blob:none', '--branch=stable',
+    'https://github.com/folke/lazy.nvim.git',
+    LAZY_PATH,
+  })
+end
+vim.opt.rtp:prepend(LAZY_PATH)
+
+-- Make our own lua/ subtree available.
+local SCRIPT_DIR = vim.fn.fnamemodify(vim.fn.expand('<sfile>:p'), ':h')
+package.path = SCRIPT_DIR .. '/lua/?.lua;' .. package.path
+
+-- General editor settings tuned for note-taking.
+vim.opt.number         = true
+vim.opt.relativenumber = false
+vim.opt.wrap           = true
+vim.opt.linebreak      = true
+vim.opt.breakindent    = true
+vim.opt.conceallevel   = 2
+vim.opt.concealcursor  = 'nc'
+vim.opt.expandtab      = true
+vim.opt.shiftwidth     = 2
+vim.opt.tabstop        = 2
+vim.opt.softtabstop    = 2
+vim.opt.signcolumn     = 'no'
+vim.opt.swapfile       = false
+vim.opt.undofile       = true
+vim.opt.termguicolors  = true
+vim.opt.cmdheight      = 1
+vim.opt.laststatus     = 2
+vim.opt.mouse          = 'a'
+vim.opt.clipboard      = 'unnamedplus'
+
+-- All relative paths resolve to the notes root.
+vim.cmd('cd ' .. vim.fn.fnameescape(NOTES_ROOT))
+
+-- Auto-save on focus lost / buffer leave.
+vim.api.nvim_create_autocmd({ 'FocusLost', 'BufLeave' }, {
+  pattern = '*.md',
+  callback = function()
+    if vim.bo.modified and vim.bo.buftype == '' and vim.fn.expand('%') ~= '' then
+      vim.cmd('silent! write')
+    end
+  end,
+})
+
+-- Plugin spec.
+require('lazy').setup({
+  {
+    'folke/tokyonight.nvim',
+    priority = 1000,
+    config = function()
+      vim.cmd.colorscheme('tokyonight-night')
+    end,
+  },
+  {
+    'nvim-treesitter/nvim-treesitter',
+    branch = 'master',
+    build = ':TSUpdate',
+    config = function()
+      local ok, ts_configs = pcall(require, 'nvim-treesitter.configs')
+      if not ok then return end
+      ts_configs.setup({
+        ensure_installed = { 'markdown', 'markdown_inline', 'lua', 'vim', 'bash', 'json', 'yaml' },
+        highlight = { enable = true },
+      })
+    end,
+  },
+  {
+    'MeanderingProgrammer/render-markdown.nvim',
+    dependencies = { 'nvim-treesitter/nvim-treesitter' },
+    ft = { 'markdown' },
+    opts = {
+      heading = { width = 'block', position = 'inline' },
+      code = { width = 'block', sign = false },
+      checkbox = {
+        unchecked = { icon = '󰄱 ' },
+        checked   = { icon = '󰱒 ' },
+      },
+    },
+  },
+  { 'nvim-lua/plenary.nvim', lazy = true },
+  { 'nvim-tree/nvim-web-devicons', lazy = true },
+  { 'MunifTanjim/nui.nvim', lazy = true },
+  {
+    'folke/noice.nvim',
+    event = 'VeryLazy',
+    dependencies = { 'MunifTanjim/nui.nvim' },
+    opts = {
+      cmdline = {
+        enabled = true,
+        view = 'cmdline_popup',
+      },
+      messages = {
+        enabled = true,
+        view = 'mini',
+        view_error = 'mini',
+        view_warn = 'mini',
+        view_history = 'messages',
+        view_search = false,
+      },
+      popupmenu = { enabled = true, backend = 'nui' },
+      lsp = {
+        override = {
+          ['vim.lsp.util.convert_input_to_markdown_lines'] = true,
+          ['vim.lsp.util.stylize_markdown'] = true,
+        },
+      },
+      presets = {
+        bottom_search = false,
+        command_palette = true,
+        long_message_to_split = true,
+        inc_rename = false,
+        lsp_doc_border = true,
+      },
+      views = {
+        cmdline_popup = {
+          position = { row = '40%', col = '50%' },
+          size = { width = 80, height = 'auto' },
+          border = { style = 'rounded' },
+        },
+        popupmenu = {
+          relative = 'editor',
+          position = { row = '50%', col = '50%' },
+          size = { width = 80, height = 10 },
+          border = { style = 'rounded' },
+        },
+      },
+    },
+  },
+  {
+    'folke/which-key.nvim',
+    event = 'VeryLazy',
+    opts = {
+      preset = 'modern',
+      delay = 300,
+      win = { border = 'rounded' },
+      icons = { mappings = false },
+      spec = {
+        { '<leader>f', desc = 'find note' },
+        { '<leader>g', desc = 'live grep' },
+        { '<leader>n', desc = 'new note' },
+        { '<leader>v', desc = 'open in vsplit' },
+        { '<leader>s', desc = 'open in hsplit' },
+        { '<leader>q', desc = 'close buffer / quit' },
+        { '<leader>l', desc = 'insert link' },
+        { '<leader>b', desc = 'backlinks' },
+        { '<leader>j', desc = 'journal today' },
+        { '<leader>J', desc = 'journal pick' },
+        { '<leader>G', desc = 'link graph' },
+        { '<leader>X', desc = 'delete note' },
+        { '<leader>R', desc = 'rename note' },
+        { '<leader>t', desc = 'insert task' },
+        { '<leader>x', desc = 'toggle task done' },
+        { '<leader>d', desc = 'insert date' },
+        { '<leader>D', desc = 'insert datetime' },
+        { '<leader>h', desc = 'insert heading' },
+        { '<leader>c', desc = 'insert code block' },
+        { '<leader>u', desc = 'bullet item' },
+        { '<leader>o', desc = 'ordered item' },
+        { '<leader>r', desc = 'horizontal rule' },
+        { '<leader>m', desc = 'edit frontmatter' },
+        { '<leader>+', desc = 'add tag' },
+        { '<leader>*', desc = 'wrap bold', mode = { 'v', 'i' } },
+        { '<leader>_', desc = 'wrap italic', mode = { 'v', 'i' } },
+        { '<leader>k', desc = 'wrap inline code', mode = { 'v', 'i' } },
+        { '<leader>"', desc = 'blockquote', mode = 'v' },
+      },
+    },
+  },
+  {
+    'nvim-telescope/telescope.nvim',
+    dependencies = { 'nvim-lua/plenary.nvim', 'nvim-tree/nvim-web-devicons' },
+    lazy = false,
+    priority = 900,
+    config = function()
+      local has_rg = vim.fn.executable('rg') == 1
+      local pickers = {}
+      if has_rg then
+        pickers.find_files = {
+          hidden = false,
+          no_ignore = false,
+          find_command = { 'rg', '--files', '--glob', '!**/.nvim-data/**' },
+        }
+        pickers.live_grep = {
+          additional_args = function() return { '--glob', '!**/.nvim-data/**' } end,
+        }
+      else
+        pickers.find_files = { hidden = false, no_ignore = false }
+      end
+      require('telescope').setup({
+        defaults = {
+          path_display = { 'truncate' },
+          layout_strategy = 'horizontal',
+          layout_config = { horizontal = { preview_width = 0.55 } },
+          sorting_strategy = 'ascending',
+          prompt_prefix = '  ',
+          selection_caret = '  ',
+          file_ignore_patterns = { '%.nvim%-data/' },
+        },
+        pickers = pickers,
+      })
+    end,
+  },
+}, {
+  root = LAZY_DIR,
+  lockfile = LAZY_DIR .. '/lazy-lock.json',
+  install = { colorscheme = { 'tokyonight-night', 'habamax' } },
+  ui = { border = 'rounded' },
+  performance = {
+    rtp = {
+      reset = true,
+      disabled_plugins = { 'gzip', 'tarPlugin', 'tohtml', 'tutor', 'zipPlugin', 'netrwPlugin' },
+    },
+  },
+})
+
+-- Load kra notes modules.
+require('kra_notes_keymaps').setup(NOTES_ROOT)
+require('kra_notes_inserts').setup()
+require('kra_notes_links').setup(NOTES_ROOT)
+require('kra_notes_backlinks').setup(NOTES_ROOT)
+require('kra_notes_journal').setup(NOTES_ROOT)
+require('kra_notes_graph').setup(NOTES_ROOT)
+require('kra_notes_delete').setup(NOTES_ROOT)
+require('kra_notes_rename').setup(NOTES_ROOT)
+
+-- :KraNotesPicker entrypoint used when invoked with no file arg.
+vim.api.nvim_create_user_command('KraNotesPicker', function()
+  local ok = pcall(require, 'telescope')
+  if not ok then
+    print('[kra notes] telescope not yet installed; run :Lazy sync then retry')
+    return
+  end
+  require('telescope.builtin').find_files({ cwd = NOTES_ROOT })
+end, {})

--- a/notes-files/lua/kra_notes_backlinks.lua
+++ b/notes-files/lua/kra_notes_backlinks.lua
@@ -1,0 +1,59 @@
+-- kra notes: backlinks. Uses ripgrep to find references to the current note.
+local M = {}
+
+function M.setup(notes_root)
+  vim.keymap.set('n', '<leader>b', function()
+    local file = vim.fn.expand('%:p')
+    if file == '' then
+      print('[kra notes] no file open')
+      return
+    end
+    local prefix = notes_root .. '/'
+    if file:sub(1, #prefix) ~= prefix then
+      print('[kra notes] current file is outside notes root')
+      return
+    end
+    local rel = file:sub(#prefix + 1)
+    local stem = vim.fn.fnamemodify(file, ':t:r')
+
+    local results = {}
+    local seen = {}
+    local function run(pattern)
+      local out = vim.fn.systemlist({ 'rg', '--vimgrep', '--no-heading', '-F', pattern, notes_root })
+      for _, line in ipairs(out) do
+        if not seen[line] and not line:find(rel, 1, true) then
+          seen[line] = true
+          table.insert(results, line)
+        end
+      end
+    end
+
+    run('[[' .. stem .. ']]')
+    run('[[' .. rel:gsub('%.md$', '') .. ']]')
+    run('](' .. rel .. ')')
+
+    if #results == 0 then
+      print('[kra notes] no backlinks for ' .. stem)
+      return
+    end
+
+    -- Convert into quickfix list, then open via Telescope if available.
+    local qf = {}
+    for _, line in ipairs(results) do
+      local f, l, c, txt = line:match('([^:]+):(%d+):(%d+):(.*)')
+      if f then
+        table.insert(qf, { filename = f, lnum = tonumber(l), col = tonumber(c), text = txt })
+      end
+    end
+    vim.fn.setqflist(qf, 'r')
+
+    local ok = pcall(require, 'telescope')
+    if ok then
+      require('telescope.builtin').quickfix({ prompt_title = 'Backlinks: ' .. stem })
+    else
+      vim.cmd('copen')
+    end
+  end, { desc = 'kra notes: backlinks' })
+end
+
+return M

--- a/notes-files/lua/kra_notes_delete.lua
+++ b/notes-files/lua/kra_notes_delete.lua
@@ -1,0 +1,120 @@
+-- kra notes: delete the current note (with confirmation) and close the buffer.
+-- Mapped to <leader>X in markdown buffers under the notes root. Also exposes
+-- :KraNotesDelete and a Telescope-driven picker via <leader>X in non-note buffers.
+
+local M = {}
+
+local notes_root
+
+local function rel(file)
+  local prefix = notes_root .. '/'
+  if file:sub(1, #prefix) == prefix then
+    return file:sub(#prefix + 1)
+  end
+  return file
+end
+
+local function delete_file(path, on_done)
+  if vim.fn.filereadable(path) == 0 then
+    vim.notify('[kra notes] not a file: ' .. path, vim.log.levels.WARN)
+    return
+  end
+  if not path:match('^' .. vim.pesc(notes_root)) then
+    vim.notify('[kra notes] refusing to delete outside notes root', vim.log.levels.ERROR)
+    return
+  end
+
+  local answer = vim.fn.confirm('Delete ' .. rel(path) .. '?', '&Yes\n&No', 2, 'Question')
+  if answer ~= 1 then return end
+
+  -- Wipe any buffer pointing at this file before unlinking.
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(buf) and vim.api.nvim_buf_get_name(buf) == path then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end
+
+  local ok, err = os.remove(path)
+  if not ok then
+    vim.notify('[kra notes] delete failed: ' .. tostring(err), vim.log.levels.ERROR)
+    return
+  end
+  vim.notify('[kra notes] deleted ' .. rel(path))
+  if on_done then on_done() end
+end
+
+local function delete_current()
+  local file = vim.fn.expand('%:p')
+  if file == '' then
+    vim.notify('[kra notes] no file in this buffer', vim.log.levels.WARN)
+    return
+  end
+  delete_file(file)
+end
+
+local function delete_pick()
+  local ok, builtin = pcall(require, 'telescope.builtin')
+  if not ok then
+    vim.notify('[kra notes] telescope not available', vim.log.levels.ERROR)
+    return
+  end
+  local actions = require('telescope.actions')
+  local action_state = require('telescope.actions.state')
+  builtin.find_files({
+    prompt_title = 'Delete note',
+    cwd = notes_root,
+    attach_mappings = function(prompt_bufnr, map)
+      local function confirm()
+        local entry = action_state.get_selected_entry()
+        actions.close(prompt_bufnr)
+        if entry then
+          local path = entry.path or (notes_root .. '/' .. entry.value)
+          delete_file(path)
+        end
+      end
+      map('i', '<CR>', confirm)
+      map('n', '<CR>', confirm)
+      return true
+    end,
+  })
+end
+
+function M.setup(root)
+  notes_root = root
+
+  vim.api.nvim_create_user_command('KraNotesDelete', function(opts)
+    if opts.args and opts.args ~= '' then
+      local path = opts.args
+      if not path:match('^/') then path = notes_root .. '/' .. path end
+      if not path:match('%.md$') then path = path .. '.md' end
+      delete_file(path)
+    else
+      delete_current()
+    end
+  end, { nargs = '?', complete = 'file' })
+
+  vim.api.nvim_create_user_command('KraNotesDeletePick', function() delete_pick() end, {})
+
+  -- Buffer-local <leader>X in note buffers; global picker fallback otherwise.
+  local grp = vim.api.nvim_create_augroup('KraNotesDelete', { clear = true })
+  vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
+    group = grp,
+    pattern = notes_root .. '/*.md',
+    callback = function(args)
+      vim.keymap.set('n', '<leader>X', delete_current,
+        { buffer = args.buf, nowait = true, silent = true, desc = 'kra notes: delete current note' })
+    end,
+  })
+
+  -- Global fallback so <leader>X works even when not in a note buffer.
+  vim.keymap.set('n', '<leader>X', function()
+    local file = vim.fn.expand('%:p')
+    if file ~= '' and file:match('^' .. vim.pesc(notes_root)) and file:match('%.md$') then
+      delete_current()
+    else
+      delete_pick()
+    end
+  end, { desc = 'kra notes: delete note (current or pick)' })
+end
+
+return M

--- a/notes-files/lua/kra_notes_graph.lua
+++ b/notes-files/lua/kra_notes_graph.lua
@@ -1,0 +1,260 @@
+-- kra notes: ASCII outgoing-link tree + backlinks for the current note.
+-- Press <leader>G to open. <CR> opens the note under cursor in the previous
+-- window, <Tab> expands/collapses, q closes, gv/gs open in vsplit/hsplit.
+
+local M = {}
+
+local notes_root
+local MAX_DEPTH_DEFAULT = 3
+
+local function rel(file)
+  local prefix = notes_root .. '/'
+  if file:sub(1, #prefix) == prefix then
+    return file:sub(#prefix + 1):gsub('%.md$', '')
+  end
+  return file:gsub('%.md$', '')
+end
+
+local function abs(rel_path)
+  local p = rel_path
+  if not p:match('^/') then p = notes_root .. '/' .. p end
+  if not p:match('%.md$') then p = p .. '.md' end
+  return p
+end
+
+-- Build adjacency map: { [relpath] = { outgoing = { rel, ... }, incoming = {...} } }
+local function build_graph()
+  local graph = {}
+  local function ensure(node) graph[node] = graph[node] or { outgoing = {}, incoming = {}, seen_out = {}, seen_in = {} } end
+
+  local files = vim.fn.systemlist({ 'rg', '--files', '--type-add', 'md:*.md', '--type', 'md', '--glob', '!**/.nvim-data/**', notes_root })
+  if vim.v.shell_error ~= 0 then
+    files = vim.fn.systemlist({ 'find', notes_root, '-type', 'f', '-name', '*.md', '-not', '-path', '*/.nvim-data/*' })
+  end
+
+  for _, file in ipairs(files) do
+    local from = rel(file)
+    ensure(from)
+    local lines = {}
+    local fh = io.open(file, 'r')
+    if fh then
+      for l in fh:lines() do table.insert(lines, l) end
+      fh:close()
+    end
+    for _, line in ipairs(lines) do
+      for target in line:gmatch('%[%[([^%]]+)%]%]') do
+        local t = target:gsub('%.md$', '')
+        ensure(t)
+        if not graph[from].seen_out[t] then
+          graph[from].seen_out[t] = true
+          table.insert(graph[from].outgoing, t)
+        end
+        if not graph[t].seen_in[from] then
+          graph[t].seen_in[from] = true
+          table.insert(graph[t].incoming, from)
+        end
+      end
+      for _, target in line:gmatch('%[([^%]]-)%]%(([^)]+)%)') do
+        if not target:match('^https?://') and not target:match('^mailto:') then
+          local t = target:gsub('%.md$', ''):gsub('^%./', '')
+          ensure(t)
+          if not graph[from].seen_out[t] then
+            graph[from].seen_out[t] = true
+            table.insert(graph[from].outgoing, t)
+          end
+          if not graph[t].seen_in[from] then
+            graph[t].seen_in[from] = true
+            table.insert(graph[t].incoming, from)
+          end
+        end
+      end
+    end
+  end
+
+  return graph
+end
+
+local state = {} -- { lines = {{text, target, depth}}, graph, root, max_depth, prev_win, graph_win, graph_buf }
+
+local function expand(root, depth, max_depth, visited, out)
+  local node = state.graph[root] or { outgoing = {}, incoming = {} }
+  local outc = #node.outgoing
+  local inc  = #node.incoming
+  local marker = ''
+  if visited[root] then marker = ' (cycle)' end
+  local annotation = string.format('  (%d\u{2197}  %d\u{2199})', outc, inc)
+  local prefix = string.rep('  ', depth) .. (depth == 0 and '' or '\u{2502} ')
+  table.insert(out, { text = prefix .. root .. annotation .. marker, target = root, depth = depth })
+  if visited[root] then return end
+  if depth >= max_depth then
+    if outc > 0 then
+      table.insert(out, { text = string.rep('  ', depth + 1) .. '\u{2026} (' .. outc .. ' more, expand)', target = nil, depth = depth + 1 })
+    end
+    return
+  end
+  visited[root] = true
+  for _, child in ipairs(node.outgoing) do
+    expand(child, depth + 1, max_depth, visited, out)
+  end
+  visited[root] = nil
+end
+
+local function render(root, max_depth, prev_win)
+  local graph = build_graph()
+  state = {
+    lines = {},
+    graph = graph,
+    root = root,
+    max_depth = max_depth,
+    prev_win = prev_win,
+  }
+
+  table.insert(state.lines, { text = '\u{1F4DD} kra notes graph  \u{2014}  root: ' .. root, target = nil, depth = 0 })
+  table.insert(state.lines, { text = '   <CR> open  <Tab> expand deeper  gv/gs split  q close', target = nil, depth = 0 })
+  table.insert(state.lines, { text = '', target = nil, depth = 0 })
+  table.insert(state.lines, { text = '\u{25BE} Outgoing (depth ' .. max_depth .. ')', target = nil, depth = 0 })
+  expand(root, 0, max_depth, {}, state.lines)
+
+  local incoming = (graph[root] or {}).incoming or {}
+  table.insert(state.lines, { text = '', target = nil, depth = 0 })
+  table.insert(state.lines, { text = '\u{25C2} Backlinks (' .. #incoming .. ')', target = nil, depth = 0 })
+  if #incoming == 0 then
+    table.insert(state.lines, { text = '   (none)', target = nil, depth = 0 })
+  else
+    for _, src in ipairs(incoming) do
+      local outc = #(graph[src] and graph[src].outgoing or {})
+      table.insert(state.lines, {
+        text = '  \u{2502} ' .. src .. string.format('  (%d\u{2197})', outc),
+        target = src,
+        depth = 1,
+      })
+    end
+  end
+
+  -- Find or create the graph buffer
+  local bufname = 'kra://notes-graph'
+  local buf = vim.fn.bufnr(bufname)
+  if buf == -1 then
+    buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(buf, bufname)
+  end
+  vim.bo[buf].buftype = 'nofile'
+  vim.bo[buf].bufhidden = 'wipe'
+  vim.bo[buf].swapfile = false
+  vim.bo[buf].modifiable = true
+
+  local text_lines = {}
+  for _, l in ipairs(state.lines) do table.insert(text_lines, l.text) end
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, text_lines)
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].filetype = 'kra-notes-graph'
+
+  -- Open in a right-side split if not already shown
+  local win = nil
+  for _, w in ipairs(vim.api.nvim_list_wins()) do
+    if vim.api.nvim_win_get_buf(w) == buf then win = w; break end
+  end
+  if not win then
+    vim.cmd('botright vsplit')
+    vim.api.nvim_win_set_width(0, math.max(50, math.floor(vim.o.columns * 0.4)))
+    vim.api.nvim_win_set_buf(0, buf)
+    win = vim.api.nvim_get_current_win()
+  else
+    vim.api.nvim_set_current_win(win)
+  end
+  vim.wo[win].wrap = false
+  vim.wo[win].number = false
+  vim.wo[win].relativenumber = false
+  vim.wo[win].cursorline = true
+  state.graph_win = win
+  state.graph_buf = buf
+
+  vim.api.nvim_create_autocmd('BufWipeout', {
+    buffer = buf,
+    once = true,
+    callback = function()
+      state.graph_win = nil
+      state.graph_buf = nil
+    end,
+  })
+
+  -- Buffer-local keymaps
+  local function target_under_cursor()
+    local row = vim.api.nvim_win_get_cursor(0)[1]
+    local entry = state.lines[row]
+    return entry and entry.target or nil
+  end
+
+  local function open_in(cmd)
+    local t = target_under_cursor()
+    if not t then return end
+    local file = abs(t)
+    vim.fn.mkdir(vim.fn.fnamemodify(file, ':h'), 'p')
+    local target_win = state.prev_win
+    if target_win and vim.api.nvim_win_is_valid(target_win) then
+      vim.api.nvim_set_current_win(target_win)
+    else
+      vim.cmd('wincmd p')
+    end
+    vim.cmd(cmd .. ' ' .. vim.fn.fnameescape(file))
+  end
+
+  local opts = { buffer = buf, nowait = true, silent = true }
+  vim.keymap.set('n', '<CR>', function() open_in('edit') end, opts)
+  vim.keymap.set('n', 'gv',   function() open_in('vsplit') end, opts)
+  vim.keymap.set('n', 'gs',   function() open_in('split') end, opts)
+  vim.keymap.set('n', 'q',    function() vim.cmd('quit') end, opts)
+  vim.keymap.set('n', '<Tab>', function()
+    -- Re-render with depth +1
+    render(state.root, state.max_depth + 1, state.prev_win)
+  end, opts)
+  vim.keymap.set('n', '<S-Tab>', function()
+    render(state.root, math.max(1, state.max_depth - 1), state.prev_win)
+  end, opts)
+  vim.keymap.set('n', 'r', function()
+    render(state.root, state.max_depth, state.prev_win)
+  end, opts)
+end
+
+function M.setup(root)
+  notes_root = root
+
+  -- In any note buffer, <Tab> jumps back to the graph sidebar when it's open.
+  -- Falls through to the default <C-i> jump otherwise so the jumplist still works.
+  local function focus_graph_or_jump()
+    if state.graph_win and vim.api.nvim_win_is_valid(state.graph_win) then
+      vim.api.nvim_set_current_win(state.graph_win)
+    else
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<C-i>', true, false, true), 'n', false)
+    end
+  end
+
+  local grp = vim.api.nvim_create_augroup('KraNotesGraphTab', { clear = true })
+  vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
+    group = grp,
+    pattern = notes_root .. '/*.md',
+    callback = function(args)
+      vim.keymap.set('n', '<Tab>', focus_graph_or_jump,
+        { buffer = args.buf, nowait = true, silent = true, desc = 'kra notes: focus link graph' })
+    end,
+  })
+  vim.keymap.set('n', '<leader>G', function()
+    local file = vim.fn.expand('%:p')
+    local current
+    if file == '' or not file:match('^' .. vim.pesc(notes_root)) then
+      current = 'index'
+    else
+      current = rel(file)
+    end
+    local prev_win = vim.api.nvim_get_current_win()
+    render(current, MAX_DEPTH_DEFAULT, prev_win)
+  end, { desc = 'kra notes: link graph' })
+
+  vim.api.nvim_create_user_command('KraNotesGraph', function(opts)
+    local root = opts.args ~= '' and opts.args or 'index'
+    local prev_win = vim.api.nvim_get_current_win()
+    render(root, MAX_DEPTH_DEFAULT, prev_win)
+  end, { nargs = '?' })
+end
+
+return M

--- a/notes-files/lua/kra_notes_inserts.lua
+++ b/notes-files/lua/kra_notes_inserts.lua
@@ -1,0 +1,160 @@
+-- kra notes: insert-element keymaps. All under <leader>.
+local M = {}
+
+-- Insert text at cursor in normal mode (cursor lands at end of inserted text in insert mode).
+local function insert_at_cursor(text, enter_insert)
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  vim.api.nvim_buf_set_text(0, row - 1, col, row - 1, col, { text })
+  vim.api.nvim_win_set_cursor(0, { row, col + #text })
+  if enter_insert then
+    vim.cmd('startinsert')
+    -- Move past the inserted text
+    vim.api.nvim_win_set_cursor(0, { row, col + #text })
+  end
+end
+
+-- Replace current line content with `text`.
+local function set_line(text)
+  local row = vim.api.nvim_win_get_cursor(0)[1]
+  vim.api.nvim_buf_set_lines(0, row - 1, row, false, { text })
+end
+
+-- Wrap visual selection with prefix/suffix.
+local function wrap_selection(prefix, suffix)
+  local s_row, s_col = unpack(vim.api.nvim_buf_get_mark(0, '<'))
+  local e_row, e_col = unpack(vim.api.nvim_buf_get_mark(0, '>'))
+  -- Adjust end col for inclusive selection.
+  local lines = vim.api.nvim_buf_get_lines(0, s_row - 1, e_row, false)
+  if #lines == 0 then return end
+  if #lines == 1 then
+    local line = lines[1]
+    local before = line:sub(1, s_col)
+    local mid    = line:sub(s_col + 1, e_col + 1)
+    local after  = line:sub(e_col + 2)
+    vim.api.nvim_buf_set_lines(0, s_row - 1, s_row, false, { before .. prefix .. mid .. suffix .. after })
+  else
+    lines[1] = lines[1]:sub(1, s_col) .. prefix .. lines[1]:sub(s_col + 1)
+    lines[#lines] = lines[#lines]:sub(1, e_col + 1) .. suffix .. lines[#lines]:sub(e_col + 2)
+    vim.api.nvim_buf_set_lines(0, s_row - 1, e_row, false, lines)
+  end
+end
+
+function M.setup()
+  local map = vim.keymap.set
+
+  -- ── Tasks ──────────────────────────────────────────────────────────
+  map('n', '<leader>t', function()
+    insert_at_cursor('- [ ] ', true)
+  end, { desc = 'kra notes: insert task' })
+
+  map('n', '<leader>x', function()
+    local row = vim.api.nvim_win_get_cursor(0)[1]
+    local line = vim.api.nvim_get_current_line()
+    if line:match('%[ %]') then
+      set_line((line:gsub('%[ %]', '[x]', 1)))
+    elseif line:match('%[x%]') then
+      set_line((line:gsub('%[x%]', '[ ]', 1)))
+    elseif line:match('%[X%]') then
+      set_line((line:gsub('%[X%]', '[ ]', 1)))
+    end
+    vim.api.nvim_win_set_cursor(0, { row, 0 })
+  end, { desc = 'kra notes: toggle task done' })
+
+  -- ── Date / time ────────────────────────────────────────────────────
+  map('n', '<leader>d', function()
+    insert_at_cursor(os.date('%Y-%m-%d'), false)
+  end, { desc = 'kra notes: insert date' })
+
+  map('n', '<leader>D', function()
+    insert_at_cursor(os.date('%Y-%m-%d %H:%M'), false)
+  end, { desc = 'kra notes: insert datetime' })
+
+  -- ── Heading ────────────────────────────────────────────────────────
+  map('n', '<leader>h', function()
+    vim.ui.input({ prompt = 'Heading level (1-6): ', default = '2' }, function(input)
+      if not input then return end
+      local level = tonumber(input) or 2
+      if level < 1 then level = 1 end
+      if level > 6 then level = 6 end
+      local row = vim.api.nvim_win_get_cursor(0)[1]
+      vim.api.nvim_buf_set_lines(0, row - 1, row - 1, false, { string.rep('#', level) .. ' ' })
+      vim.api.nvim_win_set_cursor(0, { row, level + 1 })
+      vim.cmd('startinsert!')
+    end)
+  end, { desc = 'kra notes: insert heading' })
+
+  -- ── Code block ─────────────────────────────────────────────────────
+  map('n', '<leader>c', function()
+    vim.ui.input({ prompt = 'Code language: ', default = '' }, function(lang)
+      if lang == nil then return end
+      local row = vim.api.nvim_win_get_cursor(0)[1]
+      local block = { '```' .. lang, '', '```' }
+      vim.api.nvim_buf_set_lines(0, row, row, false, block)
+      vim.api.nvim_win_set_cursor(0, { row + 2, 0 })
+      vim.cmd('startinsert')
+    end)
+  end, { desc = 'kra notes: insert code block' })
+
+  -- ── Lists ──────────────────────────────────────────────────────────
+  map('n', '<leader>u', function()
+    insert_at_cursor('- ', true)
+  end, { desc = 'kra notes: insert bullet' })
+
+  map('n', '<leader>o', function()
+    -- Continue numbering if previous line is "<n>. ..."
+    local row = vim.api.nvim_win_get_cursor(0)[1]
+    local prev = row > 1 and vim.api.nvim_buf_get_lines(0, row - 2, row - 1, false)[1] or ''
+    local n = tonumber((prev or ''):match('^(%d+)%.%s'))
+    local next_n = (n or 0) + 1
+    insert_at_cursor(next_n .. '. ', true)
+  end, { desc = 'kra notes: insert ordered list item' })
+
+  map('n', '<leader>r', function()
+    local row = vim.api.nvim_win_get_cursor(0)[1]
+    vim.api.nvim_buf_set_lines(0, row, row, false, { '', '---', '' })
+    vim.api.nvim_win_set_cursor(0, { row + 3, 0 })
+  end, { desc = 'kra notes: insert horizontal rule' })
+
+  -- ── Wrap-selection inserts (visual mode) ───────────────────────────
+  map('v', '<leader>*', function() wrap_selection('**', '**') end, { desc = 'kra notes: wrap bold' })
+  map('v', '<leader>_', function() wrap_selection('*', '*') end, { desc = 'kra notes: wrap italic' })
+  map('v', '<leader>k', function() wrap_selection('`', '`') end, { desc = 'kra notes: wrap inline code' })
+  map('v', '<leader>"', function() wrap_selection('> ', '') end, { desc = 'kra notes: wrap blockquote' })
+
+  -- Normal-mode wrap shortcuts that drop into insert between markers
+  map('n', '<leader>*', function() insert_at_cursor('****', false); vim.cmd('normal! hh'); vim.cmd('startinsert') end, { desc = 'kra notes: bold pair' })
+  map('n', '<leader>_', function() insert_at_cursor('**', false); vim.cmd('normal! h'); vim.cmd('startinsert') end, { desc = 'kra notes: italic pair' })
+  map('n', '<leader>k', function() insert_at_cursor('``', false); vim.cmd('normal! h'); vim.cmd('startinsert') end, { desc = 'kra notes: inline code pair' })
+
+  -- ── Frontmatter / tags ─────────────────────────────────────────────
+  map('n', '<leader>m', function()
+    local lines = vim.api.nvim_buf_get_lines(0, 0, 4, false)
+    if lines[1] == '---' then
+      -- Jump to inside existing frontmatter
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    else
+      local date = os.date('%Y-%m-%d')
+      vim.api.nvim_buf_set_lines(0, 0, 0, false, { '---', 'created: ' .. date, 'tags: []', '---', '' })
+      vim.api.nvim_win_set_cursor(0, { 3, 7 })
+      vim.cmd('startinsert')
+    end
+  end, { desc = 'kra notes: edit frontmatter' })
+
+  map('n', '<leader>+', function()
+    vim.ui.input({ prompt = 'Add tag: ' }, function(tag)
+      if not tag or tag == '' then return end
+      local lines = vim.api.nvim_buf_get_lines(0, 0, 20, false)
+      for i, line in ipairs(lines) do
+        local existing = line:match('^tags:%s*%[(.-)%]')
+        if existing ~= nil then
+          local new = existing == '' and tag or (existing .. ', ' .. tag)
+          vim.api.nvim_buf_set_lines(0, i - 1, i, false, { 'tags: [' .. new .. ']' })
+          return
+        end
+      end
+      print('[kra notes] no `tags: [...]` line in frontmatter; run <leader>m first')
+    end)
+  end, { desc = 'kra notes: add tag' })
+end
+
+return M

--- a/notes-files/lua/kra_notes_journal.lua
+++ b/notes-files/lua/kra_notes_journal.lua
@@ -1,0 +1,70 @@
+-- kra notes: daily journal. Notes under <root>/journal/YYYY/MM/YYYY-MM-DD.md
+local M = {}
+
+local function journal_path(notes_root, date)
+  local y = os.date('%Y', date)
+  local m = os.date('%m', date)
+  local d = os.date('%Y-%m-%d', date)
+  return notes_root .. '/journal/' .. y .. '/' .. m .. '/' .. d .. '.md'
+end
+
+local function open_journal(notes_root, date)
+  local file = journal_path(notes_root, date)
+  vim.fn.mkdir(vim.fn.fnamemodify(file, ':h'), 'p')
+  if vim.fn.filereadable(file) == 0 then
+    local nice = os.date('%A, %B %d %Y', date)
+    local iso  = os.date('%Y-%m-%d', date)
+    vim.fn.writefile({
+      '---',
+      'created: ' .. iso,
+      'tags: [journal]',
+      '---',
+      '',
+      '# ' .. nice,
+      '',
+      '## Notes',
+      '',
+      '## Tasks',
+      '',
+      '- [ ] ',
+      '',
+    }, file)
+  end
+  vim.cmd('edit ' .. vim.fn.fnameescape(file))
+end
+
+function M.setup(notes_root)
+  vim.keymap.set('n', '<leader>j', function()
+    open_journal(notes_root, os.time())
+  end, { desc = 'kra notes: journal today' })
+
+  vim.keymap.set('n', '<leader>J', function()
+    require('telescope.builtin').find_files({
+      cwd = notes_root .. '/journal',
+      prompt_title = 'Journal entries',
+    })
+  end, { desc = 'kra notes: journal picker' })
+
+  vim.api.nvim_create_user_command('KraNotesJournal', function(opts)
+    local arg = opts.args
+    local t = os.time()
+    if arg == '' or arg == 'today' then
+      -- nothing
+    elseif arg == 'yesterday' then
+      t = t - 86400
+    elseif arg == 'tomorrow' then
+      t = t + 86400
+    else
+      local y, m, d = arg:match('^(%d%d%d%d)%-(%d%d)%-(%d%d)$')
+      if y then
+        t = os.time({ year = tonumber(y), month = tonumber(m), day = tonumber(d), hour = 12 })
+      else
+        print('[kra notes] unrecognized journal date: ' .. arg)
+        return
+      end
+    end
+    open_journal(notes_root, t)
+  end, { nargs = '?' })
+end
+
+return M

--- a/notes-files/lua/kra_notes_keymaps.lua
+++ b/notes-files/lua/kra_notes_keymaps.lua
@@ -1,0 +1,69 @@
+-- kra notes: keymap setup. Leader is space.
+local M = {}
+
+function M.setup(notes_root)
+  local map = vim.keymap.set
+
+  -- ── File navigation ────────────────────────────────────────────────
+  map('n', '<leader>f', function()
+    require('telescope.builtin').find_files({ cwd = notes_root })
+  end, { desc = 'kra notes: find file' })
+
+  map('n', '<leader>g', function()
+    require('telescope.builtin').live_grep({ cwd = notes_root })
+  end, { desc = 'kra notes: live grep' })
+
+  map('n', '<leader>n', function()
+    vim.ui.input({ prompt = 'New note (e.g. work/idea-x): ' }, function(input)
+      if not input or input == '' then return end
+      local rel = input:gsub('%.md$', '') .. '.md'
+      local full = notes_root .. '/' .. rel
+      vim.fn.mkdir(vim.fn.fnamemodify(full, ':h'), 'p')
+      if vim.fn.filereadable(full) == 0 then
+        local title = vim.fn.fnamemodify(full, ':t:r'):gsub('[-_]', ' ')
+        local date  = os.date('%Y-%m-%d')
+        vim.fn.writefile({ '---', 'created: ' .. date, 'tags: []', '---', '', '# ' .. title, '' }, full)
+      end
+      vim.cmd('edit ' .. vim.fn.fnameescape(full))
+    end)
+  end, { desc = 'kra notes: new note' })
+
+  map('n', '<leader>v', function()
+    require('telescope.builtin').find_files({
+      cwd = notes_root,
+      attach_mappings = function(_, lmap)
+        local actions = require('telescope.actions')
+        actions.select_default:replace(actions.select_vertical)
+        lmap('i', '<CR>', actions.select_vertical)
+        lmap('n', '<CR>', actions.select_vertical)
+        return true
+      end,
+    })
+  end, { desc = 'kra notes: open in vsplit' })
+
+  map('n', '<leader>s', function()
+    require('telescope.builtin').find_files({
+      cwd = notes_root,
+      attach_mappings = function(_, lmap)
+        local actions = require('telescope.actions')
+        actions.select_default:replace(actions.select_horizontal)
+        lmap('i', '<CR>', actions.select_horizontal)
+        lmap('n', '<CR>', actions.select_horizontal)
+        return true
+      end,
+    })
+  end, { desc = 'kra notes: open in hsplit' })
+
+  -- ── Buffer navigation ──────────────────────────────────────────────
+  map('n', '<BS>', '<cmd>bprev<cr>', { desc = 'kra notes: prev buffer' })
+  map('n', '<leader>q', function()
+    local bufs = vim.fn.getbufinfo({ buflisted = 1 })
+    if #bufs <= 1 then
+      vim.cmd('quit')
+    else
+      vim.cmd('bdelete')
+    end
+  end, { desc = 'kra notes: close buffer / quit' })
+end
+
+return M

--- a/notes-files/lua/kra_notes_links.lua
+++ b/notes-files/lua/kra_notes_links.lua
@@ -1,0 +1,100 @@
+-- kra notes: link insertion + follow.
+local M = {}
+
+local notes_root
+
+local function rel_to_root(path)
+  local prefix = notes_root .. '/'
+  if path:sub(1, #prefix) == prefix then
+    return path:sub(#prefix + 1)
+  end
+  return path
+end
+
+-- Insert [[relpath-without-md]] for the chosen note.
+local function insert_link_picker()
+  local ok = pcall(require, 'telescope')
+  if not ok then
+    print('[kra notes] telescope not yet installed')
+    return
+  end
+  local actions = require('telescope.actions')
+  local action_state = require('telescope.actions.state')
+
+  require('telescope.builtin').find_files({
+    cwd = notes_root,
+    prompt_title = 'Insert link to note',
+    attach_mappings = function(prompt_bufnr, _)
+      actions.select_default:replace(function()
+        local entry = action_state.get_selected_entry()
+        actions.close(prompt_bufnr)
+        if not entry then return end
+        local rel = rel_to_root(entry.path or (notes_root .. '/' .. entry[1]))
+        rel = rel:gsub('%.md$', '')
+        local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+        local snippet = '[[' .. rel .. ']]'
+        vim.api.nvim_buf_set_text(0, row - 1, col, row - 1, col, { snippet })
+        vim.api.nvim_win_set_cursor(0, { row, col + #snippet })
+      end)
+      return true
+    end,
+  })
+end
+
+-- Find a [[wiki-link]] or [text](path) under the cursor and open it.
+local function follow_link()
+  local line = vim.api.nvim_get_current_line()
+  local col = vim.api.nvim_win_get_cursor(0)[2] + 1
+
+  -- [[wiki-link]]
+  local s, e = 1, 0
+  while true do
+    local ws, we, target = line:find('%[%[(.-)%]%]', e + 1)
+    if not ws then break end
+    if col >= ws and col <= we then
+      local target_path = notes_root .. '/' .. target:gsub('%.md$', '') .. '.md'
+      vim.fn.mkdir(vim.fn.fnamemodify(target_path, ':h'), 'p')
+      vim.cmd('edit ' .. vim.fn.fnameescape(target_path))
+      return
+    end
+    s, e = ws, we
+  end
+
+  -- [text](path)
+  e = 0
+  while true do
+    local ms, me, _, target = line:find('%[([^%]]-)%]%(([^)]+)%)', e + 1)
+    if not ms then break end
+    if col >= ms and col <= me then
+      if target:match('^https?://') or target:match('^mailto:') then
+        vim.fn.jobstart({ vim.fn.has('mac') == 1 and 'open' or 'xdg-open', target }, { detach = true })
+        return
+      end
+      local target_path = target
+      if not target_path:match('^/') then
+        target_path = notes_root .. '/' .. target_path
+      end
+      vim.fn.mkdir(vim.fn.fnamemodify(target_path, ':h'), 'p')
+      vim.cmd('edit ' .. vim.fn.fnameescape(target_path))
+      return
+    end
+    e = me
+  end
+
+  print('[kra notes] no link under cursor')
+end
+
+function M.setup(root)
+  notes_root = root
+  vim.keymap.set('n', '<leader>l', insert_link_picker, { desc = 'kra notes: insert link' })
+  vim.keymap.set({ 'n', 'i' }, '<C-]>', function()
+    if vim.fn.mode() == 'i' then
+      vim.cmd('stopinsert')
+    end
+    follow_link()
+  end, { desc = 'kra notes: follow link' })
+  vim.keymap.set('n', '<CR>', follow_link, { desc = 'kra notes: follow link' })
+  vim.keymap.set('n', 'gf', follow_link, { desc = 'kra notes: follow link' })
+end
+
+return M

--- a/notes-files/lua/kra_notes_rename.lua
+++ b/notes-files/lua/kra_notes_rename.lua
@@ -1,0 +1,155 @@
+-- kra notes: rename / move the current note. Optionally rewrites incoming
+-- [[wiki]] and ](path) links across the vault.
+
+local M = {}
+
+local notes_root
+
+local function rel(file)
+  local prefix = notes_root .. '/'
+  if file:sub(1, #prefix) == prefix then
+    return file:sub(#prefix + 1):gsub('%.md$', '')
+  end
+  return file:gsub('%.md$', '')
+end
+
+local function abs(rel_path)
+  local p = rel_path
+  if not p:match('^/') then p = notes_root .. '/' .. p end
+  if not p:match('%.md$') then p = p .. '.md' end
+  return p
+end
+
+local function list_md_files()
+  local files = vim.fn.systemlist({ 'rg', '--files', '--type-add', 'md:*.md', '--type', 'md',
+    '--glob', '!**/.nvim-data/**', notes_root })
+  if vim.v.shell_error ~= 0 then
+    files = vim.fn.systemlist({ 'find', notes_root, '-type', 'f', '-name', '*.md',
+      '-not', '-path', '*/.nvim-data/*' })
+  end
+  return files
+end
+
+local function rewrite_links(old_rel, new_rel)
+  local changed = 0
+  local old_esc = old_rel:gsub('([%(%)%.%%%+%-%*%?%[%]%^%$])', '%%%1')
+  for _, file in ipairs(list_md_files()) do
+    local fh = io.open(file, 'r')
+    if fh then
+      local content = fh:read('*a')
+      fh:close()
+      local original = content
+      -- [[old_rel]] and [[old_rel.md]] (wiki-style)
+      content = content:gsub('%[%[' .. old_esc .. '%.md%]%]', '[[' .. new_rel .. '.md]]')
+      content = content:gsub('%[%[' .. old_esc .. '%]%]', '[[' .. new_rel .. ']]')
+      content = content:gsub('%[%[' .. old_esc .. '|', '[[' .. new_rel .. '|')
+      -- ](old_rel.md) markdown link target
+      content = content:gsub('%]%(' .. old_esc .. '%.md%)', '](' .. new_rel .. '.md)')
+      if content ~= original then
+        local out = io.open(file, 'w')
+        if out then
+          out:write(content)
+          out:close()
+          changed = changed + 1
+        end
+      end
+    end
+  end
+  return changed
+end
+
+local function do_rename(old_path, new_rel_input)
+  if new_rel_input == nil or new_rel_input == '' then return end
+  local new_rel = new_rel_input:gsub('%.md$', '')
+  local old_rel = rel(old_path)
+  if new_rel == old_rel then
+    vim.notify('[kra notes] same name; nothing to do', vim.log.levels.INFO)
+    return
+  end
+  local new_path = abs(new_rel)
+  if vim.fn.filereadable(new_path) == 1 then
+    vim.notify('[kra notes] target already exists: ' .. new_rel, vim.log.levels.ERROR)
+    return
+  end
+
+  vim.fn.mkdir(vim.fn.fnamemodify(new_path, ':h'), 'p')
+
+  local cur_buf = vim.api.nvim_get_current_buf()
+  local cur_buf_path = vim.api.nvim_buf_get_name(cur_buf)
+  local was_modified = vim.bo[cur_buf].modified
+  if was_modified and cur_buf_path == old_path then
+    vim.cmd('silent! write')
+  end
+
+  local ok, err = os.rename(old_path, new_path)
+  if not ok then
+    vim.notify('[kra notes] rename failed: ' .. tostring(err), vim.log.levels.ERROR)
+    return
+  end
+
+  -- Replace any open buffer pointing at the old path with the new one.
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(buf) and vim.api.nvim_buf_get_name(buf) == old_path then
+      for _, win in ipairs(vim.api.nvim_list_wins()) do
+        if vim.api.nvim_win_get_buf(win) == buf then
+          vim.api.nvim_win_call(win, function() vim.cmd('edit ' .. vim.fn.fnameescape(new_path)) end)
+        end
+      end
+      pcall(vim.api.nvim_buf_delete, buf, { force = true })
+    end
+  end
+
+  local answer = vim.fn.confirm('Rewrite incoming links to ' .. new_rel .. '?', '&Yes\n&No', 1, 'Question')
+  if answer == 1 then
+    local n = rewrite_links(old_rel, new_rel)
+    vim.notify(string.format('[kra notes] renamed -> %s (%d file%s updated)',
+      new_rel, n, n == 1 and '' or 's'))
+    vim.cmd('checktime')
+  else
+    vim.notify('[kra notes] renamed -> ' .. new_rel)
+  end
+end
+
+local function rename_current()
+  local file = vim.fn.expand('%:p')
+  if file == '' or not file:match('^' .. vim.pesc(notes_root)) or not file:match('%.md$') then
+    vim.notify('[kra notes] not a note buffer', vim.log.levels.WARN)
+    return
+  end
+  vim.ui.input({
+    prompt = 'Rename to (relative, no .md): ',
+    default = rel(file),
+    completion = 'file',
+  }, function(input)
+    if input then do_rename(file, input) end
+  end)
+end
+
+function M.setup(root)
+  notes_root = root
+
+  vim.api.nvim_create_user_command('KraNotesRename', function(opts)
+    if opts.args and opts.args ~= '' then
+      local file = vim.fn.expand('%:p')
+      if file == '' then
+        vim.notify('[kra notes] no current file', vim.log.levels.WARN)
+        return
+      end
+      do_rename(file, opts.args)
+    else
+      rename_current()
+    end
+  end, { nargs = '?' })
+
+  local grp = vim.api.nvim_create_augroup('KraNotesRename', { clear = true })
+  vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
+    group = grp,
+    pattern = notes_root .. '/*.md',
+    callback = function(args)
+      vim.keymap.set('n', '<leader>R', rename_current,
+        { buffer = args.buf, nowait = true, silent = true, desc = 'kra notes: rename current note' })
+    end,
+  })
+end
+
+return M

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "automationScripts",
         "settings.toml.example",
         "tmux-files",
+        "notes-files",
         "start.js",
         "README.md",
         "LICENSE.md",

--- a/src/commandsMaps/notesCommands.ts
+++ b/src/commandsMaps/notesCommands.ts
@@ -1,0 +1,45 @@
+import * as notes from '@/notes/runNotes';
+import { NotesCommands } from '@/commandsMaps/types/commandTypes';
+
+export const notesCommands: NotesCommands = {
+    'open': {
+        run: notes.openNote,
+        description: 'Open (or create) a markdown note by name in the bundled nvim config',
+        details: 'Resolves <name> under ~/.kra/notes/<name>.md (sub-directories allowed) and opens it in nvim using the bundled notes config (space leader, render-markdown, telescope, link-following, backlinks). With no name, opens the Telescope picker over all notes.',
+        highlights: [
+            'Opens in nvim with bundled config so behavior is identical on every machine.',
+            'Auto-creates parent directories under ~/.kra/notes for category sub-paths.',
+            'Bare invocation opens the fuzzy notes picker; pass a name to jump straight in.',
+        ],
+    },
+    'new': {
+        run: notes.newNote,
+        description: 'Create a new note with seed frontmatter and open it',
+        details: 'Like open, but refuses to overwrite an existing note and seeds the file with YAML frontmatter (created date + empty tags) plus a top-level title heading.',
+        highlights: [
+            'Seeds frontmatter and title to keep notes consistent.',
+            'Refuses to clobber an existing note of the same name.',
+            'Sub-paths like work/idea-x are supported and auto-create directories.',
+        ],
+    },
+    'journal': {
+        run: notes.journalNote,
+        description: 'Open today’s journal entry (or a relative/explicit day)',
+        details: 'Opens ~/.kra/notes/journal/YYYY/MM/YYYY-MM-DD.md, seeding it with frontmatter and Notes/Tasks sections on first use. Accepts no argument (today), `yesterday`, `tomorrow`, or an explicit `YYYY-MM-DD`.',
+        highlights: [
+            'Auto-creates the dated file under journal/YYYY/MM/.',
+            'Seeds Notes + Tasks sections so each day has a consistent shape.',
+            'Inside nvim: <leader>j opens today, <leader>J fuzzy-picks past entries.',
+        ],
+    },
+    'pick': {
+        run: notes.pickNote,
+        description: 'Open the Telescope-style notes picker',
+        details: 'Same as bare `kra notes` \u2014 launches nvim with the bundled config and opens the Telescope find-files picker rooted at ~/.kra/notes.',
+        highlights: [
+            'Fuzzy search across every note in the notes root.',
+            'Live preview of the highlighted note.',
+            'Enter to open in current buffer, splits via the bundled keymaps.',
+        ],
+    },
+};

--- a/src/commandsMaps/types/commandTypes.ts
+++ b/src/commandsMaps/types/commandTypes.ts
@@ -11,6 +11,7 @@ export type CommandCatalog<T extends string> = Record<T, CommandDefinition>;
 
 export type SystemCommandName = 'grep' | 'scripts' | 'process-manager' | 'disk-usage';
 export type TmuxCommandName = 'save-server' | 'load-server' | 'save-session' | 'load-session' | 'list-sessions' | 'manage-saves' | 'find-session' | 'kill';
+export type NotesCommandName = 'open' | 'new' | 'pick' | 'journal';
 export type GitCommandName =
     | 'restore'
     | 'cache-untracked'
@@ -33,10 +34,11 @@ export type AiCommandName =
     | 'delete'
     | 'quota-agent'
     | 'index';
-export type CommandType = 'sys' | 'tmux' | 'git' | 'ai' | 'memory' | 'settings';
+export type CommandType = 'sys' | 'tmux' | 'git' | 'ai' | 'memory' | 'settings' | 'notes';
 
 export type SystemCommands = CommandCatalog<SystemCommandName>;
 export type TmuxCommands = CommandCatalog<TmuxCommandName>;
+export type NotesCommands = CommandCatalog<NotesCommandName>;
 export type GitCommands = CommandCatalog<GitCommandName>;
 export type AiCommands = CommandCatalog<AiCommandName>;
 

--- a/src/filePaths.ts
+++ b/src/filePaths.ts
@@ -28,6 +28,10 @@ export const singleSessionFilesFolder = path.join(tmuxFiles, 'single-sessions');
 // nvim
 export const nvimSessionsPath = path.join(tmuxFiles, 'nvim-sessions');
 
+// notes (kra notes markdown note app)
+export const notesRoot = path.join(root, 'notes');
+export const notesNvimDataDir = path.join(notesRoot, '.nvim-data');
+
 // ai
 export const aiHistoryPath = path.join(root, 'ai-files', 'chat-history');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,16 @@ const commandTypeOptions: ReadonlyArray<MenuOption<CommandType>> = [
         ],
     },
     {
+        name: 'notes',
+        description: 'Markdown note-taking app (nvim + render-markdown + telescope)',
+        details: 'Open the bundled markdown note app powered by nvim with a self-contained config. Notes live under ~/.kra/notes/ with category sub-directories. In-buffer markdown render, fuzzy file picker, link following, backlinks, and quick-insert keymaps under <leader> (space).',
+        highlights: [
+            'In-buffer markdown rendering and Telescope picker out of the box.',
+            'Sub-directory categories (e.g. work/idea-x), wiki-style [[link]] follow, and backlinks.',
+            'Quick-insert keymaps for tasks, dates, headings, code blocks, lists, and links.',
+        ],
+    },
+    {
         name: 'sys',
         description: 'System cleanup and automation-script utilities',
         details: 'Operational helpers for cleaning up files or directories and running local automation scripts. This group stays focused on filesystem maintenance and repo-specific scripted workflows.',
@@ -136,6 +146,25 @@ const main = async (): Promise<void> => {
     if (commandType === 'memory') {
         const { memoryDashboard } = await import('@/AI');
         await memoryDashboard();
+
+        return;
+    }
+
+    if (commandType === 'notes') {
+        // Notes is dispatched directly so bare `kra notes` and `kra notes <name>`
+        // both work without going through the command-selection menu.
+        const { notesCommands } = await import('@/commandsMaps/notesCommands');
+        const sub = args[1];
+        const rest = args.slice(2);
+        if (sub === 'new') {
+            await notesCommands.new.run(rest);
+        } else if (sub === 'pick') {
+            await notesCommands.pick.run(rest);
+        } else if (sub === 'journal') {
+            await notesCommands.journal.run(rest);
+        } else {
+            await notesCommands.open.run(sub ? [sub, ...rest] : []);
+        }
 
         return;
     }

--- a/src/notes/runNotes.ts
+++ b/src/notes/runNotes.ts
@@ -1,0 +1,155 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { notesRoot } from '@/filePaths';
+import { notesNvimInitLuaPath } from '@/packagePaths';
+
+function ensureNotesRoot(): void {
+    if (!fs.existsSync(notesRoot)) {
+        fs.mkdirSync(notesRoot, { recursive: true });
+    }
+}
+
+/**
+ * If we're inside tmux and not already inside a kra-notes popup, re-launch
+ * ourselves through `tmux display-popup` so notes always opens as an overlay
+ * (even if invoked from a regular pane that's running nvim, etc).
+ * Returns true if we handed off; the caller should bail out.
+ */
+function popupIfNeeded(extraArgs: string[]): boolean {
+    if (!process.env.TMUX) return false;
+    if (process.env.KRA_NOTES_INNER === '1') return false;
+
+    const argv = ['kra', 'notes', ...extraArgs];
+    const quoted = argv.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
+    const proc = spawn(
+        'tmux',
+        ['display-popup', '-E', '-w', '90%', '-h', '90%', '-T', ' kra notes ', `KRA_NOTES_INNER=1 ${quoted}`],
+        { stdio: 'inherit', shell: false },
+    );
+    proc.on('error', () => { /* fall through; caller already returned */ });
+
+    return true;
+}
+
+function resolveNoteName(rawName: string): string {
+    let name = rawName.trim();
+    if (!name) name = 'index';
+    name = name.replace(/^[/\\]+/, '');
+    if (path.isAbsolute(name)) {
+        return name.endsWith('.md') ? name : `${name}.md`;
+    }
+    if (!name.endsWith('.md')) name = `${name}.md`;
+    const abs = path.resolve(notesRoot, name);
+    const rel = path.relative(notesRoot, abs);
+    if (rel.startsWith('..')) {
+        throw new Error(`note name '${rawName}' resolves outside notes root`);
+    }
+
+    return abs;
+}
+
+async function spawnNvim(filePath: string | null): Promise<void> {
+    const args = ['-u', notesNvimInitLuaPath];
+    if (filePath) {
+        args.push(filePath);
+    } else {
+        // No specific file requested — launch the Telescope picker.
+        args.push('+KraNotesPicker');
+    }
+
+    const dataDir = path.join(notesRoot, '.nvim-data');
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    const env = {
+        ...process.env,
+        XDG_DATA_HOME: path.join(dataDir, 'share'),
+        XDG_STATE_HOME: path.join(dataDir, 'state'),
+        XDG_CACHE_HOME: path.join(dataDir, 'cache'),
+        XDG_CONFIG_HOME: path.join(dataDir, 'config'),
+    };
+
+    return new Promise((resolve, reject) => {
+        const proc = spawn('nvim', args, { stdio: 'inherit', shell: false, env });
+        proc.on('close', (code) => {
+            if (code === 0 || code === null) return resolve();
+            reject(new Error(`nvim exited with code ${code}`));
+        });
+        proc.on('error', (err) => {
+            if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                reject(new Error('nvim not found in PATH. Please install Neovim.'));
+            } else {
+                reject(err);
+            }
+        });
+    });
+}
+
+export async function openNote(args: string[] = []): Promise<void> {
+    ensureNotesRoot();
+    if (popupIfNeeded(args)) return;
+    const name = args[0];
+    if (!name) {
+        await spawnNvim(null);
+
+        return;
+    }
+    const filePath = resolveNoteName(name);
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    await spawnNvim(filePath);
+}
+
+export async function newNote(args: string[] = []): Promise<void> {
+    ensureNotesRoot();
+    if (popupIfNeeded(['new', ...args])) return;
+    const name = args[0];
+    if (!name) {
+        throw new Error('usage: kra notes new <name>');
+    }
+    const filePath = resolveNoteName(name);
+    if (fs.existsSync(filePath)) {
+        throw new Error(`note already exists: ${path.relative(notesRoot, filePath)}`);
+    }
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const title = path.basename(filePath, '.md').replace(/[-_]/g, ' ');
+    const date = new Date().toISOString().slice(0, 10);
+    const seed = `---\ncreated: ${date}\ntags: []\n---\n\n# ${title}\n\n`;
+    fs.writeFileSync(filePath, seed, 'utf8');
+    await spawnNvim(filePath);
+}
+
+export async function pickNote(_args: string[] = []): Promise<void> {
+    ensureNotesRoot();
+    if (popupIfNeeded(['pick'])) return;
+    await spawnNvim(null);
+}
+
+export async function journalNote(args: string[] = []): Promise<void> {
+    ensureNotesRoot();
+    if (popupIfNeeded(['journal', ...args])) return;
+    const when = (args[0] || 'today').trim();
+    const date = resolveJournalDate(when);
+    const yyyy = String(date.getFullYear());
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    const iso = `${yyyy}-${mm}-${dd}`;
+    const filePath = path.join(notesRoot, 'journal', yyyy, mm, `${iso}.md`);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    if (!fs.existsSync(filePath)) {
+        const nice = date.toDateString();
+        const seed = `---\ncreated: ${iso}\ntags: [journal]\n---\n\n# ${nice}\n\n## Notes\n\n## Tasks\n\n- [ ] \n`;
+        fs.writeFileSync(filePath, seed, 'utf8');
+    }
+    await spawnNvim(filePath);
+}
+
+function resolveJournalDate(when: string): Date {
+    const now = new Date();
+    if (!when || when === 'today') return now;
+    if (when === 'yesterday') return new Date(now.getTime() - 86400 * 1000);
+    if (when === 'tomorrow') return new Date(now.getTime() + 86400 * 1000);
+    const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(when);
+    if (iso) return new Date(Number(iso[1]), Number(iso[2]) - 1, Number(iso[3]), 12);
+    throw new Error(`unrecognized journal date: ${when} (use today|yesterday|tomorrow|YYYY-MM-DD)`);
+}

--- a/src/packagePaths.ts
+++ b/src/packagePaths.ts
@@ -66,3 +66,6 @@ export const docsPythonRequirementsPath = path.join(automationScriptsDir, 'pytho
 export const settingsExamplePath = assetPath('settings.toml.example');
 export const defaultTmuxConfPath = assetPath('tmux-files', '.tmux.conf');
 
+// notes nvim config bundled with the package
+export const notesNvimInitLuaPath = assetPath('notes-files', 'init.lua');
+

--- a/tmux-files/.tmux.conf
+++ b/tmux-files/.tmux.conf
@@ -38,6 +38,8 @@ bind R source ~/.tmux.conf \; display-message "tmux.conf reloaded."
 # Telescope-style fuzzy session/window picker (replaces default choose-tree)
 unbind s
 bind s display-popup -E -w 90% -h 90% "kra tmux find-session"
+unbind o
+bind o display-popup -E -w 90% -h 90% -T " kra notes " "KRA_NOTES_INNER=1 kra notes"
 
 setw -g mode-keys vi
 setw -g mouse on


### PR DESCRIPTION
A self-contained markdown note-taking workflow. Notes live under ~/.kra/notes/ with sub-directories as categories. The UI is Neovim, with a private plugin set bootstrapped on first run via lazy.nvim into ~/.kra/notes/.nvim-data/ ? completely isolated from the user's own nvim config.

Inside tmux, `prefix o` opens the app in a centered popup (~90% of the screen) so it can be summoned over any session. Outside tmux it runs inline.